### PR TITLE
WS2 Fase 2 — topics stage + fetch hardening

### DIFF
--- a/.claude/skills/enriching-x-knowledge/SKILL.md
+++ b/.claude/skills/enriching-x-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: enriching-x-knowledge
-description: Use when the user wants to enrich their XBrain knowledge base (item summaries + topics) with their Claude subscription instead of the paid API. Drives the `xbrain enrich` worksheet flow end to end.
+description: Use when the user wants to enrich their XBrain knowledge base (item summaries + topics) or synthesize its topic-page overviews with their Claude subscription instead of the paid API. Drives the `xbrain enrich` and `xbrain topics` worksheet flows end to end.
 ---
 
 # Enriching the XBrain knowledge base
@@ -39,6 +39,32 @@ paid `api` executor.
 4. **Apply.** Run `xbrain enrich --apply data/enrich-worksheet.json`. It validates
    and attaches the valid judgments. If it reports rejected items, fix those
    judgments in the worksheet and run `--apply` again.
+
+## Topic-page overviews
+
+After items are enriched, the `topics` stage synthesizes a prose overview for
+each topic page — also via a worksheet, at no API cost.
+
+1. **Export the worksheet.** Run `xbrain topics --executor claude-code`. It
+   writes `data/topic-worksheet.json` with the topics needing (re)synthesis,
+   their post summaries and the topic-page rubric, and writes the topic pages
+   with their current post lists. If it reports 0 topics pending, stop.
+
+2. **Read `data/topic-worksheet.json`.** It has `rubric` and `topics` (each with
+   a `slug`, a `description` and the `summaries` of its posts).
+
+3. **Produce one judgment per topic**, following the embedded rubric exactly:
+   - `overview`: 1-3 paragraphs of plain Spanish prose, faithful to the
+     summaries.
+   - `notes`: 0-15 plain-prose strings, one important idea each.
+   - Emit only `{slug, overview, notes}`. **Never write a wikilink (`[[...]]`),
+     a filename or any identifier** — you have summaries, not posts, and the
+     code adds the links. The validator rejects any judgment that contains `[[`.
+   - Append every judgment to the worksheet's `judgments` array.
+
+4. **Apply.** Run `xbrain topics --apply data/topic-worksheet.json`. It
+   validates the judgments, stores the overviews and rewrites the topic pages.
+   If it reports rejected topics, fix those judgments and run `--apply` again.
 
 ## Notes
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -22,3 +22,8 @@ model = "claude-haiku-4-5-20251001"
 [vocab]
 # Number of topics the `vocab` stage induces from the corpus.
 target_count = 30
+
+[topics]
+# Re-synthesize a topic's overview when it has grown by this many posts since
+# the last synthesis. `xbrain topics --resynth` re-synthesizes every stale one.
+resynth_threshold = 25

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -147,10 +147,14 @@ def _run_extract(cfg: Config, source: str, since: datetime | None, until: dateti
 
 def _run_fetch(cfg: Config, since: datetime | None, until: datetime | None, force: bool) -> None:
     store = load_store(cfg.items_path)
-    articles = fetch_pending(store, since, until, force)
-    x_articles = fetch_x_articles(store, cfg.storage_state_path, force)
-    threads = expand_threads(store, cfg.storage_state_path, force)
-    save_store(store, cfg.items_path)
+    try:
+        articles = fetch_pending(store, since, until, force)
+        x_articles = fetch_x_articles(store, cfg.storage_state_path, force, since, until)
+        threads = expand_threads(store, cfg.storage_state_path, force)
+    finally:
+        # Persist whatever was fetched even if a later stage raised — a stage
+        # error (e.g. an expired X session) must not discard in-memory work.
+        save_store(store, cfg.items_path)
     typer.echo(f"Contenido descargado: {articles} artículos, {x_articles} de X, {threads} hilos")
 
 

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -20,6 +20,7 @@ from xbrain.extract.browser import x_context
 from xbrain.extract.extractor import extract_source
 from xbrain.extract.threads import expand_threads
 from xbrain.fetch import fetch_pending
+from xbrain.fetch_x import fetch_x_articles
 from xbrain.generate import generate as run_generate
 from xbrain.models import ArchiveImport, Author, SourceName
 from xbrain.rubrics import load_vocab, save_vocab
@@ -126,9 +127,10 @@ def _run_extract(cfg: Config, source: str, since: datetime | None, until: dateti
 def _run_fetch(cfg: Config, since: datetime | None, until: datetime | None, force: bool) -> None:
     store = load_store(cfg.items_path)
     articles = fetch_pending(store, since, until, force)
+    x_articles = fetch_x_articles(store, cfg.storage_state_path, force)
     threads = expand_threads(store, cfg.storage_state_path, force)
     save_store(store, cfg.items_path)
-    typer.echo(f"Contenido descargado: {articles} artículos, {threads} hilos")
+    typer.echo(f"Contenido descargado: {articles} artículos, {x_articles} de X, {threads} hilos")
 
 
 def _run_generate(cfg: Config, since: datetime | None, until: datetime | None) -> None:

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -328,7 +328,7 @@ def _topics_run(cfg: Config, store: dict, vocab: list, resynth: bool, executor: 
     merge_overviews(pages, judgments, posts)
     save_topic_pages(pages, cfg.topics_path)
     written = write_topic_pages(cfg.output_dir, vocab, posts, pages)
-    typer.echo(f"Topics sintetizados: {len(judgments)} · {written} páginas escritas")
+    typer.echo(f"Topics sintetizados: {len(judgments)}/{len(inputs)} · {written} páginas escritas")
 
 
 @app.command()

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -24,7 +24,28 @@ from xbrain.fetch_x import fetch_x_articles
 from xbrain.generate import generate as run_generate
 from xbrain.models import ArchiveImport, Author, SourceName
 from xbrain.rubrics import load_vocab, save_vocab
-from xbrain.store import load_state, load_store, merge_items, save_state, save_store
+from xbrain.store import (
+    load_state,
+    load_store,
+    load_topic_pages,
+    merge_items,
+    save_state,
+    save_store,
+    save_topic_pages,
+)
+from xbrain.topic_synth import (
+    apply_overview_judgments,
+    export_topic_worksheet,
+    import_topic_worksheet,
+    synthesize_overviews_api,
+)
+from xbrain.topics import (
+    build_topic_inputs,
+    compute_topic_posts,
+    merge_overviews,
+    topics_needing_synth,
+    write_topic_pages,
+)
 from xbrain.vocab import induce_vocab
 from xbrain.worksheet import export_worksheet, import_worksheet
 
@@ -259,6 +280,72 @@ def vocab(
         save_store(store, cfg.items_path)
         typer.echo("Todos los items marcados para re-enriquecer.")
     typer.echo(f"Vocabulario inducido: {len(topics)} topics → {cfg.data_dir / 'vocab.yaml'}")
+
+
+def _topics_apply(cfg: Config, store: dict, vocab: list, apply: Path) -> None:
+    """`xbrain topics --apply` — import a filled overview worksheet."""
+    pages = load_topic_pages(cfg.topics_path)
+    posts = compute_topic_posts(store, vocab)
+    valid, invalid = apply_overview_judgments(import_topic_worksheet(apply))
+    merge_overviews(pages, valid, posts)
+    save_topic_pages(pages, cfg.topics_path)
+    written = write_topic_pages(cfg.output_dir, vocab, posts, pages)
+    typer.echo(f"Worksheet aplicada: {len(valid)} overviews · {written} páginas escritas")
+    _report_invalid(invalid)
+
+
+def _topics_run(cfg: Config, store: dict, vocab: list, resynth: bool, executor: str | None) -> None:
+    """`xbrain topics` — update lists and (re)synthesize stale overviews."""
+    pages = load_topic_pages(cfg.topics_path)
+    posts = compute_topic_posts(store, vocab)
+    stale = topics_needing_synth(vocab, posts, pages, cfg.topics_resynth_threshold, resynth)
+    inputs = build_topic_inputs(stale, vocab, posts)
+
+    if not inputs:
+        written = write_topic_pages(cfg.output_dir, vocab, posts, pages)
+        typer.echo(f"Topic pages actualizadas: {written} páginas (sin overviews pendientes).")
+        return
+
+    chosen = executor or cfg.enrich_executor
+    if chosen in ("manual", "claude-code"):
+        worksheet = cfg.data_dir / "topic-worksheet.json"
+        export_topic_worksheet(inputs, worksheet)
+        written = write_topic_pages(cfg.output_dir, vocab, posts, pages)
+        typer.echo(
+            f"{len(inputs)} topics exportados a {worksheet} · {written} páginas escritas\n"
+            f"Rellena el array `judgments` y ejecuta:\n"
+            f"  xbrain topics --apply {worksheet}"
+        )
+        return
+    if chosen != "api":
+        raise ValueError(f"Ejecutor desconocido: {chosen!r}")
+
+    judgments = synthesize_overviews_api(inputs, cfg.enrich_model)
+    merge_overviews(pages, judgments, posts)
+    save_topic_pages(pages, cfg.topics_path)
+    written = write_topic_pages(cfg.output_dir, vocab, posts, pages)
+    typer.echo(f"Topics sintetizados: {len(judgments)} · {written} páginas escritas")
+
+
+@app.command()
+@_handle_cli_errors
+def topics(
+    resynth: bool = typer.Option(False, help="Re-sintetizar todos los overviews obsoletos"),
+    apply: Path = typer.Option(None, "--apply", help="Importar un worksheet de overviews relleno"),
+    executor: str = typer.Option(
+        None, help="api | manual | claude-code (default: el de config.toml)"
+    ),
+) -> None:
+    """Genera las páginas de topic: listas de posts + overviews sintetizados."""
+    cfg = _config()
+    store = load_store(cfg.items_path)
+    vocab = load_vocab(cfg.data_dir / "vocab.yaml")
+    if not vocab:
+        raise RuntimeError("No hay vocabulario — ejecuta `xbrain vocab` antes.")
+    if apply is not None:
+        _topics_apply(cfg, store, vocab, apply)
+    else:
+        _topics_run(cfg, store, vocab, resynth, executor)
 
 
 @app.command()

--- a/src/xbrain/config.py
+++ b/src/xbrain/config.py
@@ -20,6 +20,7 @@ class Config:
     enrich_executor: ExecutorName
     enrich_model: str
     vocab_target_count: int
+    topics_resynth_threshold: int
 
     @property
     def items_path(self) -> Path:
@@ -28,6 +29,10 @@ class Config:
     @property
     def state_path(self) -> Path:
         return self.data_dir / "state.json"
+
+    @property
+    def topics_path(self) -> Path:
+        return self.data_dir / "topics.json"
 
     @property
     def storage_state_path(self) -> Path:
@@ -53,6 +58,10 @@ def load_config(repo_root: Path) -> Config:
     target_count = int(vocab.get("target_count", 30))
     if target_count < 1:
         raise ValueError("config.toml: [vocab].target_count must be >= 1")
+    topics = settings.get("topics", {})
+    resynth_threshold = int(topics.get("resynth_threshold", 25))
+    if resynth_threshold < 1:
+        raise ValueError("config.toml: [topics].resynth_threshold must be >= 1")
     return Config(
         repo_root=repo_root,
         vault=vault,
@@ -62,4 +71,5 @@ def load_config(repo_root: Path) -> Config:
         enrich_executor=executor,
         enrich_model=enrich.get("model", "claude-haiku-4-5-20251001"),
         vocab_target_count=target_count,
+        topics_resynth_threshold=resynth_threshold,
     )

--- a/src/xbrain/fetch.py
+++ b/src/xbrain/fetch.py
@@ -8,6 +8,8 @@ they are handled by `xbrain.fetch_x`.
 
 from __future__ import annotations
 
+import json
+import os
 import socket
 import urllib.error
 import urllib.request
@@ -23,6 +25,8 @@ from xbrain.models import Content, ContentSource, FailureReason, Item
 _X_HOSTS = {"x.com", "www.x.com", "twitter.com", "www.twitter.com", "mobile.twitter.com"}
 _UA = "Mozilla/5.0 (compatible; XBrain/1.0)"
 _TIMEOUT = 20
+_FIRECRAWL_URL = "https://api.firecrawl.dev/v1/scrape"
+_FIRECRAWL_TIMEOUT = 60
 
 
 @dataclass
@@ -79,7 +83,11 @@ def _probe_status(
     try:
         with opener(req, timeout=_TIMEOUT) as resp:
             status = getattr(resp, "status", None) or 200
-        return status, "js_required", "Descargable pero sin artículo extraíble (posible JavaScript)."
+        return (
+            status,
+            "js_required",
+            "Descargable pero sin artículo extraíble (posible JavaScript).",
+        )
     except urllib.error.HTTPError as exc:
         return exc.code, _reason_for_status(exc.code), f"HTTP {exc.code}: {exc.reason}"
     except urllib.error.URLError as exc:
@@ -113,10 +121,59 @@ def trafilatura_extract(
     return FetchResult(title=title, text=text, http_status=200, attempts=1)
 
 
-def extract_article(url: str) -> FetchResult:
-    """Default extractor — trafilatura only. The Firecrawl fallback is wired in
-    a later task, which replaces this function."""
-    return trafilatura_extract(url)
+def _firecrawl_extract(
+    url: str, *, opener: Callable = urllib.request.urlopen
+) -> FetchResult | None:
+    """Second-attempt extraction via Firecrawl (renders JavaScript).
+
+    Returns `None` when `FIRECRAWL_API_KEY` is unset — the fallback is optional,
+    so XBrain users without a key simply do not get it.
+    """
+    key = os.environ.get("FIRECRAWL_API_KEY")
+    if not key:
+        return None
+    body = json.dumps({"url": url, "formats": ["markdown"], "onlyMainContent": True}).encode()
+    req = urllib.request.Request(
+        _FIRECRAWL_URL,
+        data=body,
+        method="POST",
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+    )
+    try:
+        with opener(req, timeout=_FIRECRAWL_TIMEOUT) as resp:
+            payload = json.loads(resp.read())
+    except Exception as exc:  # noqa: BLE001 - a fallback failure must not abort the batch
+        return FetchResult(error=f"Firecrawl falló: {exc}", attempts=1)
+    data = payload.get("data") or {}
+    text = data.get("markdown")
+    if text:
+        title = (data.get("metadata") or {}).get("title")
+        return FetchResult(title=title, text=text, http_status=200, attempts=1)
+    return FetchResult(
+        failure_reason="empty_content", error="Firecrawl no devolvió contenido.", attempts=1
+    )
+
+
+def extract_article(
+    url: str,
+    *,
+    primary: Callable = trafilatura_extract,
+    firecrawl: Callable = _firecrawl_extract,
+) -> FetchResult:
+    """Default extractor: trafilatura, then Firecrawl for JS-rendered pages."""
+    result = primary(url)
+    if result.text:
+        return result
+    if result.failure_reason not in ("js_required", "empty_content"):
+        return result  # a hard failure (404, dns, ...) — Firecrawl will not help
+    fallback = firecrawl(url)
+    if fallback is None:
+        return result  # Firecrawl not configured — keep the original evidence
+    if fallback.text:
+        fallback.attempts = result.attempts + 1
+        return fallback
+    result.attempts = result.attempts + 1  # both attempts exhausted; keep first evidence
+    return result
 
 
 def fetch_item(item: Item, extractor: ArticleExtractor = extract_article) -> Content:
@@ -166,11 +223,7 @@ def fetch_item(item: Item, extractor: ArticleExtractor = extract_article) -> Con
                     attempts=result.attempts,
                 )
             )
-    kept = (
-        [s for s in item.content.sources if s.kind != "external_article"]
-        if item.content
-        else []
-    )
+    kept = [s for s in item.content.sources if s.kind != "external_article"] if item.content else []
     return Content(fetched_at=datetime.now(timezone.utc), sources=kept + new_sources)
 
 

--- a/src/xbrain/fetch.py
+++ b/src/xbrain/fetch.py
@@ -142,8 +142,13 @@ def _firecrawl_extract(
     try:
         with opener(req, timeout=_FIRECRAWL_TIMEOUT) as resp:
             payload = json.loads(resp.read())
-    except Exception as exc:  # noqa: BLE001 - a fallback failure must not abort the batch
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as exc:
         return FetchResult(error=f"Firecrawl falló: {exc}", attempts=1)
+    if payload.get("success") is False or payload.get("error"):
+        return FetchResult(
+            error=f"Firecrawl falló: {payload.get('error') or 'respuesta de error'}",
+            attempts=1,
+        )
     data = payload.get("data") or {}
     text = data.get("markdown")
     if text:
@@ -173,26 +178,29 @@ def extract_article(
         fallback.attempts = result.attempts + 1
         return fallback
     result.attempts = result.attempts + 1  # both attempts exhausted; keep first evidence
+    if fallback.error:
+        result.error = f"{result.error or 'sin contenido'} | Firecrawl: {fallback.error}"
     return result
 
 
 def fetch_item(item: Item, extractor: ArticleExtractor = extract_article) -> Content:
     """Build/refresh the `external_article` sources of an item.
 
-    x.com links are skipped (see `xbrain.fetch_x`). Non-external sources already
-    on the item (threads, x_article) are preserved across a re-fetch.
+    x.com links are skipped (see `xbrain.fetch_x`). Only `external_article`
+    sources are rebuilt; every other source kind already on the item is
+    preserved across a re-fetch.
     """
     new_sources: list[ContentSource] = []
-    for link in item.links:
-        if is_x_url(link.url):
-            continue
+    # Dedup: an item whose links repeat a URL must not yield duplicate sources.
+    non_x_urls = dict.fromkeys(link.url for link in item.links if not is_x_url(link.url))
+    for url in non_x_urls:
         try:
-            result = extractor(link.url)
+            result = extractor(url)
         except Exception as exc:  # noqa: BLE001 - one bad URL must not abort the batch
             new_sources.append(
                 ContentSource(
                     kind="external_article",
-                    url=link.url,
+                    url=url,
                     ok=False,
                     error=f"Error al descargar el artículo: {exc}",
                     attempts=1,
@@ -203,7 +211,7 @@ def fetch_item(item: Item, extractor: ArticleExtractor = extract_article) -> Con
             new_sources.append(
                 ContentSource(
                     kind="external_article",
-                    url=link.url,
+                    url=url,
                     title=result.title,
                     text=result.text,
                     ok=True,
@@ -215,7 +223,7 @@ def fetch_item(item: Item, extractor: ArticleExtractor = extract_article) -> Con
             new_sources.append(
                 ContentSource(
                     kind="external_article",
-                    url=link.url,
+                    url=url,
                     ok=False,
                     error=result.error,
                     http_status=result.http_status,
@@ -237,7 +245,8 @@ def fetch_pending(
     """Fetch external content for items that have non-x links and no content yet."""
     fetched = 0
     for item in store.values():
-        if not any(not is_x_url(link.url) for link in item.links):
+        # all links are x.com — handled by fetch_x
+        if all(is_x_url(link.url) for link in item.links):
             continue
         if item.content is not None and not force:
             continue

--- a/src/xbrain/fetch.py
+++ b/src/xbrain/fetch.py
@@ -1,82 +1,177 @@
 """Fetch the external content linked from items.
 
-v1 fetches external web articles via trafilatura. x.com links (X articles,
-threads, quoted tweets) are recorded but not auto-extracted — see the plan's
-scope notes.
+External (non-x.com) links are extracted with trafilatura; a failed fetch
+records *structured evidence* (HTTP status + a categorised reason) so a broken
+link is demonstrable, not assumed (design §4). x.com links are skipped here —
+they are handled by `xbrain.fetch_x`.
 """
 
 from __future__ import annotations
 
+import socket
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Callable
 from urllib.parse import urlparse
 
 import trafilatura
 
-from xbrain.models import Content, ContentSource, Item
-
-ArticleExtractor = Callable[[str], tuple[str | None, str | None]]
+from xbrain.models import Content, ContentSource, FailureReason, Item
 
 _X_HOSTS = {"x.com", "www.x.com", "twitter.com", "www.twitter.com", "mobile.twitter.com"}
+_UA = "Mozilla/5.0 (compatible; XBrain/1.0)"
+_TIMEOUT = 20
 
 
-def extract_article(url: str) -> tuple[str | None, str | None]:
-    """Download and extract a web article. Returns (title, text)."""
-    downloaded = trafilatura.fetch_url(url)
+@dataclass
+class FetchResult:
+    """The structured outcome of one content-extraction attempt."""
+
+    title: str | None = None
+    text: str | None = None
+    http_status: int | None = None
+    failure_reason: FailureReason | None = None
+    error: str | None = None
+    attempts: int = 1
+
+
+ArticleExtractor = Callable[[str], FetchResult]
+
+
+def is_x_url(url: str) -> bool:
+    """True for a link whose host is x.com / twitter.com."""
+    return (urlparse(url).hostname or "").lower() in _X_HOSTS
+
+
+def _reason_for_status(code: int) -> FailureReason | None:
+    """Map an HTTP status code to a failure category (None = not categorised)."""
+    if code in (404, 410):
+        return "not_found"
+    if code in (401, 403):
+        return "forbidden"
+    if code in (402, 451):
+        return "paywall"
+    return None
+
+
+def _categorize_url_error(exc: urllib.error.URLError) -> FailureReason | None:
+    """Classify a network-level URLError as timeout / dns_error / uncategorised."""
+    reason = getattr(exc, "reason", None)
+    if isinstance(reason, (TimeoutError, socket.timeout)):
+        return "timeout"
+    if isinstance(reason, socket.gaierror):
+        return "dns_error"
+    return None
+
+
+def _probe_status(
+    url: str, opener: Callable = urllib.request.urlopen
+) -> tuple[int | None, FailureReason | None, str]:
+    """Probe a URL trafilatura could not download, to categorise the failure.
+
+    Returns `(http_status, failure_reason, error_text)`. A *successful* probe
+    means the page is reachable but trafilatura found no article — most likely
+    JavaScript-rendered, so the reason is `js_required`.
+    """
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    try:
+        with opener(req, timeout=_TIMEOUT) as resp:
+            status = getattr(resp, "status", None) or 200
+        return status, "js_required", "Descargable pero sin artículo extraíble (posible JavaScript)."
+    except urllib.error.HTTPError as exc:
+        return exc.code, _reason_for_status(exc.code), f"HTTP {exc.code}: {exc.reason}"
+    except urllib.error.URLError as exc:
+        return None, _categorize_url_error(exc), f"Error de red: {exc.reason}"
+    except (TimeoutError, socket.timeout) as exc:
+        return None, "timeout", f"Tiempo de espera agotado: {exc}"
+
+
+def trafilatura_extract(
+    url: str,
+    *,
+    fetch: Callable = trafilatura.fetch_url,
+    extract: Callable = trafilatura.extract,
+    prober: Callable = _probe_status,
+) -> FetchResult:
+    """Extract an article with trafilatura, categorising any failure."""
+    downloaded = fetch(url)
     if downloaded is None:
-        return None, None
-    text = trafilatura.extract(downloaded)
+        status, reason, error = prober(url)
+        return FetchResult(http_status=status, failure_reason=reason, error=error, attempts=1)
+    text = extract(downloaded)
+    if not text:
+        return FetchResult(
+            http_status=200,
+            failure_reason="empty_content",
+            error="La página se descargó pero no tiene un artículo extraíble.",
+            attempts=1,
+        )
     metadata = trafilatura.extract_metadata(downloaded)
     title = metadata.title if metadata else None
-    return title, text
+    return FetchResult(title=title, text=text, http_status=200, attempts=1)
+
+
+def extract_article(url: str) -> FetchResult:
+    """Default extractor — trafilatura only. The Firecrawl fallback is wired in
+    a later task, which replaces this function."""
+    return trafilatura_extract(url)
 
 
 def fetch_item(item: Item, extractor: ArticleExtractor = extract_article) -> Content:
-    """Fetch every external link of an item into ContentSource entries."""
-    sources: list[ContentSource] = []
+    """Build/refresh the `external_article` sources of an item.
+
+    x.com links are skipped (see `xbrain.fetch_x`). Non-external sources already
+    on the item (threads, x_article) are preserved across a re-fetch.
+    """
+    new_sources: list[ContentSource] = []
     for link in item.links:
-        if _is_x_url(link.url):
-            sources.append(
-                ContentSource(
-                    kind="x_article",
-                    url=link.url,
-                    ok=False,
-                    error="El contenido de x.com no se extrae automáticamente en v1.",
-                )
-            )
+        if is_x_url(link.url):
             continue
         try:
-            title, text = extractor(link.url)
+            result = extractor(link.url)
         except Exception as exc:  # noqa: BLE001 - one bad URL must not abort the batch
-            sources.append(
+            new_sources.append(
                 ContentSource(
                     kind="external_article",
                     url=link.url,
                     ok=False,
                     error=f"Error al descargar el artículo: {exc}",
+                    attempts=1,
                 )
             )
             continue
-        if text:
-            sources.append(
+        if result.text:
+            new_sources.append(
                 ContentSource(
                     kind="external_article",
                     url=link.url,
-                    title=title,
-                    text=text,
+                    title=result.title,
+                    text=result.text,
                     ok=True,
+                    http_status=result.http_status,
+                    attempts=result.attempts,
                 )
             )
         else:
-            sources.append(
+            new_sources.append(
                 ContentSource(
                     kind="external_article",
                     url=link.url,
                     ok=False,
-                    error="No se pudo extraer el artículo.",
+                    error=result.error,
+                    http_status=result.http_status,
+                    failure_reason=result.failure_reason,
+                    attempts=result.attempts,
                 )
             )
-    return Content(fetched_at=datetime.now(timezone.utc), sources=sources)
+    kept = (
+        [s for s in item.content.sources if s.kind != "external_article"]
+        if item.content
+        else []
+    )
+    return Content(fetched_at=datetime.now(timezone.utc), sources=kept + new_sources)
 
 
 def fetch_pending(
@@ -86,10 +181,10 @@ def fetch_pending(
     force: bool = False,
     extractor: ArticleExtractor = extract_article,
 ) -> int:
-    """Fetch content for items that have links and no content yet."""
+    """Fetch external content for items that have non-x links and no content yet."""
     fetched = 0
     for item in store.values():
-        if not item.links:
+        if not any(not is_x_url(link.url) for link in item.links):
             continue
         if item.content is not None and not force:
             continue
@@ -100,7 +195,3 @@ def fetch_pending(
         item.content = fetch_item(item, extractor)
         fetched += 1
     return fetched
-
-
-def _is_x_url(url: str) -> bool:
-    return (urlparse(url).hostname or "").lower() in _X_HOSTS

--- a/src/xbrain/fetch_x.py
+++ b/src/xbrain/fetch_x.py
@@ -23,7 +23,7 @@ from xbrain.fetch import is_x_url
 from xbrain.models import Content, ContentSource, Item
 
 _SETTLE_MS = 4000
-_STATUS_RE = re.compile(r"/status/(\d+)")
+_STATUS_RE = re.compile(r"/[^/]+/status/(\d+)")
 
 LinkFetcher = Callable[[str], ContentSource]
 
@@ -37,10 +37,12 @@ def _x_status_id(url: str) -> str | None:
 def _classify_x_url(url: str) -> Literal["status", "article", "other"]:
     """Classify an x.com URL: a tweet/thread, an X article, or anything else."""
     path = urlparse(url).path
-    if _STATUS_RE.search(path):
-        return "status"
+    # Check the article prefix before /status/ — an X article URL can itself
+    # contain a `/status/<id>` segment and must not be misrouted as a tweet.
     if path.startswith("/i/article/"):
         return "article"
+    if _STATUS_RE.search(path):
+        return "status"
     return "other"
 
 
@@ -63,7 +65,11 @@ def assemble_linked_thread(responses: list, anchor_id: str) -> tuple[str | None,
 
 
 def _fetch_tweet(context: BrowserContext, url: str) -> ContentSource:
-    """Fetch a linked tweet/thread via TweetDetail interception."""
+    """Fetch a linked tweet/thread via TweetDetail interception.
+
+    The result is filed as `kind="x_article"` (not `thread`) so all x.com-link
+    content shares one source kind for `_needs_x_fetch` / `_attach_x_sources`.
+    """
     captured: list[dict] = []
     page = context.new_page()
 
@@ -148,8 +154,17 @@ def _fetch_x_link(context: BrowserContext, url: str) -> ContentSource:
     return _fetch_rendered(context, url)
 
 
-def _needs_x_fetch(item: Item, force: bool) -> bool:
+def _needs_x_fetch(
+    item: Item,
+    force: bool,
+    since: datetime | None = None,
+    until: datetime | None = None,
+) -> bool:
     if not any(is_x_url(link.url) for link in item.links):
+        return False
+    if since and item.created_at < since:
+        return False
+    if until and item.created_at > until:
         return False
     if force or item.content is None:
         return True
@@ -169,21 +184,26 @@ def fetch_x_articles(
     store: dict[str, Item],
     storage_state_path: Path | None,
     force: bool = False,
+    since: datetime | None = None,
+    until: datetime | None = None,
     *,
     link_fetcher: LinkFetcher | None = None,
 ) -> int:
     """Fetch x.com link content for every item that has one and needs it.
 
     `link_fetcher` is injected by tests; in production it is bound to a live
-    Playwright context opened from `storage_state_path`.
+    Playwright context opened from `storage_state_path`. `since`/`until` apply
+    the same `created_at` date-window filter as `fetch.fetch_pending`.
     """
-    pending = [item for item in store.values() if _needs_x_fetch(item, force)]
+    pending = [item for item in store.values() if _needs_x_fetch(item, force, since, until)]
     if not pending:
         return 0
 
     def _process(fetcher: LinkFetcher) -> None:
         for item in pending:
-            sources = [fetcher(link.url) for link in item.links if is_x_url(link.url)]
+            # Dedup x.com URLs so a repeated link yields a single source.
+            urls = dict.fromkeys(link.url for link in item.links if is_x_url(link.url))
+            sources = [fetcher(url) for url in urls]
             _attach_x_sources(item, sources)
 
     if link_fetcher is not None:

--- a/src/xbrain/fetch_x.py
+++ b/src/xbrain/fetch_x.py
@@ -1,0 +1,196 @@
+"""Fetch X (x.com) content linked from items.
+
+`/status/` links are fetched by reusing the `TweetDetail` GraphQL interception
+proven in `xbrain.extract.threads`; `/i/article/` and other x.com links are
+fetched as Playwright-rendered HTML and run through trafilatura. A fetch failure
+records the same structured evidence as `xbrain.fetch` (design §4, §15.2).
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, Literal
+from urllib.parse import urlparse
+
+import trafilatura
+from playwright.sync_api import BrowserContext, Response
+
+from xbrain.extract.browser import is_logged_out, x_context
+from xbrain.extract.graphql import parse_tweets
+from xbrain.fetch import is_x_url
+from xbrain.models import Content, ContentSource, Item
+
+_SETTLE_MS = 4000
+_STATUS_RE = re.compile(r"/status/(\d+)")
+
+LinkFetcher = Callable[[str], ContentSource]
+
+
+def _x_status_id(url: str) -> str | None:
+    """The tweet id of an x.com `/status/<id>` URL, or None."""
+    match = _STATUS_RE.search(urlparse(url).path)
+    return match.group(1) if match else None
+
+
+def _classify_x_url(url: str) -> Literal["status", "article", "other"]:
+    """Classify an x.com URL: a tweet/thread, an X article, or anything else."""
+    path = urlparse(url).path
+    if _STATUS_RE.search(path):
+        return "status"
+    if path.startswith("/i/article/"):
+        return "article"
+    return "other"
+
+
+def assemble_linked_thread(responses: list, anchor_id: str) -> tuple[str | None, str]:
+    """From captured `TweetDetail` responses, concatenate the thread rooted at
+    the linked tweet. Pure — no browser. Returns `(author_handle, text)`."""
+    tweets: list[Item] = []
+    seen: set[str] = set()
+    for response in responses:
+        for tweet in parse_tweets(response, "bookmark"):
+            if tweet.id not in seen:
+                seen.add(tweet.id)
+                tweets.append(tweet)
+    anchor = next((t for t in tweets if t.id == anchor_id), None)
+    if anchor is None:
+        return None, ""
+    handle = anchor.author.handle
+    thread = sorted((t for t in tweets if t.author.handle == handle), key=lambda t: t.created_at)
+    return handle, "\n\n".join(t.text for t in thread)
+
+
+def _fetch_tweet(context: BrowserContext, url: str) -> ContentSource:
+    """Fetch a linked tweet/thread via TweetDetail interception."""
+    captured: list[dict] = []
+    page = context.new_page()
+
+    def on_response(response: Response) -> None:
+        if "/graphql/" in response.url and "TweetDetail" in response.url:
+            try:
+                captured.append(response.json())
+            except Exception:  # noqa: BLE001 - ignore non-JSON / partial bodies
+                pass
+
+    page.on("response", on_response)
+    try:
+        try:
+            page.goto(url, wait_until="domcontentloaded")
+            page.wait_for_timeout(_SETTLE_MS)
+        except Exception:  # noqa: BLE001 - navigation failure -> empty result
+            return ContentSource(
+                kind="x_article",
+                url=url,
+                ok=False,
+                failure_reason="timeout",
+                error="No se pudo cargar el tweet.",
+                attempts=1,
+            )
+        if is_logged_out(page.url):
+            raise RuntimeError("Sesión de X caducada. Ejecuta `xbrain login`.")
+        _handle, text = assemble_linked_thread(captured, _x_status_id(url) or "")
+    finally:
+        page.close()
+    if text:
+        return ContentSource(kind="x_article", url=url, text=text, ok=True, attempts=1)
+    return ContentSource(
+        kind="x_article",
+        url=url,
+        ok=False,
+        failure_reason="empty_content",
+        error="No se pudo recuperar el contenido del tweet.",
+        attempts=1,
+    )
+
+
+def _fetch_rendered(context: BrowserContext, url: str) -> ContentSource:
+    """Fetch an X article (or other x.com page) as rendered HTML."""
+    page = context.new_page()
+    try:
+        try:
+            page.goto(url, wait_until="domcontentloaded")
+            page.wait_for_timeout(_SETTLE_MS)
+        except Exception:  # noqa: BLE001 - navigation failure -> empty result
+            return ContentSource(
+                kind="x_article",
+                url=url,
+                ok=False,
+                failure_reason="timeout",
+                error="No se pudo cargar el artículo de X.",
+                attempts=1,
+            )
+        if is_logged_out(page.url):
+            raise RuntimeError("Sesión de X caducada. Ejecuta `xbrain login`.")
+        html = page.content()
+    finally:
+        page.close()
+    text = trafilatura.extract(html)
+    if text:
+        return ContentSource(
+            kind="x_article", url=url, text=text, ok=True, http_status=200, attempts=1
+        )
+    return ContentSource(
+        kind="x_article",
+        url=url,
+        ok=False,
+        failure_reason="empty_content",
+        error="No se pudo extraer el contenido del artículo de X.",
+        attempts=1,
+    )
+
+
+def _fetch_x_link(context: BrowserContext, url: str) -> ContentSource:
+    """Fetch one x.com link, routed by URL kind."""
+    if _classify_x_url(url) == "status":
+        return _fetch_tweet(context, url)
+    return _fetch_rendered(context, url)
+
+
+def _needs_x_fetch(item: Item, force: bool) -> bool:
+    if not any(is_x_url(link.url) for link in item.links):
+        return False
+    if force or item.content is None:
+        return True
+    return not any(s.kind == "x_article" for s in item.content.sources)
+
+
+def _attach_x_sources(item: Item, sources: list[ContentSource]) -> None:
+    """Replace the item's `x_article` sources, keeping every other kind."""
+    if item.content is None:
+        item.content = Content(fetched_at=datetime.now(timezone.utc), sources=list(sources))
+    else:
+        kept = [s for s in item.content.sources if s.kind != "x_article"]
+        item.content.sources = kept + list(sources)
+
+
+def fetch_x_articles(
+    store: dict[str, Item],
+    storage_state_path: Path | None,
+    force: bool = False,
+    *,
+    link_fetcher: LinkFetcher | None = None,
+) -> int:
+    """Fetch x.com link content for every item that has one and needs it.
+
+    `link_fetcher` is injected by tests; in production it is bound to a live
+    Playwright context opened from `storage_state_path`.
+    """
+    pending = [item for item in store.values() if _needs_x_fetch(item, force)]
+    if not pending:
+        return 0
+
+    def _process(fetcher: LinkFetcher) -> None:
+        for item in pending:
+            sources = [fetcher(link.url) for link in item.links if is_x_url(link.url)]
+            _attach_x_sources(item, sources)
+
+    if link_fetcher is not None:
+        _process(link_fetcher)
+    else:
+        if storage_state_path is None:
+            raise ValueError("storage_state_path is required without an injected link_fetcher")
+        with x_context(storage_state_path) as context:
+            _process(lambda url: _fetch_x_link(context, url))
+    return len(pending)

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -8,7 +8,7 @@ import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.models import Item
+from xbrain.models import ContentSource, Item
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +19,28 @@ _DEFAULT_TAIL = (
     "*(Escribe debajo. El bloque por encima de este punto se regenera "
     "automáticamente; no lo edites.)*\n\n"
 )
+
+_FAILURE_ES = {
+    "not_found": "no encontrado",
+    "forbidden": "acceso denegado",
+    "paywall": "muro de pago",
+    "timeout": "tiempo de espera agotado",
+    "dns_error": "dominio no resuelto",
+    "js_required": "requiere JavaScript",
+    "empty_content": "sin contenido extraíble",
+}
+
+
+def _broken_link_line(source: ContentSource, fetched_at: datetime) -> str:
+    """A one-line, human-readable record of a link that could not be fetched."""
+    bits: list[str] = []
+    if source.http_status:
+        bits.append(f"HTTP {source.http_status}")
+    if source.failure_reason:
+        bits.append(_FAILURE_ES.get(source.failure_reason, source.failure_reason))
+    detail = " · ".join(bits) or "no se pudo recuperar"
+    date = fetched_at.date().isoformat()
+    return f"> ⚠ Enlace roto: <{source.url}> — {detail} (verificado {date})"
 
 
 def generate(
@@ -126,6 +148,8 @@ def _render_note(item: Item) -> str:
             if source.ok and source.text:
                 heading = source.title or source.url
                 lines += [f"## Contenido: {heading}", "", source.text, ""]
+            elif not source.ok and source.kind in ("external_article", "x_article"):
+                lines += [_broken_link_line(source, item.content.fetched_at), ""]
     return "\n".join(lines).rstrip()
 
 

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -6,18 +6,12 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.models import ContentSource, Item
-from xbrain.notes_io import note_filename, slugify, title_of, user_tail, wrap
+from xbrain.models import Content, ContentSource, FailureReason, Item
+from xbrain.notes_io import DEFAULT_TAIL, note_filename, slugify, title_of, user_tail, wrap
 
 logger = logging.getLogger(__name__)
 
-_DEFAULT_TAIL = (
-    "\n\n## Mis notas\n\n"
-    "*(Escribe debajo. El bloque por encima de este punto se regenera "
-    "automáticamente; no lo edites.)*\n\n"
-)
-
-_FAILURE_ES = {
+_FAILURE_ES: dict[FailureReason, str] = {
     "not_found": "no encontrado",
     "forbidden": "acceso denegado",
     "paywall": "muro de pago",
@@ -88,12 +82,12 @@ def _write_note(items_dir: Path, item: Item) -> None:
     block = wrap(_render_note(item))
     source = path if path.exists() else _stale_note(items_dir, item, path)
     if source is not None:
-        tail = user_tail(source.read_text(encoding="utf-8"), _DEFAULT_TAIL)
+        tail = user_tail(source.read_text(encoding="utf-8"), DEFAULT_TAIL)
         if source != path:
             source.unlink()
             logger.info("Migrated note %s -> %s", source.name, path.name)
     else:
-        tail = _DEFAULT_TAIL
+        tail = DEFAULT_TAIL
     path.write_text(block + tail, encoding="utf-8")
 
 
@@ -111,14 +105,34 @@ def _stale_note(items_dir: Path, item: Item, current: Path) -> Path | None:
     return None
 
 
+def _enrichment_lines(item: Item) -> list[str]:
+    """Summary + topic links for an enriched item (empty if not enriched)."""
+    if not item.enriched:
+        return []
+    lines: list[str] = []
+    if item.enriched.summary:
+        lines += [item.enriched.summary, ""]
+    if item.enriched.topics:
+        links = " · ".join(f"[[{t}]]" for t in item.enriched.topics)
+        lines += [f"**Temas:** {links}", ""]
+    return lines
+
+
+def _content_lines(content: Content) -> list[str]:
+    """Rendered article bodies + broken-link evidence for a fetched item."""
+    lines: list[str] = []
+    for source in content.sources:
+        if source.ok and source.text:
+            heading = source.title or source.url
+            lines += [f"## Contenido: {heading}", "", source.text, ""]
+        elif not source.ok and source.kind in ("external_article", "x_article"):
+            lines += [_broken_link_line(source, content.fetched_at), ""]
+    return lines
+
+
 def _render_note(item: Item) -> str:
     lines = [_frontmatter(item), "", f"# {title_of(item)}", ""]
-    if item.enriched:
-        if item.enriched.summary:
-            lines += [item.enriched.summary, ""]
-        if item.enriched.topics:
-            topic_links = " · ".join(f"[[{t}]]" for t in item.enriched.topics)
-            lines += [f"**Temas:** {topic_links}", ""]
+    lines += _enrichment_lines(item)
     lines += ["## Tweet", "", item.text, ""]
     if item.links:
         lines.append("## Enlaces")
@@ -126,12 +140,7 @@ def _render_note(item: Item) -> str:
         lines.append("")
     lines += [f"[Ver tweet original]({item.url})", ""]
     if item.content:
-        for source in item.content.sources:
-            if source.ok and source.text:
-                heading = source.title or source.url
-                lines += [f"## Contenido: {heading}", "", source.text, ""]
-            elif not source.ok and source.kind in ("external_article", "x_article"):
-                lines += [_broken_link_line(source, item.content.fetched_at), ""]
+        lines += _content_lines(item.content)
     return "\n".join(lines).rstrip()
 
 

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -3,17 +3,14 @@
 from __future__ import annotations
 
 import logging
-import re
-import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
 
 from xbrain.models import ContentSource, Item
+from xbrain.notes_io import note_filename, slugify, title_of, user_tail, wrap
 
 logger = logging.getLogger(__name__)
 
-GEN_START = "<!-- xbrain:generated:start -->"
-GEN_END = "<!-- xbrain:generated:end -->"
 _DEFAULT_TAIL = (
     "\n\n## Mis notas\n\n"
     "*(Escribe debajo. El bloque por encima de este punto se regenera "
@@ -87,11 +84,11 @@ def _write_note(items_dir: Path, item: Item) -> None:
     so the user's hand-written tail follows the item instead of being
     orphaned.
     """
-    path = items_dir / _note_filename(item)
-    block = f"{GEN_START}\n{_render_note(item)}\n{GEN_END}"
+    path = items_dir / note_filename(item)
+    block = wrap(_render_note(item))
     source = path if path.exists() else _stale_note(items_dir, item, path)
     if source is not None:
-        tail = _user_tail(source.read_text(encoding="utf-8"))
+        tail = user_tail(source.read_text(encoding="utf-8"), _DEFAULT_TAIL)
         if source != path:
             source.unlink()
             logger.info("Migrated note %s -> %s", source.name, path.name)
@@ -114,23 +111,8 @@ def _stale_note(items_dir: Path, item: Item, current: Path) -> Path | None:
     return None
 
 
-def _user_tail(existing: str) -> str:
-    """Return the content to preserve after the generated block.
-
-    Normally everything after GEN_END. If GEN_END is missing (markers
-    deleted or corrupted) but the file has content, preserve the whole
-    file rather than discarding the user's work.
-    """
-    idx = existing.find(GEN_END)
-    if idx != -1:
-        return existing[idx + len(GEN_END) :]
-    if existing.strip():
-        return "\n\n" + existing
-    return _DEFAULT_TAIL
-
-
 def _render_note(item: Item) -> str:
-    lines = [_frontmatter(item), "", f"# {_title(item)}", ""]
+    lines = [_frontmatter(item), "", f"# {title_of(item)}", ""]
     if item.enriched:
         if item.enriched.summary:
             lines += [item.enriched.summary, ""]
@@ -159,7 +141,7 @@ def _frontmatter(item: Item) -> str:
     if item.enriched:
         tags += item.enriched.topics  # topics already includes primary_topic
     if item.bookmark_folder:
-        tags.append(_slugify(item.bookmark_folder))
+        tags.append(slugify(item.bookmark_folder))
     tags = list(dict.fromkeys(tags))
     lines = [
         "---",
@@ -216,25 +198,6 @@ def _render_log(items: list[Item]) -> str:
     for item in items:
         date = item.created_at.date().isoformat()
         snippet = item.text.replace("\n", " ")[:120]
-        link = f" → [[items/{Path(_note_filename(item)).stem}|nota]]" if _has_note(item) else ""
+        link = f" → [[items/{Path(note_filename(item)).stem}|nota]]" if _has_note(item) else ""
         lines.append(f"- `{date}` @{item.author.handle}: {snippet}{link}")
     return "\n".join(lines) + "\n"
-
-
-def _title(item: Item) -> str:
-    if item.content:
-        for source in item.content.sources:
-            if source.title:
-                return source.title
-    return item.text.replace("\n", " ")[:80] or item.id
-
-
-def _note_filename(item: Item) -> str:
-    return f"{item.created_at.date().isoformat()}-{_slugify(_title(item))}-{item.id}.md"
-
-
-def _slugify(text: str) -> str:
-    normalized = unicodedata.normalize("NFKD", text)
-    ascii_text = normalized.encode("ascii", "ignore").decode("ascii").lower()
-    slug = re.sub(r"[^a-z0-9]+", "-", ascii_text).strip("-")
-    return slug[:60] or "item"

--- a/src/xbrain/guardrails.yaml
+++ b/src/xbrain/guardrails.yaml
@@ -10,3 +10,11 @@ enrichment:
   topics_max: 4
   # `summary` must be present and non-empty
   summary_required: true
+
+# Mechanical constraints on a topic-overview judgment (validate_overview).
+topic_overview:
+  # `overview` must be present and non-empty
+  overview_required: true
+  # allowed size of the `notes` list
+  notes_min: 0
+  notes_max: 15

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -58,6 +58,7 @@ class ContentSource(BaseModel):
     error: str | None = None
     http_status: int | None = None
     failure_reason: FailureReason | None = None
+    # extraction attempts: 1 = single pass, 2 = + Firecrawl fallback; 0 only on pre-Fase-2 records
     attempts: int = 0
 
 

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -15,6 +15,18 @@ ExecutorName = Literal["manual", "api", "claude-code"]
 # and the GraphQL parser.
 SourceName = Literal["bookmark", "own_tweet"]
 
+# Categorised reasons a content fetch can fail — structured evidence so a
+# broken link is demonstrable, not assumed (design §4).
+FailureReason = Literal[
+    "not_found",
+    "forbidden",
+    "paywall",
+    "timeout",
+    "dns_error",
+    "js_required",
+    "empty_content",
+]
+
 
 class Author(BaseModel):
     handle: str
@@ -44,6 +56,9 @@ class ContentSource(BaseModel):
     text: str | None = None
     ok: bool = True
     error: str | None = None
+    http_status: int | None = None
+    failure_reason: FailureReason | None = None
+    attempts: int = 0
 
 
 class Content(BaseModel):

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -82,6 +82,21 @@ class Topic(BaseModel):
     description: str
 
 
+class TopicPage(BaseModel):
+    """One synthesized topic-page overview, persisted in data/topics.json.
+
+    `post_count_at_synth` records how many posts the topic had when the overview
+    was synthesized — comparing it to the live count derives staleness without a
+    stored flag that could desync.
+    """
+
+    slug: str
+    overview: str
+    notes: list[str] = Field(default_factory=list)
+    synthesized_at: datetime
+    post_count_at_synth: int
+
+
 class Item(BaseModel):
     id: str
     source: SourceName

--- a/src/xbrain/notes_io.py
+++ b/src/xbrain/notes_io.py
@@ -15,6 +15,15 @@ from xbrain.models import Item
 GEN_START = "<!-- xbrain:generated:start -->"
 GEN_END = "<!-- xbrain:generated:end -->"
 
+# The default "Mis notas" tail appended after the generated block of a freshly
+# created page — shared by item notes (`xbrain.generate`) and topic pages
+# (`xbrain.topics`).
+DEFAULT_TAIL = (
+    "\n\n## Mis notas\n\n"
+    "*(Escribe debajo. El bloque por encima de este punto se regenera "
+    "automáticamente; no lo edites.)*\n\n"
+)
+
 
 def wrap(body: str) -> str:
     """Surround a generated body with the start / end markers."""

--- a/src/xbrain/notes_io.py
+++ b/src/xbrain/notes_io.py
@@ -1,0 +1,58 @@
+"""Shared markdown helpers for the generated wiki pages.
+
+The generated-block markers, user-tail preservation and the slug / filename
+helpers — used by both `xbrain.generate` (item notes) and `xbrain.topics`
+(topic pages).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from xbrain.models import Item
+
+GEN_START = "<!-- xbrain:generated:start -->"
+GEN_END = "<!-- xbrain:generated:end -->"
+
+
+def wrap(body: str) -> str:
+    """Surround a generated body with the start / end markers."""
+    return f"{GEN_START}\n{body}\n{GEN_END}"
+
+
+def user_tail(existing: str, default_tail: str) -> str:
+    """Return the content to preserve after the generated block.
+
+    Normally everything after `GEN_END`. If `GEN_END` is missing (markers
+    deleted or corrupted) but the file has content, preserve the whole file
+    rather than discarding the user's work. An empty file gets `default_tail`.
+    """
+    idx = existing.find(GEN_END)
+    if idx != -1:
+        return existing[idx + len(GEN_END) :]
+    if existing.strip():
+        return "\n\n" + existing
+    return default_tail
+
+
+def slugify(text: str) -> str:
+    """A lowercase ASCII kebab-case slug, capped at 60 characters."""
+    normalized = unicodedata.normalize("NFKD", text)
+    ascii_text = normalized.encode("ascii", "ignore").decode("ascii").lower()
+    slug = re.sub(r"[^a-z0-9]+", "-", ascii_text).strip("-")
+    return slug[:60] or "item"
+
+
+def title_of(item: Item) -> str:
+    """A display title for an item — a fetched article title, else the text."""
+    if item.content:
+        for source in item.content.sources:
+            if source.title:
+                return source.title
+    return item.text.replace("\n", " ")[:80] or item.id
+
+
+def note_filename(item: Item) -> str:
+    """The collision-free filename of an item's note (ends with its id)."""
+    return f"{item.created_at.date().isoformat()}-{slugify(title_of(item))}-{item.id}.md"

--- a/src/xbrain/rubrics/rubric-topic-page.md
+++ b/src/xbrain/rubrics/rubric-topic-page.md
@@ -1,0 +1,27 @@
+# Rubric — Topic page overview
+
+Synthesize the overview of one topic page from the summaries of its posts.
+
+You receive a topic `slug`, its `description`, and the Spanish summaries of
+every post filed under it. Produce two things:
+
+- **`overview`** — 1 to 3 paragraphs, in Spanish. Synthesize what this topic is
+  about *in this corpus*: the recurring ideas, the arc over time, the tensions
+  or debates. Write for someone deciding whether to read the posts. Be faithful
+  to the summaries — never invent facts, names or numbers that are not in them.
+- **`notes`** — a list of 0 to 15 short strings, in Spanish. Each note is one
+  important thread, claim or pattern in the topic. One idea per note, a plain
+  sentence. Use an empty list only for a topic with no thematic core.
+
+## Hard rules
+
+- **Plain prose only.** Never write a wikilink (`[[...]]`), a filename, a note
+  title or any identifier. You are given summaries, not posts — you cannot know
+  the identifiers, and inventing them breaks the wiki. The code adds the post
+  links; you write the prose.
+- **No markdown headings** inside `overview` or `notes`, and no bullet
+  characters inside a note string.
+- Output **only** the JSON object `{"overview": "...", "notes": ["...", ...]}`.
+- If the topic is `misc` or genuinely has no thematic core, say so plainly in a
+  one-paragraph `overview` and a short (or empty) `notes` list — do not
+  manufacture themes.

--- a/src/xbrain/store.py
+++ b/src/xbrain/store.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from xbrain.models import Item, State
+from xbrain.models import Item, State, TopicPage
 
 
 def load_store(path: Path) -> dict[str, Item]:
@@ -34,6 +34,22 @@ def merge_items(store: dict[str, Item], new_items: list[Item]) -> int:
             store[item.id] = item
             added += 1
     return added
+
+
+def load_topic_pages(path: Path) -> dict[str, TopicPage]:
+    """Load the topic-page store; an empty dict if the file does not exist."""
+    if not path.exists():
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    return {slug: TopicPage.model_validate(data) for slug, data in raw.items()}
+
+
+def save_topic_pages(pages: dict[str, TopicPage], path: Path) -> None:
+    """Persist the topic-page store as pretty, sorted, UTF-8 JSON (atomic write)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {slug: page.model_dump(mode="json") for slug, page in pages.items()}
+    text = json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)
+    _atomic_write(path, text)
 
 
 def load_state(path: Path) -> State:

--- a/src/xbrain/topic_synth.py
+++ b/src/xbrain/topic_synth.py
@@ -1,0 +1,153 @@
+"""Topic-overview synthesis — the two executor tracks for the `topics` stage.
+
+Mirrors the enrich pattern: an `api` track (one Anthropic call per topic) and a
+worksheet track (export / import for the `manual` / `claude-code` executors).
+Both consume the same declarative `rubric-topic-page.md`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from xbrain.llm_json import json_from_response
+from xbrain.rubrics import load_rubric
+from xbrain.validate import validate_overview
+
+_MAX_TOKENS = 2000
+
+
+class OverviewJudgment(BaseModel):
+    """One synthesized topic overview — judgment only, no identifiers."""
+
+    slug: str
+    overview: str
+    notes: list[str] = Field(default_factory=list)
+
+
+@dataclass
+class TopicInput:
+    """Everything an executor needs to synthesize one topic's overview."""
+
+    slug: str
+    description: str
+    summaries: list[str]
+
+
+def _system_prompt() -> str:
+    """The rubric is the system prompt — the declarative source of truth."""
+    return (
+        load_rubric("topic-page") + "\n\n---\n\n"
+        "Respond with a single JSON object and nothing else:\n"
+        '{"overview": "...", "notes": ["...", ...]}'
+    )
+
+
+def _user_prompt(topic: TopicInput) -> str:
+    lines = [
+        f"Topic slug: {topic.slug}",
+        f"Topic description: {topic.description}",
+        "",
+        f"Summaries of the {len(topic.summaries)} posts in this topic:",
+    ]
+    lines += [f"- {summary}" for summary in topic.summaries]
+    return "\n".join(lines)
+
+
+def _judgment_from_response(response, slug: str) -> OverviewJudgment:
+    judgment = json_from_response(response, context=f"topic {slug}")
+    errors = validate_overview(judgment)
+    if errors:
+        raise ValueError(f"overview rechazado: {'; '.join(errors)}")
+    return OverviewJudgment(
+        slug=slug, overview=str(judgment["overview"]), notes=list(judgment["notes"])
+    )
+
+
+def synthesize_overviews_api(
+    inputs: list[TopicInput], model: str, client=None
+) -> list[OverviewJudgment]:
+    """Synthesize topic overviews via the Anthropic API — one call per topic."""
+    if client is None:
+        from anthropic import Anthropic  # lazy: tests inject a fake
+
+        client = Anthropic()  # reads ANTHROPIC_API_KEY from the environment
+    system = _system_prompt()
+    results: list[OverviewJudgment] = []
+    for topic in inputs:
+        try:
+            response = client.messages.create(
+                model=model,
+                max_tokens=_MAX_TOKENS,
+                system=system,
+                messages=[{"role": "user", "content": _user_prompt(topic)}],
+            )
+            results.append(_judgment_from_response(response, topic.slug))
+        except Exception as exc:  # noqa: BLE001
+            # One failed topic must not abort the batch — it stays unsynthesized
+            # and is retried on the next run.
+            print(
+                f"warn: topic synthesis failed for {topic.slug}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+    return results
+
+
+def export_topic_worksheet(inputs: list[TopicInput], path: Path) -> None:
+    """Write a worksheet a Claude Code session (or a person) fills with overviews."""
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "instructions": (
+            "For each entry in `topics`, append one object to `judgments` with "
+            "keys {slug, overview, notes}. `overview` is plain Spanish prose; "
+            "`notes` is a list of plain-prose strings. No wikilinks, no "
+            "filenames. Then run: xbrain topics --apply <this file>."
+        ),
+        "rubric": load_rubric("topic-page"),
+        "topics": [
+            {"slug": t.slug, "description": t.description, "summaries": t.summaries} for t in inputs
+        ],
+        "judgments": [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def import_topic_worksheet(path: Path) -> list[dict]:
+    """Read the `judgments` list from a filled topic worksheet."""
+    if not path.exists():
+        raise FileNotFoundError(f"Worksheet not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    judgments = data.get("judgments", [])
+    if not isinstance(judgments, list):
+        raise ValueError("worksheet `judgments` must be a list")
+    return judgments
+
+
+def apply_overview_judgments(
+    judgments: list[dict],
+) -> tuple[list[OverviewJudgment], list[tuple[str, list[str]]]]:
+    """Validate worksheet judgments. Returns `(valid, invalid)`."""
+    valid: list[OverviewJudgment] = []
+    invalid: list[tuple[str, list[str]]] = []
+    for judgment in judgments:
+        slug = str(judgment.get("slug", ""))
+        candidate = {"overview": judgment.get("overview"), "notes": judgment.get("notes")}
+        errors = validate_overview(candidate)
+        if errors:
+            invalid.append((slug, errors))
+            continue
+        valid.append(
+            OverviewJudgment(
+                slug=slug,
+                overview=str(judgment["overview"]),
+                notes=list(judgment["notes"]),
+            )
+        )
+    return valid, invalid

--- a/src/xbrain/topic_synth.py
+++ b/src/xbrain/topic_synth.py
@@ -23,7 +23,12 @@ _MAX_TOKENS = 2000
 
 
 class OverviewJudgment(BaseModel):
-    """One synthesized topic overview — judgment only, no identifiers."""
+    """One synthesized topic overview.
+
+    The LLM emits only the judgment ``{overview, notes}``; `slug` is the
+    caller-supplied topic identifier stitched in after validation, never
+    produced by the LLM.
+    """
 
     slug: str
     overview: str
@@ -137,6 +142,9 @@ def apply_overview_judgments(
     valid: list[OverviewJudgment] = []
     invalid: list[tuple[str, list[str]]] = []
     for judgment in judgments:
+        if not isinstance(judgment, dict):
+            invalid.append(("", ["worksheet judgment is not a JSON object"]))
+            continue
         slug = str(judgment.get("slug", ""))
         candidate = {"overview": judgment.get("overview"), "notes": judgment.get("notes")}
         errors = validate_overview(candidate)

--- a/src/xbrain/topics.py
+++ b/src/xbrain/topics.py
@@ -32,7 +32,9 @@ def compute_topic_posts(store: dict[str, Item], vocab: list[Topic]) -> dict[str,
     """Group enriched items into per-topic primary / also-relevant lists.
 
     A post is *primary* under its `primary_topic` and *also-relevant* under each
-    of its other topics. Lists are sorted newest-first.
+    of its other topics. Lists are sorted newest-first. An item whose
+    `primary_topic` is not in the current vocabulary is skipped from the primary
+    block (its also-relevant placements still apply).
     """
     result: dict[str, TopicPosts] = {topic.slug: TopicPosts() for topic in vocab}
     for item in store.values():
@@ -41,20 +43,13 @@ def compute_topic_posts(store: dict[str, Item], vocab: list[Topic]) -> dict[str,
             continue
         if enriched.primary_topic in result:
             result[enriched.primary_topic].primary.append(item)
-        for slug in enriched.topics:
+        for slug in dict.fromkeys(enriched.topics):
             if slug != enriched.primary_topic and slug in result:
                 result[slug].also.append(item)
     for posts in result.values():
         posts.primary.sort(key=lambda i: i.created_at, reverse=True)
         posts.also.sort(key=lambda i: i.created_at, reverse=True)
     return result
-
-
-_TOPIC_DEFAULT_TAIL = (
-    "\n\n## Mis notas\n\n"
-    "*(Escribe debajo. El bloque por encima de este punto se regenera "
-    "automáticamente; no lo edites.)*\n\n"
-)
 
 
 def _post_block(heading: str, items: list[Item]) -> list[str]:
@@ -99,7 +94,7 @@ def render_topic_page(topic: Topic, posts: TopicPosts, page: TopicPage | None) -
     if page is None:
         lines += ["*(Overview pendiente — ejecuta `xbrain topics`.)*", ""]
     else:
-        if posts.total != page.post_count_at_synth:
+        if posts.total > page.post_count_at_synth:
             delta = posts.total - page.post_count_at_synth
             lines += [
                 f"> ⚠ Overview desactualizado: {delta:+d} posts desde la última "
@@ -133,9 +128,9 @@ def write_topic_pages(
         block = render_topic_page(topic, posts, pages.get(topic.slug))
         path = topics_dir / f"{topic.slug}.md"
         tail = (
-            notes_io.user_tail(path.read_text(encoding="utf-8"), _TOPIC_DEFAULT_TAIL)
+            notes_io.user_tail(path.read_text(encoding="utf-8"), notes_io.DEFAULT_TAIL)
             if path.exists()
-            else _TOPIC_DEFAULT_TAIL
+            else notes_io.DEFAULT_TAIL
         )
         path.write_text(block + tail, encoding="utf-8")
         written += 1
@@ -179,15 +174,16 @@ def build_topic_inputs(
     by_slug = {topic.slug: topic for topic in vocab}
     inputs: list[TopicInput] = []
     for slug in slugs:
+        topic = by_slug.get(slug)
+        if topic is None:
+            raise ValueError(f"slug '{slug}' is not in the vocabulary")
         posts = all_posts.get(slug, TopicPosts())
         summaries = [
             item.enriched.summary
             for item in (posts.primary + posts.also)
             if item.enriched and item.enriched.summary
         ]
-        inputs.append(
-            TopicInput(slug=slug, description=by_slug[slug].description, summaries=summaries)
-        )
+        inputs.append(TopicInput(slug=slug, description=topic.description, summaries=summaries))
     return inputs
 
 

--- a/src/xbrain/topics.py
+++ b/src/xbrain/topics.py
@@ -8,8 +8,10 @@ topics need (re)synthesis.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
-from xbrain.models import Item, Topic
+from xbrain import notes_io
+from xbrain.models import Item, Topic, TopicPage
 
 
 @dataclass
@@ -44,3 +46,125 @@ def compute_topic_posts(store: dict[str, Item], vocab: list[Topic]) -> dict[str,
         posts.primary.sort(key=lambda i: i.created_at, reverse=True)
         posts.also.sort(key=lambda i: i.created_at, reverse=True)
     return result
+
+
+_TOPIC_DEFAULT_TAIL = (
+    "\n\n## Mis notas\n\n"
+    "*(Escribe debajo. El bloque por encima de este punto se regenera "
+    "automáticamente; no lo edites.)*\n\n"
+)
+
+
+def _post_block(heading: str, items: list[Item]) -> list[str]:
+    """Render one post block as markdown lines (empty when the block is empty)."""
+    if not items:
+        return []
+    lines = [f"## {heading} ({len(items)})", ""]
+    for item in items:
+        date = item.created_at.date().isoformat()
+        stem = Path(notes_io.note_filename(item)).stem
+        title = item.text.replace("\n", " ")[:80] or item.id
+        lines.append(f"- `{date}` · @{item.author.handle} · [[items/{stem}|{title}]]")
+    lines.append("")
+    return lines
+
+
+def _topic_frontmatter(topic: Topic, posts: TopicPosts) -> str:
+    return "\n".join(
+        [
+            "---",
+            f"topic: {topic.slug}",
+            f"tags: [x-knowledge-topic, {topic.slug}]",
+            f"posts: {posts.total}",
+            f"primary_posts: {len(posts.primary)}",
+            "---",
+        ]
+    )
+
+
+def render_topic_page(topic: Topic, posts: TopicPosts, page: TopicPage | None) -> str:
+    """Render one topic page's generated block (frontmatter, overview, lists)."""
+    lines = [
+        _topic_frontmatter(topic, posts),
+        "",
+        f"# {topic.slug}",
+        "",
+        f"> {topic.description}",
+        "",
+        "## Overview",
+        "",
+    ]
+    if page is None:
+        lines += ["*(Overview pendiente — ejecuta `xbrain topics`.)*", ""]
+    else:
+        if posts.total != page.post_count_at_synth:
+            delta = posts.total - page.post_count_at_synth
+            lines += [
+                f"> ⚠ Overview desactualizado: {delta:+d} posts desde la última "
+                "síntesis. Ejecuta `xbrain topics --resynth`.",
+                "",
+            ]
+        lines += [page.overview, ""]
+        if page.notes:
+            lines += ["## Notas importantes", ""]
+            lines += [f"- {note}" for note in page.notes]
+            lines += [""]
+    lines += _post_block("Posts primarios", posts.primary)
+    lines += _post_block("También relevante", posts.also)
+    return notes_io.wrap("\n".join(lines).rstrip())
+
+
+def write_topic_pages(
+    output_dir: Path,
+    vocab: list[Topic],
+    all_posts: dict[str, TopicPosts],
+    pages: dict[str, TopicPage],
+) -> int:
+    """Write `topics/<slug>.md` for every non-empty topic. Returns the count."""
+    topics_dir = output_dir / "topics"
+    topics_dir.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for topic in vocab:
+        posts = all_posts.get(topic.slug, TopicPosts())
+        if posts.total == 0:
+            continue
+        block = render_topic_page(topic, posts, pages.get(topic.slug))
+        path = topics_dir / f"{topic.slug}.md"
+        tail = (
+            notes_io.user_tail(path.read_text(encoding="utf-8"), _TOPIC_DEFAULT_TAIL)
+            if path.exists()
+            else _TOPIC_DEFAULT_TAIL
+        )
+        path.write_text(block + tail, encoding="utf-8")
+        written += 1
+    return written
+
+
+def topics_needing_synth(
+    vocab: list[Topic],
+    all_posts: dict[str, TopicPosts],
+    pages: dict[str, TopicPage],
+    threshold: int,
+    resynth: bool,
+) -> list[str]:
+    """The slugs whose overview must be (re)synthesized.
+
+    A topic with no page is always included. With `resynth`, any topic whose
+    post count changed is included; otherwise only topics that grew by at least
+    `threshold` posts. Empty topics are never synthesized.
+    """
+    needing: list[str] = []
+    for topic in vocab:
+        posts = all_posts.get(topic.slug, TopicPosts())
+        if posts.total == 0:
+            continue
+        page = pages.get(topic.slug)
+        if page is None:
+            needing.append(topic.slug)
+            continue
+        delta = posts.total - page.post_count_at_synth
+        if resynth and delta != 0:
+            needing.append(topic.slug)
+        elif not resynth and delta >= threshold:
+            needing.append(topic.slug)
+    return needing

--- a/src/xbrain/topics.py
+++ b/src/xbrain/topics.py
@@ -1,0 +1,46 @@
+"""The `topics` stage — topic-page post lists, rendering and staleness.
+
+Post lists are mechanical (computed from item enrichments). Overview synthesis
+lives in `xbrain.topic_synth`; this module renders the pages and decides which
+topics need (re)synthesis.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from xbrain.models import Item, Topic
+
+
+@dataclass
+class TopicPosts:
+    """The two post blocks of one topic page."""
+
+    primary: list[Item] = field(default_factory=list)
+    also: list[Item] = field(default_factory=list)
+
+    @property
+    def total(self) -> int:
+        return len(self.primary) + len(self.also)
+
+
+def compute_topic_posts(store: dict[str, Item], vocab: list[Topic]) -> dict[str, TopicPosts]:
+    """Group enriched items into per-topic primary / also-relevant lists.
+
+    A post is *primary* under its `primary_topic` and *also-relevant* under each
+    of its other topics. Lists are sorted newest-first.
+    """
+    result: dict[str, TopicPosts] = {topic.slug: TopicPosts() for topic in vocab}
+    for item in store.values():
+        enriched = item.enriched
+        if enriched is None or not enriched.primary_topic:
+            continue
+        if enriched.primary_topic in result:
+            result[enriched.primary_topic].primary.append(item)
+        for slug in enriched.topics:
+            if slug != enriched.primary_topic and slug in result:
+                result[slug].also.append(item)
+    for posts in result.values():
+        posts.primary.sort(key=lambda i: i.created_at, reverse=True)
+        posts.also.sort(key=lambda i: i.created_at, reverse=True)
+    return result

--- a/src/xbrain/topics.py
+++ b/src/xbrain/topics.py
@@ -8,10 +8,12 @@ topics need (re)synthesis.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 
 from xbrain import notes_io
 from xbrain.models import Item, Topic, TopicPage
+from xbrain.topic_synth import OverviewJudgment, TopicInput
 
 
 @dataclass
@@ -168,3 +170,40 @@ def topics_needing_synth(
         elif not resynth and delta >= threshold:
             needing.append(topic.slug)
     return needing
+
+
+def build_topic_inputs(
+    slugs: list[str], vocab: list[Topic], all_posts: dict[str, TopicPosts]
+) -> list[TopicInput]:
+    """Build the synthesis input for each slug — its description + post summaries."""
+    by_slug = {topic.slug: topic for topic in vocab}
+    inputs: list[TopicInput] = []
+    for slug in slugs:
+        posts = all_posts.get(slug, TopicPosts())
+        summaries = [
+            item.enriched.summary
+            for item in (posts.primary + posts.also)
+            if item.enriched and item.enriched.summary
+        ]
+        inputs.append(
+            TopicInput(slug=slug, description=by_slug[slug].description, summaries=summaries)
+        )
+    return inputs
+
+
+def merge_overviews(
+    pages: dict[str, TopicPage],
+    judgments: list[OverviewJudgment],
+    all_posts: dict[str, TopicPosts],
+) -> None:
+    """Fold synthesized overviews into the topic-page store (in place)."""
+    now = datetime.now(timezone.utc)
+    for judgment in judgments:
+        posts = all_posts.get(judgment.slug, TopicPosts())
+        pages[judgment.slug] = TopicPage(
+            slug=judgment.slug,
+            overview=judgment.overview,
+            notes=judgment.notes,
+            synthesized_at=now,
+            post_count_at_synth=posts.total,
+        )

--- a/src/xbrain/validate.py
+++ b/src/xbrain/validate.py
@@ -61,6 +61,17 @@ def validate_judgment(judgment: dict, vocab_slugs: Iterable[str]) -> list[str]:
 _ALLOWED_OVERVIEW_KEYS = {"overview", "notes"}
 
 
+def _validate_overview_notes(notes: list, rules: dict) -> list[str]:
+    """Validate the `notes` list — count bounds and per-entry string typing."""
+    errors: list[str] = []
+    lo, hi = rules.get("notes_min", 0), rules.get("notes_max", 15)
+    if not (lo <= len(notes) <= hi):
+        errors.append(f"notes has {len(notes)} entries, must be {lo}-{hi}")
+    if any(not isinstance(n, str) for n in notes):
+        errors.append("notes entries must all be strings")
+    return errors
+
+
 def validate_overview(judgment: dict) -> list[str]:
     """Return a list of human-readable errors; an empty list means valid.
 
@@ -75,17 +86,17 @@ def validate_overview(judgment: dict) -> list[str]:
         errors.append(f"unexpected keys (LLM must emit only judgment): {sorted(extra)}")
 
     overview = judgment.get("overview")
-    if rules.get("overview_required", True) and not (overview and str(overview).strip()):
-        errors.append("overview is missing or empty")
+    if rules.get("overview_required", True) and not (
+        isinstance(overview, str) and overview.strip()
+    ):
+        errors.append("overview must be a non-empty string")
 
     notes = judgment.get("notes")
     if not isinstance(notes, list):
         errors.append("notes must be a list")
         return errors
 
-    lo, hi = rules.get("notes_min", 0), rules.get("notes_max", 15)
-    if not (lo <= len(notes) <= hi):
-        errors.append(f"notes has {len(notes)} entries, must be {lo}-{hi}")
+    errors += _validate_overview_notes(notes, rules)
 
     blob = str(overview or "") + " ".join(str(note) for note in notes)
     if "[[" in blob:

--- a/src/xbrain/validate.py
+++ b/src/xbrain/validate.py
@@ -55,3 +55,40 @@ def validate_judgment(judgment: dict, vocab_slugs: Iterable[str]) -> list[str]:
             errors.append(f"primary_topic '{primary}' is not inside topics")
 
     return errors
+
+
+# The only keys a topic-overview judgment may contain.
+_ALLOWED_OVERVIEW_KEYS = {"overview", "notes"}
+
+
+def validate_overview(judgment: dict) -> list[str]:
+    """Return a list of human-readable errors; an empty list means valid.
+
+    Enforces the hard rule mechanically: a topic overview is plain prose — any
+    wikilink (`[[`) is an identifier the LLM must never emit.
+    """
+    rules = load_guardrails().get("topic_overview", {})
+    errors: list[str] = []
+
+    extra = set(judgment) - _ALLOWED_OVERVIEW_KEYS
+    if extra:
+        errors.append(f"unexpected keys (LLM must emit only judgment): {sorted(extra)}")
+
+    overview = judgment.get("overview")
+    if rules.get("overview_required", True) and not (overview and str(overview).strip()):
+        errors.append("overview is missing or empty")
+
+    notes = judgment.get("notes")
+    if not isinstance(notes, list):
+        errors.append("notes must be a list")
+        return errors
+
+    lo, hi = rules.get("notes_min", 0), rules.get("notes_max", 15)
+    if not (lo <= len(notes) <= hi):
+        errors.append(f"notes has {len(notes)} entries, must be {lo}-{hi}")
+
+    blob = str(overview or "") + " ".join(str(note) for note in notes)
+    if "[[" in blob:
+        errors.append("overview/notes must not contain a wikilink ('[[')")
+
+    return errors

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -262,3 +262,16 @@ def test_enrich_manual_with_no_pending_items_writes_no_worksheet(tmp_path, monke
     assert result.exit_code == 0
     assert "No hay items pendientes" in result.output
     assert not (tmp_path / "data" / "enrich-worksheet.json").exists()
+
+
+def test_cli_fetch_reports_x_articles(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    import xbrain.cli as cli
+
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    monkeypatch.setattr(cli, "fetch_pending", lambda *a, **k: 0)
+    monkeypatch.setattr(cli, "fetch_x_articles", lambda *a, **k: 3)
+    monkeypatch.setattr(cli, "expand_threads", lambda *a, **k: 0)
+    result = runner.invoke(app, ["fetch"])
+    assert result.exit_code == 0
+    assert "3 de X" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -352,3 +352,64 @@ def test_topics_without_vocab_fails(tmp_path, monkeypatch):
     result = runner.invoke(app, ["topics"])
     assert result.exit_code == 1
     assert "vocabulario" in result.output
+
+
+def test_topics_run_with_no_stale_overviews(tmp_path, monkeypatch):
+    # Store enriched + an up-to-date TopicPage (count matches the live posts):
+    # nothing is stale, so the run only refreshes the lists.
+    _setup_repo(tmp_path, monkeypatch)
+    from xbrain.models import Topic, TopicPage
+    from xbrain.rubrics import save_vocab
+    from xbrain.store import save_topic_pages
+
+    save_store({"1": _enriched_item("1")}, tmp_path / "data" / "items.json")
+    save_vocab([Topic(slug="misc", description="d")], tmp_path / "data" / "vocab.yaml")
+    save_topic_pages(
+        {
+            "misc": TopicPage(
+                slug="misc",
+                overview="Overview ya sintetizado.",
+                notes=[],
+                synthesized_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+                post_count_at_synth=1,
+            )
+        },
+        tmp_path / "data" / "topics.json",
+    )
+    result = runner.invoke(app, ["topics"])
+    assert result.exit_code == 0
+    assert "sin overviews pendientes" in result.output
+
+
+def test_topics_resynth_succeeds(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    import xbrain.cli as cli
+    from xbrain.models import Topic, TopicPage
+    from xbrain.rubrics import save_vocab
+    from xbrain.store import save_topic_pages
+    from xbrain.topic_synth import OverviewJudgment
+
+    save_store({"1": _enriched_item("1")}, tmp_path / "data" / "items.json")
+    save_vocab([Topic(slug="misc", description="d")], tmp_path / "data" / "vocab.yaml")
+    # Page synthesized when the topic had 0 posts — a resynth picks up the change.
+    save_topic_pages(
+        {
+            "misc": TopicPage(
+                slug="misc",
+                overview="Overview viejo.",
+                notes=[],
+                synthesized_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+                post_count_at_synth=0,
+            )
+        },
+        tmp_path / "data" / "topics.json",
+    )
+
+    def _fake_synth(inputs, model, **kwargs):
+        return [OverviewJudgment(slug="misc", overview="Re-sintetizado.", notes=[])]
+
+    monkeypatch.setattr(cli, "synthesize_overviews_api", _fake_synth)
+    result = runner.invoke(app, ["topics", "--resynth", "--executor", "api"])
+    assert result.exit_code == 0
+    page = (tmp_path / "vault" / "x-knowledge" / "topics" / "misc.md").read_text(encoding="utf-8")
+    assert "Re-sintetizado." in page

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -275,3 +275,80 @@ def test_cli_fetch_reports_x_articles(tmp_path, monkeypatch):
     result = runner.invoke(app, ["fetch"])
     assert result.exit_code == 0
     assert "3 de X" in result.output
+
+
+def _enriched_item(item_id: str = "1"):
+    from xbrain.models import Enrichment
+
+    item = _linked_item(item_id)
+    item.enriched = Enrichment(
+        enriched_at=datetime.now(timezone.utc),
+        executor="api",
+        summary="resumen",
+        primary_topic="misc",
+        topics=["misc"],
+    )
+    return item
+
+
+def test_topics_claude_code_exports_a_worksheet(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    from xbrain.models import Topic
+    from xbrain.rubrics import save_vocab
+
+    save_store({"1": _enriched_item("1")}, tmp_path / "data" / "items.json")
+    save_vocab([Topic(slug="misc", description="d")], tmp_path / "data" / "vocab.yaml")
+    result = runner.invoke(app, ["topics", "--executor", "claude-code"])
+    assert result.exit_code == 0
+    assert (tmp_path / "data" / "topic-worksheet.json").exists()
+    assert (tmp_path / "vault" / "x-knowledge" / "topics" / "misc.md").exists()
+
+
+def test_topics_apply_writes_the_overview(tmp_path, monkeypatch):
+    import json
+
+    _setup_repo(tmp_path, monkeypatch)
+    from xbrain.models import Topic
+    from xbrain.rubrics import save_vocab
+
+    save_store({"1": _enriched_item("1")}, tmp_path / "data" / "items.json")
+    save_vocab([Topic(slug="misc", description="d")], tmp_path / "data" / "vocab.yaml")
+    ws = tmp_path / "ws.json"
+    ws.write_text(
+        json.dumps(
+            {"judgments": [{"slug": "misc", "overview": "Resumen del cajón.", "notes": []}]}
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["topics", "--apply", str(ws)])
+    assert result.exit_code == 0
+    page = (tmp_path / "vault" / "x-knowledge" / "topics" / "misc.md").read_text(encoding="utf-8")
+    assert "Resumen del cajón." in page
+
+
+def test_topics_api_executor_synthesizes(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    import xbrain.cli as cli
+    from xbrain.models import Topic
+    from xbrain.rubrics import save_vocab
+    from xbrain.topic_synth import OverviewJudgment
+
+    save_store({"1": _enriched_item("1")}, tmp_path / "data" / "items.json")
+    save_vocab([Topic(slug="misc", description="d")], tmp_path / "data" / "vocab.yaml")
+
+    def _fake_synth(inputs, model, **kwargs):
+        return [OverviewJudgment(slug="misc", overview="Sintetizado por API.", notes=[])]
+
+    monkeypatch.setattr(cli, "synthesize_overviews_api", _fake_synth)
+    result = runner.invoke(app, ["topics", "--executor", "api"])
+    assert result.exit_code == 0
+    page = (tmp_path / "vault" / "x-knowledge" / "topics" / "misc.md").read_text(encoding="utf-8")
+    assert "Sintetizado por API." in page
+
+
+def test_topics_without_vocab_fails(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _enriched_item("1")}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["topics"])
+    assert result.exit_code == 1
+    assert "vocabulario" in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -277,6 +277,50 @@ def test_cli_fetch_reports_x_articles(tmp_path, monkeypatch):
     assert "3 de X" in result.output
 
 
+def test_cli_fetch_persists_partial_work_when_a_stage_raises(tmp_path, monkeypatch):
+    # `_run_fetch` wraps the three fetch stages in `try:` and `save_store` in
+    # `finally:` — a stage error must not discard the in-memory work the
+    # earlier stages already produced. This proves that `finally` contract.
+    _setup_repo(tmp_path, monkeypatch)
+    import xbrain.cli as cli
+    from xbrain.models import Content, ContentSource
+    from xbrain.store import load_store
+
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+
+    def _fake_fetch_pending(store, *a, **k):
+        # Mutate the SAME store object _run_fetch passed in — that is what
+        # the `finally` block later persists to disk.
+        store["1"].content = Content(
+            fetched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+            sources=[
+                ContentSource(
+                    kind="external_article",
+                    url="https://example.com/p",
+                    text="cuerpo",
+                    ok=True,
+                )
+            ],
+        )
+        return 1
+
+    def _fake_fetch_x_articles(*a, **k):
+        raise RuntimeError("Sesión de X caducada")
+
+    monkeypatch.setattr(cli, "fetch_pending", _fake_fetch_pending)
+    monkeypatch.setattr(cli, "fetch_x_articles", _fake_fetch_x_articles)
+
+    result = runner.invoke(app, ["fetch"])
+    # The stage error still surfaces via _handle_cli_errors.
+    assert result.exit_code == 1
+
+    # ...but the partial work from fetch_pending survived: save_store ran in
+    # the `finally` despite the raise.
+    store = load_store(tmp_path / "data" / "items.json")
+    assert store["1"].content is not None
+    assert store["1"].content.sources[0].text == "cuerpo"
+
+
 def _enriched_item(item_id: str = "1"):
     from xbrain.models import Enrichment
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,3 +91,27 @@ def test_load_config_rejects_zero_target_count(tmp_path: Path):
     )
     with pytest.raises(ValueError, match="target_count must be >= 1"):
         load_config(tmp_path)
+
+
+def test_config_topics_threshold_defaults_to_25(tmp_path):
+    from xbrain.config import load_config
+
+    (tmp_path / "config.toml").write_text(
+        '[paths]\nvault = "/v"\noutput_subdir = "o"\ndata_dir = "data"\n[x]\nhandle = "h"\n',
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.topics_resynth_threshold == 25
+    assert cfg.topics_path == tmp_path / "data" / "topics.json"
+
+
+def test_config_topics_threshold_is_configurable(tmp_path):
+    from xbrain.config import load_config
+
+    (tmp_path / "config.toml").write_text(
+        '[paths]\nvault = "/v"\noutput_subdir = "o"\ndata_dir = "data"\n'
+        '[x]\nhandle = "h"\n'
+        "[topics]\nresynth_threshold = 50\n",
+        encoding="utf-8",
+    )
+    assert load_config(tmp_path).topics_resynth_threshold == 50

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -169,3 +169,82 @@ def test_fetch_pending_force_refetches():
     assert fetch_pending(store, extractor=_fake_extractor) == 1
     assert fetch_pending(store, extractor=_fake_extractor) == 0
     assert fetch_pending(store, force=True, extractor=_fake_extractor) == 1
+
+
+def test_firecrawl_extract_returns_none_without_api_key(monkeypatch):
+    from xbrain.fetch import _firecrawl_extract
+
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    assert _firecrawl_extract("https://e.com/a") is None
+
+
+def test_firecrawl_extract_parses_markdown(monkeypatch):
+    import io
+    import json
+
+    from xbrain.fetch import _firecrawl_extract
+
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+    payload = {"data": {"markdown": "el cuerpo", "metadata": {"title": "T"}}}
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def opener(req, timeout=0):
+        return _Resp(json.dumps(payload).encode())
+
+    result = _firecrawl_extract("https://e.com/a", opener=opener)
+    assert result is not None
+    assert result.text == "el cuerpo"
+    assert result.title == "T"
+
+
+def test_extract_article_falls_back_to_firecrawl_on_js_required():
+    from xbrain.fetch import FetchResult, extract_article
+
+    def primary(url):
+        return FetchResult(failure_reason="js_required", error="js", attempts=1)
+
+    def firecrawl(url):
+        return FetchResult(text="rescatado por firecrawl", attempts=1)
+
+    result = extract_article("https://e.com/a", primary=primary, firecrawl=firecrawl)
+    assert result.text == "rescatado por firecrawl"
+    assert result.attempts == 2
+
+
+def test_extract_article_keeps_evidence_when_firecrawl_unavailable():
+    from xbrain.fetch import FetchResult, extract_article
+
+    def primary(url):
+        return FetchResult(failure_reason="js_required", error="js", attempts=1)
+
+    def firecrawl(url):
+        return None
+
+    result = extract_article("https://e.com/a", primary=primary, firecrawl=firecrawl)
+    assert result.text is None
+    assert result.failure_reason == "js_required"
+    assert result.attempts == 1
+
+
+def test_extract_article_does_not_retry_hard_failures():
+    from xbrain.fetch import FetchResult, extract_article
+
+    # A 404 is definitive — Firecrawl must not even be called.
+    calls = []
+
+    def primary(url):
+        return FetchResult(http_status=404, failure_reason="not_found", attempts=1)
+
+    def firecrawl(url):
+        calls.append(url)
+        return FetchResult(text="x")
+
+    result = extract_article("https://e.com/a", primary=primary, firecrawl=firecrawl)
+    assert result.failure_reason == "not_found"
+    assert calls == []

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -164,6 +164,15 @@ def test_fetch_pending_respects_since_until():
     assert store["2"].content is not None
 
 
+def test_fetch_item_dedups_repeated_link_urls():
+    # An item whose links repeat the same URL must yield a single source.
+    content = fetch_item(
+        _item("1", ["https://example.com/p", "https://example.com/p"]), _fake_extractor
+    )
+    urls = [s.url for s in content.sources]
+    assert urls == ["https://example.com/p"]
+
+
 def test_fetch_pending_force_refetches():
     store = {"1": _item("1", ["https://example.com/p"])}
     assert fetch_pending(store, extractor=_fake_extractor) == 1
@@ -248,3 +257,96 @@ def test_extract_article_does_not_retry_hard_failures():
     result = extract_article("https://e.com/a", primary=primary, firecrawl=firecrawl)
     assert result.failure_reason == "not_found"
     assert calls == []
+
+
+class _CtxResp:
+    """A minimal context-manager response object for fake openers."""
+
+    def __init__(self, body: bytes = b"", status: int = 200):
+        self._body = body
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def test_probe_status_success_path_marks_js_required():
+    # A reachable URL trafilatura could not parse -> categorised as js_required.
+    def opener(req, timeout=0):
+        return _CtxResp(status=200)
+
+    status, reason, error = _probe_status("https://e.com/x", opener=opener)
+    assert status == 200
+    assert reason == "js_required"
+    assert error
+
+
+def test_probe_status_categorizes_url_error_wrapping_timeout():
+    def opener(req, timeout=0):
+        raise urllib.error.URLError(socket.timeout())
+
+    status, reason, _ = _probe_status("https://e.com/x", opener=opener)
+    assert status is None
+    assert reason == "timeout"
+
+
+def test_probe_status_categorizes_url_error_wrapping_dns_error():
+    def opener(req, timeout=0):
+        raise urllib.error.URLError(socket.gaierror())
+
+    status, reason, _ = _probe_status("https://e.com/x", opener=opener)
+    assert status is None
+    assert reason == "dns_error"
+
+
+def test_firecrawl_extract_returns_error_result_when_opener_raises(monkeypatch):
+    from xbrain.fetch import _firecrawl_extract
+
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+
+    def opener(req, timeout=0):
+        raise urllib.error.URLError("network down")
+
+    result = _firecrawl_extract("https://e.com/a", opener=opener)
+    assert result is not None
+    assert result.text is None
+    assert "Firecrawl falló" in (result.error or "")
+
+
+def test_firecrawl_extract_detects_error_envelope(monkeypatch):
+    import json
+
+    from xbrain.fetch import _firecrawl_extract
+
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-test")
+    payload = {"success": False, "error": "rate limited"}
+
+    def opener(req, timeout=0):
+        return _CtxResp(json.dumps(payload).encode())
+
+    result = _firecrawl_extract("https://e.com/a", opener=opener)
+    assert result is not None
+    assert result.text is None
+    assert "rate limited" in (result.error or "")
+
+
+def test_extract_article_merges_firecrawl_error_when_both_fail():
+    from xbrain.fetch import FetchResult, extract_article
+
+    def primary(url):
+        return FetchResult(failure_reason="js_required", error="js", attempts=1)
+
+    def firecrawl(url):
+        # Firecrawl reachable but returned no text — carries its own evidence.
+        return FetchResult(error="Firecrawl no devolvió contenido.", attempts=1)
+
+    result = extract_article("https://e.com/a", primary=primary, firecrawl=firecrawl)
+    assert result.text is None
+    assert result.attempts == 2
+    assert "Firecrawl: Firecrawl no devolvió contenido." in (result.error or "")

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,7 +1,17 @@
 # tests/test_fetch.py
+import socket
+import urllib.error
 from datetime import datetime, timezone
 
-from xbrain.fetch import fetch_item, fetch_pending
+from xbrain.fetch import (
+    FetchResult,
+    _categorize_url_error,
+    _probe_status,
+    _reason_for_status,
+    fetch_item,
+    fetch_pending,
+    trafilatura_extract,
+)
 from xbrain.models import Author, Item, Link
 
 
@@ -18,8 +28,66 @@ def _item(item_id: str, urls: list[str]) -> Item:
     )
 
 
-def _fake_extractor(url: str) -> tuple[str | None, str | None]:
-    return "Título", f"cuerpo de {url}"
+def _fake_extractor(url: str) -> FetchResult:
+    return FetchResult(title="Título", text=f"cuerpo de {url}", http_status=200)
+
+
+def test_reason_for_status_maps_http_codes():
+    assert _reason_for_status(404) == "not_found"
+    assert _reason_for_status(410) == "not_found"
+    assert _reason_for_status(403) == "forbidden"
+    assert _reason_for_status(402) == "paywall"
+    assert _reason_for_status(451) == "paywall"
+    assert _reason_for_status(500) is None  # server error — keep raw error text
+
+
+def test_categorize_url_error_detects_timeout_and_dns():
+    assert _categorize_url_error(urllib.error.URLError(socket.timeout())) == "timeout"
+    assert _categorize_url_error(urllib.error.URLError(socket.gaierror())) == "dns_error"
+    assert _categorize_url_error(urllib.error.URLError("other")) is None
+
+
+def test_probe_status_categorizes_http_error():
+    def opener(req, timeout=0):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)
+
+    status, reason, _ = _probe_status("https://e.com/x", opener=opener)
+    assert status == 404
+    assert reason == "not_found"
+
+
+def test_trafilatura_extract_success():
+    result = trafilatura_extract(
+        "https://e.com/a",
+        fetch=lambda url: "<html>body</html>",
+        extract=lambda html: "el cuerpo",
+        prober=lambda url: (None, None, ""),
+    )
+    assert result.text == "el cuerpo"
+    assert result.http_status == 200
+    assert result.failure_reason is None
+
+
+def test_trafilatura_extract_empty_content_when_no_article():
+    result = trafilatura_extract(
+        "https://e.com/a",
+        fetch=lambda url: "<html></html>",
+        extract=lambda html: None,
+        prober=lambda url: (None, None, ""),
+    )
+    assert result.text is None
+    assert result.failure_reason == "empty_content"
+
+
+def test_trafilatura_extract_probes_when_download_fails():
+    result = trafilatura_extract(
+        "https://e.com/a",
+        fetch=lambda url: None,
+        extract=lambda html: None,
+        prober=lambda url: (404, "not_found", "HTTP 404"),
+    )
+    assert result.http_status == 404
+    assert result.failure_reason == "not_found"
 
 
 def test_fetch_item_extracts_external_articles():
@@ -29,38 +97,54 @@ def test_fetch_item_extracts_external_articles():
     assert content.sources[0].text == "cuerpo de https://example.com/p"
 
 
-def test_fetch_item_marks_x_urls_as_deferred():
+def test_fetch_item_skips_x_urls():
+    # x.com links are handled by fetch_x.fetch_x_articles, not fetch_item.
     content = fetch_item(_item("1", ["https://x.com/foo/status/9"]), _fake_extractor)
-    assert content.sources[0].kind == "x_article"
-    assert content.sources[0].ok is False
-    assert "v1" in content.sources[0].error
+    assert content.sources == []
 
 
-def test_fetch_item_marks_failed_extraction():
-    content = fetch_item(_item("1", ["https://example.com/p"]), lambda url: (None, None))
+def test_fetch_item_records_failure_evidence():
+    content = fetch_item(
+        _item("1", ["https://example.com/p"]),
+        lambda url: FetchResult(http_status=404, failure_reason="not_found", error="HTTP 404"),
+    )
     assert content.sources[0].ok is False
+    assert content.sources[0].http_status == 404
+    assert content.sources[0].failure_reason == "not_found"
+
+
+def test_fetch_item_isolates_extractor_exception():
+    def _raising(url):
+        raise RuntimeError("boom")
+
+    content = fetch_item(_item("1", ["https://example.com/p"]), _raising)
+    assert len(content.sources) == 1
+    assert content.sources[0].ok is False
+    assert "boom" in content.sources[0].error
+
+
+def test_fetch_item_preserves_non_external_sources_on_refetch():
+    from xbrain.models import Content, ContentSource
+
+    item = _item("1", ["https://example.com/p"])
+    item.content = Content(
+        fetched_at=datetime.now(timezone.utc),
+        sources=[ContentSource(kind="thread", url="u", text="hilo", ok=True)],
+    )
+    content = fetch_item(item, _fake_extractor)
+    kinds = {s.kind for s in content.sources}
+    assert kinds == {"thread", "external_article"}
 
 
 def test_fetch_pending_skips_already_fetched_items():
     store = {"1": _item("1", ["https://example.com/p"])}
     assert fetch_pending(store, extractor=_fake_extractor) == 1
-    assert fetch_pending(store, extractor=_fake_extractor) == 0  # already has content
-
-
-def test_fetch_pending_skips_items_without_links():
-    store = {"1": _item("1", [])}
     assert fetch_pending(store, extractor=_fake_extractor) == 0
 
 
-def _raising(url: str) -> tuple[str | None, str | None]:
-    raise RuntimeError("boom")
-
-
-def test_fetch_item_isolates_extractor_exception():
-    content = fetch_item(_item("1", ["https://example.com/p"]), _raising)
-    assert len(content.sources) == 1
-    assert content.sources[0].ok is False
-    assert "boom" in content.sources[0].error
+def test_fetch_pending_skips_items_without_external_links():
+    store = {"1": _item("1", []), "2": _item("2", ["https://x.com/a/status/9"])}
+    assert fetch_pending(store, extractor=_fake_extractor) == 0
 
 
 def test_fetch_pending_respects_since_until():
@@ -85,13 +169,3 @@ def test_fetch_pending_force_refetches():
     assert fetch_pending(store, extractor=_fake_extractor) == 1
     assert fetch_pending(store, extractor=_fake_extractor) == 0
     assert fetch_pending(store, force=True, extractor=_fake_extractor) == 1
-
-
-def test_fetch_item_handles_mixed_links():
-    item = _item("1", ["https://x.com/foo/status/9", "https://example.com/p"])
-    content = fetch_item(item, _fake_extractor)
-    assert len(content.sources) == 2
-    assert content.sources[0].kind == "x_article"
-    assert content.sources[0].ok is False
-    assert content.sources[1].kind == "external_article"
-    assert content.sources[1].ok is True

--- a/tests/test_fetch_x.py
+++ b/tests/test_fetch_x.py
@@ -24,6 +24,11 @@ def test_classify_x_url():
     assert _classify_x_url("https://x.com/some_profile") == "other"
 
 
+def test_classify_x_url_does_not_misroute_article_containing_status():
+    # An X article URL that itself contains a /status/ segment stays an article.
+    assert _classify_x_url("https://x.com/i/article/foo/status/1") == "article"
+
+
 def test_x_status_id_extracts_the_tweet_id():
     assert _x_status_id("https://x.com/jack/status/123") == "123"
     assert _x_status_id("https://x.com/i/article/9") is None
@@ -103,6 +108,43 @@ def test_fetch_x_articles_skips_already_fetched_unless_forced():
     assert fetch_x_articles(store, None, link_fetcher=fetcher) == 1
     assert fetch_x_articles(store, None, link_fetcher=fetcher) == 0
     assert fetch_x_articles(store, None, force=True, link_fetcher=fetcher) == 1
+
+
+def test_fetch_x_articles_requires_storage_state_without_link_fetcher():
+    import pytest
+
+    store = {"1": _item("1", ["https://x.com/jack/status/9"])}
+    with pytest.raises(ValueError, match="storage_state_path"):
+        fetch_x_articles(store, storage_state_path=None)
+
+
+def test_fetch_x_articles_respects_since_until():
+    early = _item("1", ["https://x.com/jack/status/9"])
+    early.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    late = _item("2", ["https://x.com/jack/status/10"])
+    late.created_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    store = {"1": early, "2": late}
+    count = fetch_x_articles(
+        store,
+        storage_state_path=None,
+        since=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        until=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        link_fetcher=lambda url: ContentSource(kind="x_article", url=url, text="x", ok=True),
+    )
+    assert count == 1
+    assert store["1"].content is None
+    assert store["2"].content is not None
+
+
+def test_fetch_x_articles_dedups_repeated_x_urls():
+    store = {"1": _item("1", ["https://x.com/jack/status/9", "https://x.com/jack/status/9"])}
+    fetch_x_articles(
+        store,
+        storage_state_path=None,
+        link_fetcher=lambda url: ContentSource(kind="x_article", url=url, text="hilo", ok=True),
+    )
+    sources = store["1"].content.sources
+    assert len(sources) == 1
 
 
 def test_fetch_x_articles_preserves_external_sources():

--- a/tests/test_fetch_x.py
+++ b/tests/test_fetch_x.py
@@ -1,0 +1,121 @@
+# tests/test_fetch_x.py
+from datetime import datetime, timezone
+
+from xbrain.fetch_x import _classify_x_url, _x_status_id, assemble_linked_thread, fetch_x_articles
+from xbrain.models import Author, Content, ContentSource, Item, Link
+
+
+def _item(item_id: str, urls: list[str]) -> Item:
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="a", name="A"),
+        text="t",
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url=u, domain="x.com") for u in urls],
+    )
+
+
+def test_classify_x_url():
+    assert _classify_x_url("https://x.com/jack/status/123") == "status"
+    assert _classify_x_url("https://x.com/i/article/456") == "article"
+    assert _classify_x_url("https://x.com/some_profile") == "other"
+
+
+def test_x_status_id_extracts_the_tweet_id():
+    assert _x_status_id("https://x.com/jack/status/123") == "123"
+    assert _x_status_id("https://x.com/i/article/9") is None
+
+
+def test_assemble_linked_thread_concatenates_the_anchor_author(monkeypatch):
+    # parse_tweets is injected via the module so the test stays offline.
+    import xbrain.fetch_x as fx
+
+    a1 = Item(
+        id="100",
+        source="bookmark",
+        url="u",
+        author=Author(handle="jack", name="J"),
+        text="primer tweet",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    a2 = Item(
+        id="101",
+        source="bookmark",
+        url="u",
+        author=Author(handle="jack", name="J"),
+        text="segundo tweet",
+        created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+    other = Item(
+        id="200",
+        source="bookmark",
+        url="u",
+        author=Author(handle="someone", name="S"),
+        text="ruido de otra persona",
+        created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(fx, "parse_tweets", lambda response, source: response)
+    handle, text = assemble_linked_thread([[a1, other, a2]], anchor_id="100")
+    assert handle == "jack"
+    assert text == "primer tweet\n\nsegundo tweet"
+
+
+def test_assemble_linked_thread_returns_empty_when_anchor_absent():
+    handle, text = assemble_linked_thread([], anchor_id="999")
+    assert handle is None
+    assert text == ""
+
+
+def test_fetch_x_articles_attaches_sources_via_injected_fetcher():
+    store = {"1": _item("1", ["https://x.com/jack/status/9"])}
+    fetched = fetch_x_articles(
+        store,
+        storage_state_path=None,
+        link_fetcher=lambda url: ContentSource(kind="x_article", url=url, text="hilo", ok=True),
+    )
+    assert fetched == 1
+    assert store["1"].content is not None
+    assert store["1"].content.sources[0].kind == "x_article"
+    assert store["1"].content.sources[0].text == "hilo"
+
+
+def test_fetch_x_articles_skips_items_without_x_links():
+    from xbrain.models import Link
+
+    item = _item("1", [])
+    item.links = [Link(url="https://example.com/p", domain="example.com")]
+    store = {"1": item}
+    assert fetch_x_articles(store, None, link_fetcher=lambda url: None) == 0
+
+
+def test_fetch_x_articles_skips_already_fetched_unless_forced():
+    store = {"1": _item("1", ["https://x.com/jack/status/9"])}
+
+    def fetcher(url):
+        return ContentSource(kind="x_article", url=url, text="hilo", ok=True)
+
+    assert fetch_x_articles(store, None, link_fetcher=fetcher) == 1
+    assert fetch_x_articles(store, None, link_fetcher=fetcher) == 0
+    assert fetch_x_articles(store, None, force=True, link_fetcher=fetcher) == 1
+
+
+def test_fetch_x_articles_preserves_external_sources():
+    item = _item("1", ["https://x.com/jack/status/9"])
+    item.content = Content(
+        fetched_at=datetime.now(timezone.utc),
+        sources=[ContentSource(kind="external_article", url="https://e.com", text="art", ok=True)],
+    )
+    store = {"1": item}
+    fetch_x_articles(
+        store,
+        None,
+        link_fetcher=lambda url: ContentSource(kind="x_article", url=url, text="x", ok=True),
+    )
+    kinds = {s.kind for s in store["1"].content.sources}
+    assert kinds == {"external_article", "x_article"}

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -149,3 +149,38 @@ def test_generate_since_until_filters_item_notes(tmp_path: Path):
     log = (tmp_path / "log.md").read_text(encoding="utf-8")
     assert "Old note" in log
     assert "New note" in log
+
+
+def test_note_renders_broken_link_evidence(tmp_path):
+    from datetime import datetime, timezone
+
+    from xbrain.generate import generate
+    from xbrain.models import Author, Content, ContentSource, Item, Link
+
+    item = Item(
+        id="1",
+        source="bookmark",
+        url="https://x.com/a/status/1",
+        author=Author(handle="a", name="A"),
+        text="t",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url="https://dead.example.com/p", domain="dead.example.com")],
+        content=Content(
+            fetched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+            sources=[
+                ContentSource(
+                    kind="external_article",
+                    url="https://dead.example.com/p",
+                    ok=False,
+                    http_status=404,
+                    failure_reason="not_found",
+                )
+            ],
+        ),
+    )
+    generate({"1": item}, tmp_path)
+    note = next((tmp_path / "items").glob("*-1.md")).read_text(encoding="utf-8")
+    assert "Enlace roto" in note
+    assert "HTTP 404" in note
+    assert "2026-05-17" in note

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -152,6 +152,15 @@ def test_generate_since_until_filters_item_notes(tmp_path: Path):
     assert "New note" in log
 
 
+def test_failure_es_covers_every_failure_reason():
+    from typing import get_args
+
+    from xbrain.generate import _FAILURE_ES
+    from xbrain.models import FailureReason
+
+    assert set(_FAILURE_ES) == set(get_args(FailureReason))
+
+
 def test_note_renders_broken_link_evidence(tmp_path):
     from datetime import datetime, timezone
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -2,8 +2,9 @@
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.generate import _slugify, generate
+from xbrain.generate import generate
 from xbrain.models import Author, Item, Link
+from xbrain.notes_io import slugify
 
 
 def _item(item_id: str, with_link: bool, text: str | None = None) -> Item:
@@ -46,13 +47,13 @@ def test_log_lists_every_item(tmp_path: Path):
 
 
 def test_slugify_handles_edge_cases():
-    slug = _slugify("Café del Día")
+    slug = slugify("Café del Día")
     assert slug == slug.lower()
     assert slug.isascii()
     assert slug == "cafe-del-dia"
-    assert _slugify("") == "item"
-    assert _slugify("!!!") == "item"
-    long_slug = _slugify("a" * 200)
+    assert slugify("") == "item"
+    assert slugify("!!!") == "item"
+    long_slug = slugify("a" * 200)
     assert len(long_slug) <= 60
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -76,3 +76,33 @@ def test_item_has_optional_bookmark_folder():
     )
     assert Item(**base).bookmark_folder is None
     assert Item(**base, bookmark_folder="AI papers").bookmark_folder == "AI papers"
+
+
+def test_content_source_carries_failure_evidence():
+    from xbrain.models import ContentSource
+
+    src = ContentSource(
+        kind="external_article",
+        url="https://example.com/x",
+        ok=False,
+        http_status=404,
+        failure_reason="not_found",
+        attempts=2,
+        error="HTTP 404",
+    )
+    assert src.http_status == 404
+    assert src.failure_reason == "not_found"
+    assert src.attempts == 2
+
+
+def test_content_source_failure_fields_default_cleanly():
+    # An old-shape dict (no failure fields) must still validate — the existing
+    # items.json predates these fields.
+    from xbrain.models import ContentSource
+
+    src = ContentSource.model_validate(
+        {"kind": "external_article", "url": "https://e.com", "ok": True}
+    )
+    assert src.http_status is None
+    assert src.failure_reason is None
+    assert src.attempts == 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -106,3 +106,21 @@ def test_content_source_failure_fields_default_cleanly():
     assert src.http_status is None
     assert src.failure_reason is None
     assert src.attempts == 0
+
+
+def test_topic_page_model_round_trips():
+    from datetime import datetime, timezone
+
+    from xbrain.models import TopicPage
+
+    page = TopicPage(
+        slug="ai-coding",
+        overview="Resumen del tema.",
+        notes=["Nota uno.", "Nota dos."],
+        synthesized_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        post_count_at_synth=42,
+    )
+    restored = TopicPage.model_validate(page.model_dump(mode="json"))
+    assert restored.slug == "ai-coding"
+    assert restored.post_count_at_synth == 42
+    assert restored.notes == ["Nota uno.", "Nota dos."]

--- a/tests/test_notes_io.py
+++ b/tests/test_notes_io.py
@@ -1,0 +1,51 @@
+# tests/test_notes_io.py
+from datetime import datetime, timezone
+
+from xbrain.models import Author, Item
+from xbrain.notes_io import GEN_END, GEN_START, note_filename, slugify, title_of, user_tail, wrap
+
+
+def _item(text: str) -> Item:
+    return Item(
+        id="123",
+        source="bookmark",
+        url="u",
+        author=Author(handle="a", name="A"),
+        text=text,
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+    )
+
+
+def test_wrap_surrounds_body_with_markers():
+    wrapped = wrap("cuerpo")
+    assert wrapped.startswith(GEN_START)
+    assert wrapped.endswith(GEN_END)
+    assert "cuerpo" in wrapped
+
+
+def test_user_tail_keeps_content_after_end_marker():
+    existing = f"{GEN_START}\nviejo\n{GEN_END}\n\nMI NOTA"
+    assert user_tail(existing, "DEFAULT") == "\n\nMI NOTA"
+
+
+def test_user_tail_preserves_a_marker_less_file():
+    assert user_tail("texto sin marcadores", "DEFAULT") == "\n\ntexto sin marcadores"
+
+
+def test_user_tail_returns_default_for_empty_input():
+    assert user_tail("", "DEFAULT") == "DEFAULT"
+
+
+def test_slugify_handles_edge_cases():
+    assert slugify("Café del Día") == "cafe-del-dia"
+    assert slugify("") == "item"
+    assert len(slugify("a" * 200)) <= 60
+
+
+def test_note_filename_ends_with_the_item_id():
+    assert note_filename(_item("Hola mundo")).endswith("-123.md")
+
+
+def test_title_of_falls_back_to_item_text():
+    assert title_of(_item("Un texto")) == "Un texto"

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -29,3 +29,11 @@ def test_save_then_load_vocab_roundtrips(tmp_path: Path):
 
 def test_load_vocab_missing_file_returns_empty(tmp_path: Path):
     assert load_vocab(tmp_path / "nope.yaml") == []
+
+
+def test_topic_page_rubric_loads():
+    from xbrain.rubrics import load_rubric
+
+    text = load_rubric("topic-page")
+    assert "overview" in text
+    assert "notes" in text

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -48,3 +48,30 @@ def test_state_round_trips(tmp_path: Path):
     path = tmp_path / "state.json"
     save_state(state, path)
     assert load_state(path).bookmarks.last_seen_id == "999"
+
+
+def test_topic_pages_round_trip(tmp_path):
+    from datetime import datetime, timezone
+
+    from xbrain.models import TopicPage
+    from xbrain.store import load_topic_pages, save_topic_pages
+
+    pages = {
+        "ai-coding": TopicPage(
+            slug="ai-coding",
+            overview="o",
+            notes=["n"],
+            synthesized_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+            post_count_at_synth=10,
+        )
+    }
+    path = tmp_path / "topics.json"
+    save_topic_pages(pages, path)
+    restored = load_topic_pages(path)
+    assert restored["ai-coding"].post_count_at_synth == 10
+
+
+def test_load_topic_pages_returns_empty_when_absent(tmp_path):
+    from xbrain.store import load_topic_pages
+
+    assert load_topic_pages(tmp_path / "missing.json") == {}

--- a/tests/test_topic_synth.py
+++ b/tests/test_topic_synth.py
@@ -1,0 +1,52 @@
+# tests/test_topic_synth.py
+from conftest import FakeAnthropic
+
+from xbrain.topic_synth import OverviewJudgment, TopicInput, synthesize_overviews_api
+
+
+def test_synthesize_overviews_api_returns_one_judgment_per_topic():
+    client = FakeAnthropic(
+        [
+            {"overview": "Resumen de ai-coding.", "notes": ["Nota."]},
+            {"overview": "Resumen de career.", "notes": []},
+        ]
+    )
+    inputs = [
+        TopicInput(slug="ai-coding", description="d", summaries=["s1", "s2"]),
+        TopicInput(slug="career", description="d", summaries=["s3"]),
+    ]
+    results = synthesize_overviews_api(inputs, model="m", client=client)
+    assert [r.slug for r in results] == ["ai-coding", "career"]
+    assert results[0].overview == "Resumen de ai-coding."
+
+
+def test_synthesize_overviews_api_skips_an_invalid_judgment():
+    # A judgment containing a wikilink fails validate_overview and is dropped;
+    # the batch continues.
+    client = FakeAnthropic(
+        [
+            {"overview": "Mira [[items/x]].", "notes": []},
+            {"overview": "Resumen válido.", "notes": ["n"]},
+        ]
+    )
+    inputs = [
+        TopicInput(slug="bad", description="d", summaries=["s"]),
+        TopicInput(slug="good", description="d", summaries=["s"]),
+    ]
+    results = synthesize_overviews_api(inputs, model="m", client=client)
+    assert [r.slug for r in results] == ["good"]
+
+
+def test_synthesize_overviews_api_isolates_an_api_error():
+    client = FakeAnthropic([RuntimeError("API caída"), {"overview": "ok", "notes": []}])
+    inputs = [
+        TopicInput(slug="first", description="d", summaries=["s"]),
+        TopicInput(slug="second", description="d", summaries=["s"]),
+    ]
+    results = synthesize_overviews_api(inputs, model="m", client=client)
+    assert [r.slug for r in results] == ["second"]
+
+
+def test_overview_judgment_is_a_model():
+    judgment = OverviewJudgment(slug="ai-coding", overview="o", notes=["n"])
+    assert judgment.slug == "ai-coding"

--- a/tests/test_topic_synth.py
+++ b/tests/test_topic_synth.py
@@ -100,3 +100,15 @@ def test_apply_overview_judgments_rejects_wikilink_in_overview():
     )
     assert valid == []
     assert any("wikilink" in e for e in invalid[0][1])
+
+
+def test_apply_overview_judgments_rejects_a_non_dict_entry():
+    from xbrain.topic_synth import apply_overview_judgments
+
+    judgments = [
+        "oops",
+        {"slug": "good", "overview": "Resumen.", "notes": ["n"]},
+    ]
+    valid, invalid = apply_overview_judgments(judgments)
+    assert [j.slug for j in valid] == ["good"]
+    assert any("not a JSON object" in e for e in invalid[0][1])

--- a/tests/test_topic_synth.py
+++ b/tests/test_topic_synth.py
@@ -50,3 +50,53 @@ def test_synthesize_overviews_api_isolates_an_api_error():
 def test_overview_judgment_is_a_model():
     judgment = OverviewJudgment(slug="ai-coding", overview="o", notes=["n"])
     assert judgment.slug == "ai-coding"
+
+
+def test_export_and_import_topic_worksheet_round_trip(tmp_path):
+    import json
+
+    from xbrain.topic_synth import export_topic_worksheet, import_topic_worksheet
+
+    inputs = [TopicInput(slug="ai-coding", description="d", summaries=["s1", "s2"])]
+    path = tmp_path / "topic-worksheet.json"
+    export_topic_worksheet(inputs, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["topics"][0]["slug"] == "ai-coding"
+    assert payload["topics"][0]["summaries"] == ["s1", "s2"]
+    assert "rubric" in payload
+    assert import_topic_worksheet(path) == []
+
+
+def test_import_topic_worksheet_rejects_non_list_judgments(tmp_path):
+    import json
+
+    import pytest
+
+    from xbrain.topic_synth import import_topic_worksheet
+
+    path = tmp_path / "ws.json"
+    path.write_text(json.dumps({"judgments": "no soy lista"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        import_topic_worksheet(path)
+
+
+def test_apply_overview_judgments_splits_valid_and_invalid():
+    from xbrain.topic_synth import apply_overview_judgments
+
+    judgments = [
+        {"slug": "good", "overview": "Resumen.", "notes": ["n"]},
+        {"slug": "bad", "overview": "", "notes": []},
+    ]
+    valid, invalid = apply_overview_judgments(judgments)
+    assert [j.slug for j in valid] == ["good"]
+    assert invalid[0][0] == "bad"
+
+
+def test_apply_overview_judgments_rejects_wikilink_in_overview():
+    from xbrain.topic_synth import apply_overview_judgments
+
+    valid, invalid = apply_overview_judgments(
+        [{"slug": "x", "overview": "Mira [[items/y]].", "notes": []}]
+    )
+    assert valid == []
+    assert any("wikilink" in e for e in invalid[0][1])

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -69,3 +69,106 @@ def test_topic_posts_total_counts_both_blocks():
     tp.primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
     tp.also.append(_enriched("2", "career", ["career", "ai-coding"]))
     assert tp.total == 2
+
+
+def _topic_page(slug: str, count: int):
+    from datetime import datetime, timezone
+
+    from xbrain.models import TopicPage
+
+    return TopicPage(
+        slug=slug,
+        overview="El overview.",
+        notes=["Nota importante."],
+        synthesized_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        post_count_at_synth=count,
+    )
+
+
+def test_render_topic_page_has_frontmatter_overview_and_post_blocks():
+    from xbrain.topics import render_topic_page
+
+    posts = TopicPosts()
+    posts.primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
+    posts.also.append(_enriched("2", "career", ["career", "ai-coding"]))
+    page = _topic_page("ai-coding", count=2)
+    rendered = render_topic_page(_VOCAB[0], posts, page)
+    assert "tags: [x-knowledge-topic, ai-coding]" in rendered
+    assert "posts: 2" in rendered
+    assert "El overview." in rendered
+    assert "## Notas importantes" in rendered
+    assert "## Posts primarios (1)" in rendered
+    assert "## También relevante (1)" in rendered
+    assert "[[items/" in rendered
+
+
+def test_render_topic_page_marks_a_stale_overview():
+    from xbrain.topics import render_topic_page
+
+    posts = TopicPosts()
+    for n in range(5):
+        posts.primary.append(_enriched(str(n), "ai-coding", ["ai-coding"]))
+    page = _topic_page("ai-coding", count=2)  # synthesized when the topic had 2
+    rendered = render_topic_page(_VOCAB[0], posts, page)
+    assert "Overview desactualizado" in rendered
+
+
+def test_render_topic_page_handles_a_missing_overview():
+    from xbrain.topics import render_topic_page
+
+    posts = TopicPosts()
+    posts.primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
+    rendered = render_topic_page(_VOCAB[0], posts, None)
+    assert "Overview pendiente" in rendered
+
+
+def test_write_topic_pages_skips_empty_topics(tmp_path):
+    from xbrain.topics import write_topic_pages
+
+    posts = {
+        "ai-coding": TopicPosts(),
+        "career": TopicPosts(),
+    }
+    posts["ai-coding"].primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
+    written = write_topic_pages(tmp_path, _VOCAB, posts, {})
+    assert written == 1
+    assert (tmp_path / "topics" / "ai-coding.md").exists()
+    assert not (tmp_path / "topics" / "career.md").exists()
+
+
+def test_write_topic_pages_preserves_user_tail(tmp_path):
+    from xbrain.topics import write_topic_pages
+
+    posts = {"ai-coding": TopicPosts()}
+    posts["ai-coding"].primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
+    write_topic_pages(tmp_path, [_VOCAB[0]], posts, {})
+    page = tmp_path / "topics" / "ai-coding.md"
+    page.write_text(page.read_text(encoding="utf-8") + "MI ANOTACION", encoding="utf-8")
+    write_topic_pages(tmp_path, [_VOCAB[0]], posts, {})
+    assert "MI ANOTACION" in page.read_text(encoding="utf-8")
+
+
+def test_topics_needing_synth_picks_missing_and_grown_topics():
+    from xbrain.topics import topics_needing_synth
+
+    posts = {"ai-coding": TopicPosts(), "career": TopicPosts()}
+    for n in range(30):
+        posts["ai-coding"].primary.append(_enriched(f"a{n}", "ai-coding", ["ai-coding"]))
+    posts["career"].primary.append(_enriched("c", "career", ["career"]))
+    pages = {"ai-coding": _topic_page("ai-coding", count=2)}  # grew 2 -> 30
+    needing = topics_needing_synth(_VOCAB, posts, pages, threshold=25, resynth=False)
+    # ai-coding grew past the threshold; career has no page yet.
+    assert set(needing) == {"ai-coding", "career"}
+
+
+def test_topics_needing_synth_resynth_takes_any_changed_topic():
+    from xbrain.topics import topics_needing_synth
+
+    posts = {"ai-coding": TopicPosts()}
+    for n in range(3):
+        posts["ai-coding"].primary.append(_enriched(f"a{n}", "ai-coding", ["ai-coding"]))
+    pages = {"ai-coding": _topic_page("ai-coding", count=2)}  # grew 2 -> 3 (below threshold)
+    assert topics_needing_synth([_VOCAB[0]], posts, pages, threshold=25, resynth=False) == []
+    assert topics_needing_synth([_VOCAB[0]], posts, pages, threshold=25, resynth=True) == [
+        "ai-coding"
+    ]

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -1,0 +1,71 @@
+# tests/test_topics.py
+from datetime import datetime, timezone
+
+from xbrain.models import Author, Enrichment, Item, Topic
+from xbrain.topics import TopicPosts, compute_topic_posts
+
+
+def _enriched(item_id: str, primary: str, topics: list[str], day: int = 1) -> Item:
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="a", name="A"),
+        text=f"post {item_id}",
+        created_at=datetime(2026, 5, day, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        enriched=Enrichment(
+            enriched_at=datetime.now(timezone.utc),
+            executor="api",
+            summary="s",
+            primary_topic=primary,
+            topics=topics,
+        ),
+    )
+
+
+_VOCAB = [Topic(slug="ai-coding", description="d"), Topic(slug="career", description="d")]
+
+
+def test_compute_topic_posts_splits_primary_and_also_relevant():
+    store = {
+        "1": _enriched("1", "ai-coding", ["ai-coding", "career"]),
+        "2": _enriched("2", "career", ["career"]),
+    }
+    posts = compute_topic_posts(store, _VOCAB)
+    assert [i.id for i in posts["ai-coding"].primary] == ["1"]
+    assert [i.id for i in posts["ai-coding"].also] == []
+    assert [i.id for i in posts["career"].primary] == ["2"]
+    assert [i.id for i in posts["career"].also] == ["1"]
+
+
+def test_compute_topic_posts_ignores_unenriched_items():
+    store = {
+        "1": Item(
+            id="1",
+            source="bookmark",
+            url="u",
+            author=Author(handle="a", name="A"),
+            text="t",
+            created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            captured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+    }
+    posts = compute_topic_posts(store, _VOCAB)
+    assert posts["ai-coding"].total == 0
+
+
+def test_compute_topic_posts_sorts_newest_first():
+    store = {
+        "1": _enriched("1", "ai-coding", ["ai-coding"], day=1),
+        "2": _enriched("2", "ai-coding", ["ai-coding"], day=9),
+    }
+    posts = compute_topic_posts(store, _VOCAB)
+    assert [i.id for i in posts["ai-coding"].primary] == ["2", "1"]
+
+
+def test_topic_posts_total_counts_both_blocks():
+    tp = TopicPosts()
+    tp.primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
+    tp.also.append(_enriched("2", "career", ["career", "ai-coding"]))
+    assert tp.total == 2

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -184,6 +184,25 @@ def test_build_topic_inputs_collects_post_summaries():
     assert inputs[0].summaries == ["s"]
 
 
+def test_build_topic_inputs_rejects_an_unknown_slug():
+    import pytest
+
+    from xbrain.topics import build_topic_inputs
+
+    with pytest.raises(ValueError, match="vocabulary"):
+        build_topic_inputs(["not-a-real-topic"], _VOCAB, {})
+
+
+def test_compute_topic_posts_dedups_duplicate_slugs_in_topics():
+    # A store record with a duplicate slug in `enriched.topics` (pre-validation
+    # data) must place the item once, not twice, in the also-relevant list.
+    store = {
+        "1": _enriched("1", "ai-coding", ["ai-coding", "career", "career"]),
+    }
+    posts = compute_topic_posts(store, _VOCAB)
+    assert [i.id for i in posts["career"].also] == ["1"]
+
+
 def test_merge_overviews_records_the_synthesis_count():
     from xbrain.topic_synth import OverviewJudgment
     from xbrain.topics import merge_overviews

--- a/tests/test_topics.py
+++ b/tests/test_topics.py
@@ -172,3 +172,25 @@ def test_topics_needing_synth_resynth_takes_any_changed_topic():
     assert topics_needing_synth([_VOCAB[0]], posts, pages, threshold=25, resynth=True) == [
         "ai-coding"
     ]
+
+
+def test_build_topic_inputs_collects_post_summaries():
+    from xbrain.topics import build_topic_inputs
+
+    posts = {"ai-coding": TopicPosts()}
+    posts["ai-coding"].primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
+    inputs = build_topic_inputs(["ai-coding"], _VOCAB, posts)
+    assert inputs[0].slug == "ai-coding"
+    assert inputs[0].summaries == ["s"]
+
+
+def test_merge_overviews_records_the_synthesis_count():
+    from xbrain.topic_synth import OverviewJudgment
+    from xbrain.topics import merge_overviews
+
+    posts = {"ai-coding": TopicPosts()}
+    posts["ai-coding"].primary.append(_enriched("1", "ai-coding", ["ai-coding"]))
+    pages: dict = {}
+    merge_overviews(pages, [OverviewJudgment(slug="ai-coding", overview="o", notes=["n"])], posts)
+    assert pages["ai-coding"].overview == "o"
+    assert pages["ai-coding"].post_count_at_synth == 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -85,3 +85,24 @@ def test_validate_overview_rejects_unexpected_keys():
 
     errors = validate_overview({"overview": "ok", "notes": [], "slug": "ai-coding"})
     assert any("unexpected keys" in e for e in errors)
+
+
+def test_validate_overview_rejects_non_string_overview():
+    from xbrain.validate import validate_overview
+
+    errors = validate_overview({"overview": {"a": 1}, "notes": ["limpio"]})
+    assert any("overview" in e for e in errors)
+
+
+def test_validate_overview_rejects_non_string_note_element():
+    from xbrain.validate import validate_overview
+
+    errors = validate_overview({"overview": "Un resumen.", "notes": [42]})
+    assert any("notes entries must all be strings" in e for e in errors)
+
+
+def test_validate_overview_rejects_too_many_notes():
+    from xbrain.validate import validate_overview
+
+    errors = validate_overview({"overview": "Un resumen.", "notes": ["n"] * 16})
+    assert any("notes has 16 entries" in e for e in errors)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -51,3 +51,37 @@ def test_duplicate_topics_are_rejected():
     bad["topics"] = ["ai-coding", "ai-coding"]
     bad["primary_topic"] = "ai-coding"
     assert any("duplicate" in e for e in validate_judgment(bad, VOCAB))
+
+
+def test_validate_overview_accepts_a_clean_judgment():
+    from xbrain.validate import validate_overview
+
+    assert validate_overview({"overview": "Un resumen.", "notes": ["Una nota."]}) == []
+
+
+def test_validate_overview_rejects_empty_overview():
+    from xbrain.validate import validate_overview
+
+    errors = validate_overview({"overview": "", "notes": []})
+    assert any("overview" in e for e in errors)
+
+
+def test_validate_overview_rejects_wikilinks():
+    from xbrain.validate import validate_overview
+
+    errors = validate_overview({"overview": "Mira [[items/algo]].", "notes": ["limpio"]})
+    assert any("wikilink" in e for e in errors)
+
+
+def test_validate_overview_rejects_non_list_notes():
+    from xbrain.validate import validate_overview
+
+    errors = validate_overview({"overview": "ok", "notes": "no soy lista"})
+    assert any("notes must be a list" in e for e in errors)
+
+
+def test_validate_overview_rejects_unexpected_keys():
+    from xbrain.validate import validate_overview
+
+    errors = validate_overview({"overview": "ok", "notes": [], "slug": "ai-coding"})
+    assert any("unexpected keys" in e for e in errors)


### PR DESCRIPTION
## WS2 Fase 2 — topics stage + fetch hardening

Implements Fase 2 of the WS2 automated-enrichment design. 14 tasks, subagent-driven, test-first.

### Part A — fetch hardening (Tasks 1-5)
- `ContentSource` gains structured failure evidence: `http_status`, `failure_reason`, `attempts`.
- `fetch.py` categorizes failures (`FetchResult`) and falls back to **Firecrawl** (optional, env-keyed — silently skipped without `FIRECRAWL_API_KEY`).
- New `fetch_x.py` actually fetches X content: `/status/` links via the proven `TweetDetail` GraphQL interception, `/i/article/` links via Playwright-rendered HTML. X links are no longer deferred.
- Broken links render as `⚠ Enlace roto: HTTP 404 (verificado ...)`.

### Part B — topics stage (Tasks 6-14)
- New `xbrain topics` command — mechanical primary / also-relevant post lists + LLM-synthesized overviews.
- Two executor tracks (mirror Fase 1's enrich): `api` (Anthropic) and the worksheet handoff (`manual`/`claude-code`).
- New `data/topics.json` store; staleness is **derived** (live count vs. count at synthesis), `--resynth` re-synthesizes stale overviews.
- Topic pages get native Obsidian `tags:` frontmatter.
- `notes_io.py` extracted — shared markdown helpers (DRY, zero behavior change in `generate.py`).

### Design decisions
1. **Plain-prose overviews, no wikilinks** — enforces the design's hard rule (LLM emits only judgment); `validate_overview` mechanically rejects `[[`.
2. **X articles fetched for real**, not just un-deferred — a poor extraction is recorded as honest `failure_reason` evidence.
3. **Staleness derived, not a stored flag** — cannot desync.

### Quality
- 185 tests pass (63 new). Coverage 84%. `poe check` green — ruff/mypy/bandit/vulture/deptry/detect-secrets all pass.
- Plan: `zz-support-files/docs/implementation-plans/2026-05-18-xbrain-ws2-fase2-topics-fetch.md`
- Design: `prds/2026-05-17-automated-enrichment-design.md`

Substantially written with an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)