### PR TITLE
vocab: worksheet executor track (no API key needed)

### DIFF
--- a/.claude/skills/enriching-x-knowledge/SKILL.md
+++ b/.claude/skills/enriching-x-knowledge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: enriching-x-knowledge
-description: Use when the user wants to enrich their XBrain knowledge base (item summaries + topics) or synthesize its topic-page overviews with their Claude subscription instead of the paid API. Drives the `xbrain enrich` and `xbrain topics` worksheet flows end to end.
+description: Use when the user wants to induce their XBrain topic vocabulary, enrich their knowledge base (item summaries + topics) or synthesize its topic-page overviews with their Claude subscription instead of the paid API. Drives the `xbrain vocab`, `xbrain enrich` and `xbrain topics` worksheet flows end to end.
 ---
 
 # Enriching the XBrain knowledge base
@@ -39,6 +39,30 @@ paid `api` executor.
 4. **Apply.** Run `xbrain enrich --apply data/enrich-worksheet.json`. It validates
    and attaches the valid judgments. If it reports rejected items, fix those
    judgments in the worksheet and run `--apply` again.
+
+## Vocabulary induction
+
+The `vocab` stage induces the controlled topic taxonomy from the corpus — also
+via a worksheet, at no API cost.
+
+1. **Export the worksheet.** Run `xbrain vocab --executor claude-code`. It writes
+   `data/vocab-worksheet.json` with the full corpus (`corpus`), the induction
+   `rubric` and the `target_count`.
+
+2. **Read `data/vocab-worksheet.json`.** Induce the taxonomy with a map-reduce
+   method: chunk `corpus`, propose candidate topics per chunk (dispatch one
+   subagent per chunk for a large corpus), then consolidate the candidates into
+   exactly `target_count` topics. Follow the embedded `rubric` — always include
+   a `misc` topic; topics must be distinct and comparably grained.
+
+3. **Fill `topics`.** Write the final taxonomy into the worksheet's `topics`
+   array as `{slug, description}` objects — `slug` is kebab-case (`[a-z0-9-]`),
+   `description` is one sentence. Never reuse a slug.
+
+4. **Apply.** Run `xbrain vocab --apply data/vocab-worksheet.json` (add
+   `--regenerate` to re-mark every item for re-enrichment against the new
+   taxonomy). It validates each entry and writes `data/vocab.yaml`. If it
+   reports rejected topics, fix them and run `--apply` again.
 
 ## Topic-page overviews
 

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -216,10 +216,12 @@ def fetch(
 @app.command()
 @_handle_cli_errors
 def enrich(
-    executor: str = typer.Option(
+    executor: str | None = typer.Option(
         None, help="api | manual | claude-code (default: the enrich executor set in config.toml)"
     ),
-    apply: Path = typer.Option(None, "--apply", help="Import a filled worksheet and apply it"),
+    apply: Path | None = typer.Option(
+        None, "--apply", help="Import a filled worksheet and apply it"
+    ),
     since: str = typer.Option(None, help="ISO date, e.g. 2025-01-01"),
     until: str = typer.Option(None, help="ISO date, e.g. 2025-12-31"),
 ) -> None:
@@ -281,12 +283,14 @@ def _mark_for_regenerate(store: dict, cfg: Config, regenerate: bool) -> None:
 def _vocab_apply(cfg: Config, store: dict, apply: Path, regenerate: bool) -> None:
     """`xbrain vocab --apply` — import a filled vocab worksheet."""
     topics, invalid = apply_vocab_worksheet(import_vocab_worksheet(apply))
+    _report_invalid(invalid)
     if not topics:
         raise RuntimeError("La worksheet no produjo ningún topic válido.")
-    save_vocab(topics, cfg.data_dir / "vocab.yaml")
+    # Mark the store first: a crash here leaves items pending (a re-run re-marks
+    # idempotently) — safer than vocab.yaml updated while items stay stale.
     _mark_for_regenerate(store, cfg, regenerate)
+    save_vocab(topics, cfg.data_dir / "vocab.yaml")
     typer.echo(f"Vocabulario aplicado: {len(topics)} topics → {cfg.data_dir / 'vocab.yaml'}")
-    _report_invalid(invalid)
 
 
 def _vocab_run(cfg: Config, store: dict, executor: str | None, regenerate: bool) -> None:
@@ -295,7 +299,7 @@ def _vocab_run(cfg: Config, store: dict, executor: str | None, regenerate: bool)
     if chosen in ("manual", "claude-code"):
         worksheet = cfg.data_dir / "vocab-worksheet.json"
         export_vocab_worksheet(store, cfg.vocab_target_count, worksheet)
-        regen = "  --regenerate" if regenerate else ""
+        regen = " --regenerate" if regenerate else ""
         typer.echo(
             f"Corpus exportado a {worksheet}\n"
             f"Induce la taxonomía (con Claude Code o a mano) y ejecuta:\n"
@@ -316,10 +320,10 @@ def vocab(
     regenerate: bool = typer.Option(
         False, help="Marca todos los items para re-enriquecer contra la taxonomía nueva"
     ),
-    executor: str = typer.Option(
+    executor: str | None = typer.Option(
         None, help="api | manual | claude-code (default: el de config.toml)"
     ),
-    apply: Path = typer.Option(None, "--apply", help="Importar una vocab worksheet rellena"),
+    apply: Path | None = typer.Option(None, "--apply", help="Importar una vocab worksheet rellena"),
 ) -> None:
     """Induce el vocabulario de topics (data/vocab.yaml) desde el corpus."""
     cfg = _config()
@@ -381,8 +385,10 @@ def _topics_run(cfg: Config, store: dict, vocab: list, resynth: bool, executor: 
 @_handle_cli_errors
 def topics(
     resynth: bool = typer.Option(False, help="Re-sintetizar todos los overviews obsoletos"),
-    apply: Path = typer.Option(None, "--apply", help="Importar un worksheet de overviews relleno"),
-    executor: str = typer.Option(
+    apply: Path | None = typer.Option(
+        None, "--apply", help="Importar un worksheet de overviews relleno"
+    ),
+    executor: str | None = typer.Option(
         None, help="api | manual | claude-code (default: el de config.toml)"
     ),
 ) -> None:

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -46,7 +46,12 @@ from xbrain.topics import (
     topics_needing_synth,
     write_topic_pages,
 )
-from xbrain.vocab import induce_vocab
+from xbrain.vocab import (
+    apply_vocab_worksheet,
+    export_vocab_worksheet,
+    import_vocab_worksheet,
+    induce_vocab,
+)
 from xbrain.worksheet import export_worksheet, import_worksheet
 
 app = typer.Typer(help="XBrain — bookmarks y tweets de X a un wiki de Obsidian")
@@ -264,26 +269,67 @@ def enrich(
     _report_invalid(invalid)
 
 
-@app.command()
-@_handle_cli_errors
-def vocab(
-    regenerate: bool = typer.Option(
-        False, help="Regenerate the taxonomy and mark every item for re-enrichment"
-    ),
-) -> None:
-    """Induce the topic vocabulary (data/vocab.yaml) from the corpus."""
-    cfg = _config()
-    store = load_store(cfg.items_path)
-    if not store:
-        raise RuntimeError("El store está vacío — ejecuta `xbrain extract` antes.")
-    topics = induce_vocab(store, cfg.vocab_target_count, cfg.enrich_model)
-    save_vocab(topics, cfg.data_dir / "vocab.yaml")
+def _mark_for_regenerate(store: dict, cfg: Config, regenerate: bool) -> None:
+    """When `--regenerate` is set, drop every item's enrichment and persist."""
     if regenerate:
         for item in store.values():
             item.enriched = None
         save_store(store, cfg.items_path)
         typer.echo("Todos los items marcados para re-enriquecer.")
+
+
+def _vocab_apply(cfg: Config, store: dict, apply: Path, regenerate: bool) -> None:
+    """`xbrain vocab --apply` — import a filled vocab worksheet."""
+    topics, invalid = apply_vocab_worksheet(import_vocab_worksheet(apply))
+    if not topics:
+        raise RuntimeError("La worksheet no produjo ningún topic válido.")
+    save_vocab(topics, cfg.data_dir / "vocab.yaml")
+    _mark_for_regenerate(store, cfg, regenerate)
+    typer.echo(f"Vocabulario aplicado: {len(topics)} topics → {cfg.data_dir / 'vocab.yaml'}")
+    _report_invalid(invalid)
+
+
+def _vocab_run(cfg: Config, store: dict, executor: str | None, regenerate: bool) -> None:
+    """`xbrain vocab` — induce the taxonomy (worksheet export, or `api`)."""
+    chosen = executor or cfg.enrich_executor
+    if chosen in ("manual", "claude-code"):
+        worksheet = cfg.data_dir / "vocab-worksheet.json"
+        export_vocab_worksheet(store, cfg.vocab_target_count, worksheet)
+        regen = "  --regenerate" if regenerate else ""
+        typer.echo(
+            f"Corpus exportado a {worksheet}\n"
+            f"Induce la taxonomía (con Claude Code o a mano) y ejecuta:\n"
+            f"  xbrain vocab --apply {worksheet}{regen}"
+        )
+        return
+    if chosen != "api":
+        raise ValueError(f"Ejecutor desconocido: {chosen!r}")
+    topics = induce_vocab(store, cfg.vocab_target_count, cfg.enrich_model)
+    save_vocab(topics, cfg.data_dir / "vocab.yaml")
+    _mark_for_regenerate(store, cfg, regenerate)
     typer.echo(f"Vocabulario inducido: {len(topics)} topics → {cfg.data_dir / 'vocab.yaml'}")
+
+
+@app.command()
+@_handle_cli_errors
+def vocab(
+    regenerate: bool = typer.Option(
+        False, help="Marca todos los items para re-enriquecer contra la taxonomía nueva"
+    ),
+    executor: str = typer.Option(
+        None, help="api | manual | claude-code (default: el de config.toml)"
+    ),
+    apply: Path = typer.Option(None, "--apply", help="Importar una vocab worksheet rellena"),
+) -> None:
+    """Induce el vocabulario de topics (data/vocab.yaml) desde el corpus."""
+    cfg = _config()
+    store = load_store(cfg.items_path)
+    if not store:
+        raise RuntimeError("El store está vacío — ejecuta `xbrain extract` antes.")
+    if apply is not None:
+        _vocab_apply(cfg, store, apply, regenerate)
+    else:
+        _vocab_run(cfg, store, executor, regenerate)
 
 
 def _topics_apply(cfg: Config, store: dict, vocab: list, apply: Path) -> None:

--- a/src/xbrain/topic_synth.py
+++ b/src/xbrain/topic_synth.py
@@ -129,6 +129,8 @@ def import_topic_worksheet(path: Path) -> list[dict]:
     if not path.exists():
         raise FileNotFoundError(f"Worksheet not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("worksheet must be a JSON object")
     judgments = data.get("judgments", [])
     if not isinstance(judgments, list):
         raise ValueError("worksheet `judgments` must be a list")

--- a/src/xbrain/vocab.py
+++ b/src/xbrain/vocab.py
@@ -114,6 +114,8 @@ def import_vocab_worksheet(path: Path) -> list[dict]:
     if not path.exists():
         raise FileNotFoundError(f"Worksheet not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("worksheet must be a JSON object")
     topics = data.get("topics", [])
     if not isinstance(topics, list):
         raise ValueError("worksheet `topics` must be a list")
@@ -136,6 +138,10 @@ def apply_vocab_worksheet(
             invalid.append(("", ["topic entry is not a JSON object"]))
             continue
         slug = str(entry.get("slug", ""))
+        extra = set(entry) - {"slug", "description"}
+        if extra:
+            invalid.append((slug, [f"unexpected keys: {sorted(extra)}"]))
+            continue
         try:
             topic = Topic(**entry)
         except Exception as exc:  # noqa: BLE001 - collect, do not abort the batch

--- a/src/xbrain/vocab.py
+++ b/src/xbrain/vocab.py
@@ -7,6 +7,10 @@ consolidation call merges all candidates into exactly `target_count` topics
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
 from xbrain.llm_json import json_from_response
 from xbrain.models import Item, Topic
 from xbrain.rubrics import load_rubric
@@ -77,3 +81,69 @@ def induce_vocab(
         except Exception as exc:  # noqa: BLE001
             raise ValueError(f"invalid topic in vocab reduce output: {entry!r} ({exc})") from exc
     return topics
+
+
+def export_vocab_worksheet(store: dict[str, Item], target_count: int, path: Path) -> None:
+    """Export the corpus + rubric so an executor can induce the taxonomy.
+
+    The no-API-cost track for the `vocab` stage: a Claude Code session (or a
+    person) reads this worksheet, induces the taxonomy and fills `topics`.
+    XBrain only moves JSON — it never handles a Claude OAuth token.
+    """
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target_count": target_count,
+        "instructions": (
+            "Induce a controlled topic taxonomy from `corpus`, following the "
+            "embedded `rubric`. Use a map-reduce method: chunk the corpus, "
+            "propose candidate topics per chunk, then consolidate to exactly "
+            f"{target_count} topics. Write the final taxonomy into `topics` as "
+            "objects {slug, description} — `slug` is kebab-case ([a-z0-9-]). "
+            "Then run: xbrain vocab --apply <this file>."
+        ),
+        "rubric": load_rubric("vocab"),
+        "corpus": [item.text for item in store.values()],
+        "topics": [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def import_vocab_worksheet(path: Path) -> list[dict]:
+    """Read the filled `topics` list from a vocab worksheet."""
+    if not path.exists():
+        raise FileNotFoundError(f"Worksheet not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    topics = data.get("topics", [])
+    if not isinstance(topics, list):
+        raise ValueError("worksheet `topics` must be a list")
+    return topics
+
+
+def apply_vocab_worksheet(
+    topics_data: list[dict],
+) -> tuple[list[Topic], list[tuple[str, list[str]]]]:
+    """Validate worksheet topic entries into `Topic`s. Returns `(valid, invalid)`.
+
+    Rejects malformed entries, invalid slugs (the `Topic` pattern) and duplicate
+    slugs — the taxonomy's join key must be unique and well-formed.
+    """
+    valid: list[Topic] = []
+    invalid: list[tuple[str, list[str]]] = []
+    seen: set[str] = set()
+    for entry in topics_data:
+        if not isinstance(entry, dict):
+            invalid.append(("", ["topic entry is not a JSON object"]))
+            continue
+        slug = str(entry.get("slug", ""))
+        try:
+            topic = Topic(**entry)
+        except Exception as exc:  # noqa: BLE001 - collect, do not abort the batch
+            invalid.append((slug, [f"invalid topic: {exc}"]))
+            continue
+        if topic.slug in seen:
+            invalid.append((topic.slug, ["duplicate slug"]))
+            continue
+        seen.add(topic.slug)
+        valid.append(topic)
+    return valid, invalid

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -70,6 +70,8 @@ def import_worksheet(path: Path) -> tuple[str, list[dict]]:
     if not path.exists():
         raise FileNotFoundError(f"Worksheet not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("worksheet must be a JSON object")
     judgments = data.get("judgments", [])
     if not isinstance(judgments, list):
         raise ValueError("worksheet `judgments` must be a list")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -519,6 +519,9 @@ def test_vocab_apply_with_no_valid_topics_fails(tmp_path, monkeypatch):
     ws.write_text(json.dumps({"topics": [{"slug": "BAD SLUG"}]}), encoding="utf-8")
     result = runner.invoke(app, ["vocab", "--apply", str(ws)])
     assert result.exit_code == 1
+    # `_report_invalid` must run BEFORE the raise — the user needs to see WHY
+    # the topic was rejected, so the bad slug shows up in the output.
+    assert "BAD SLUG" in result.output
 
 
 def test_vocab_api_executor_still_works(tmp_path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,7 +123,7 @@ def test_vocab_command_persists_induced_topics(tmp_path, monkeypatch):
     monkeypatch.setattr(
         cli, "induce_vocab", lambda *a, **k: [Topic(slug="misc", description="Noise.")]
     )
-    result = runner.invoke(app, ["vocab"])
+    result = runner.invoke(app, ["vocab", "--executor", "api"])
     assert result.exit_code == 0
     from xbrain.rubrics import load_vocab
 
@@ -457,3 +457,87 @@ def test_topics_resynth_succeeds(tmp_path, monkeypatch):
     assert result.exit_code == 0
     page = (tmp_path / "vault" / "x-knowledge" / "topics" / "misc.md").read_text(encoding="utf-8")
     assert "Re-sintetizado." in page
+
+
+def test_vocab_claude_code_exports_a_worksheet(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["vocab", "--executor", "claude-code"])
+    assert result.exit_code == 0
+    assert (tmp_path / "data" / "vocab-worksheet.json").exists()
+
+
+def test_vocab_apply_writes_vocab_yaml(tmp_path, monkeypatch):
+    import json
+
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    ws = tmp_path / "ws.json"
+    ws.write_text(
+        json.dumps({"topics": [{"slug": "misc", "description": "Ruido."}]}), encoding="utf-8"
+    )
+    result = runner.invoke(app, ["vocab", "--apply", str(ws)])
+    assert result.exit_code == 0
+    from xbrain.rubrics import load_vocab
+
+    assert [t.slug for t in load_vocab(tmp_path / "data" / "vocab.yaml")] == ["misc"]
+
+
+def test_vocab_apply_regenerate_marks_items(tmp_path, monkeypatch):
+    import json
+    from datetime import datetime, timezone
+
+    from xbrain.models import Enrichment
+
+    _setup_repo(tmp_path, monkeypatch)
+    item = _linked_item("1")
+    item.enriched = Enrichment(
+        enriched_at=datetime.now(timezone.utc),
+        executor="manual",
+        summary="s",
+        primary_topic="misc",
+        topics=["misc"],
+    )
+    save_store({"1": item}, tmp_path / "data" / "items.json")
+    ws = tmp_path / "ws.json"
+    ws.write_text(
+        json.dumps({"topics": [{"slug": "misc", "description": "Ruido."}]}), encoding="utf-8"
+    )
+    result = runner.invoke(app, ["vocab", "--apply", str(ws), "--regenerate"])
+    assert result.exit_code == 0
+    from xbrain.store import load_store as _ls
+
+    assert _ls(tmp_path / "data" / "items.json")["1"].enriched is None
+
+
+def test_vocab_apply_with_no_valid_topics_fails(tmp_path, monkeypatch):
+    import json
+
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    ws = tmp_path / "ws.json"
+    ws.write_text(json.dumps({"topics": [{"slug": "BAD SLUG"}]}), encoding="utf-8")
+    result = runner.invoke(app, ["vocab", "--apply", str(ws)])
+    assert result.exit_code == 1
+
+
+def test_vocab_api_executor_still_works(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    import xbrain.cli as cli
+    from xbrain.models import Topic
+
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    monkeypatch.setattr(cli, "induce_vocab", lambda *a, **k: [Topic(slug="misc", description="d")])
+    result = runner.invoke(app, ["vocab", "--executor", "api"])
+    assert result.exit_code == 0
+    from xbrain.rubrics import load_vocab
+
+    assert [t.slug for t in load_vocab(tmp_path / "data" / "vocab.yaml")] == ["misc"]
+
+
+def test_vocab_rejects_unknown_executor(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["vocab", "--executor", "bogus"])
+    assert result.exit_code == 1
+    assert "bogus" in result.output

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -66,3 +66,100 @@ def test_induce_vocab_raises_when_map_response_has_no_candidates():
     with pytest.raises(ValueError) as exc_info:
         induce_vocab(store, target_count=1, model="m", client=client, chunk_size=50)
     assert "candidates" in str(exc_info.value)
+
+
+def test_export_vocab_worksheet_writes_corpus_and_rubric(tmp_path):
+    from datetime import datetime, timezone
+
+    from xbrain.models import Author, Item
+    from xbrain.vocab import export_vocab_worksheet
+
+    def _item(i):
+        return Item(
+            id=str(i),
+            source="bookmark",
+            url=f"https://x.com/a/status/{i}",
+            author=Author(handle="a", name="A"),
+            text=f"post {i}",
+            created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            captured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+
+    store = {"1": _item(1), "2": _item(2)}
+    path = tmp_path / "vocab-worksheet.json"
+    export_vocab_worksheet(store, target_count=45, path=path)
+    import json
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["target_count"] == 45
+    assert payload["corpus"] == ["post 1", "post 2"]
+    assert "rubric" in payload and payload["rubric"]
+    assert payload["topics"] == []
+
+
+def test_import_vocab_worksheet_round_trips(tmp_path):
+    import json
+
+    from xbrain.vocab import import_vocab_worksheet
+
+    path = tmp_path / "ws.json"
+    path.write_text(json.dumps({"topics": [{"slug": "ai", "description": "d"}]}), encoding="utf-8")
+    assert import_vocab_worksheet(path) == [{"slug": "ai", "description": "d"}]
+
+
+def test_import_vocab_worksheet_rejects_non_list_topics(tmp_path):
+    import json
+
+    import pytest
+
+    from xbrain.vocab import import_vocab_worksheet
+
+    path = tmp_path / "ws.json"
+    path.write_text(json.dumps({"topics": "no soy lista"}), encoding="utf-8")
+    with pytest.raises(ValueError):
+        import_vocab_worksheet(path)
+
+
+def test_import_vocab_worksheet_missing_file_raises(tmp_path):
+    import pytest
+
+    from xbrain.vocab import import_vocab_worksheet
+
+    with pytest.raises(FileNotFoundError):
+        import_vocab_worksheet(tmp_path / "absent.json")
+
+
+def test_apply_vocab_worksheet_validates_topics():
+    from xbrain.vocab import apply_vocab_worksheet
+
+    valid, invalid = apply_vocab_worksheet(
+        [
+            {"slug": "ai-coding", "description": "Desarrollo con IA."},
+            {"slug": "BAD SLUG", "description": "espacios y mayúsculas"},
+            {"slug": "misc"},  # missing description
+        ]
+    )
+    assert [t.slug for t in valid] == ["ai-coding"]
+    assert {row[0] for row in invalid} == {"BAD SLUG", "misc"}
+
+
+def test_apply_vocab_worksheet_rejects_duplicate_slugs():
+    from xbrain.vocab import apply_vocab_worksheet
+
+    valid, invalid = apply_vocab_worksheet(
+        [
+            {"slug": "ai", "description": "d1"},
+            {"slug": "ai", "description": "d2"},
+        ]
+    )
+    assert [t.slug for t in valid] == ["ai"]
+    assert invalid and invalid[0][0] == "ai"
+    assert any("duplicate" in e for e in invalid[0][1])
+
+
+def test_apply_vocab_worksheet_rejects_non_dict_entry():
+    from xbrain.vocab import apply_vocab_worksheet
+
+    valid, invalid = apply_vocab_worksheet(["oops"])
+    assert valid == []
+    assert invalid and "not a JSON object" in invalid[0][1][0]

--- a/tests/test_vocab.py
+++ b/tests/test_vocab.py
@@ -129,6 +129,21 @@ def test_import_vocab_worksheet_missing_file_raises(tmp_path):
         import_vocab_worksheet(tmp_path / "absent.json")
 
 
+def test_import_vocab_worksheet_rejects_non_dict_root(tmp_path):
+    import json
+
+    import pytest
+
+    from xbrain.vocab import import_vocab_worksheet
+
+    # A worksheet whose top-level JSON is a list (not an object) must surface a
+    # clean ValueError, not an uncaught AttributeError from `data.get(...)`.
+    path = tmp_path / "ws.json"
+    path.write_text(json.dumps(["a", "b"]), encoding="utf-8")
+    with pytest.raises(ValueError):
+        import_vocab_worksheet(path)
+
+
 def test_apply_vocab_worksheet_validates_topics():
     from xbrain.vocab import apply_vocab_worksheet
 
@@ -163,3 +178,19 @@ def test_apply_vocab_worksheet_rejects_non_dict_entry():
     valid, invalid = apply_vocab_worksheet(["oops"])
     assert valid == []
     assert invalid and "not a JSON object" in invalid[0][1][0]
+
+
+def test_apply_vocab_worksheet_rejects_unexpected_keys():
+    from xbrain.vocab import apply_vocab_worksheet
+
+    # `Topic` is lenient, so an entry with an extra key would otherwise be
+    # accepted with the extra key silently dropped — reject it instead.
+    valid, invalid = apply_vocab_worksheet(
+        [
+            {"slug": "ai", "description": "d", "notes": []},
+            {"slug": "ml", "description": "clean sibling"},
+        ]
+    )
+    assert [t.slug for t in valid] == ["ml"]
+    assert invalid and invalid[0][0] == "ai"
+    assert any("unexpected keys" in e for e in invalid[0][1])


### PR DESCRIPTION
Gives the `vocab` stage a worksheet executor track, closing the Fase 1 gap where `vocab` was API-only — design §7 (pluggable executors) + §15.1 ("sin API y con API, todo").

- `xbrain vocab --executor claude-code` exports `data/vocab-worksheet.json` (corpus + vocab rubric + target_count).
- `xbrain vocab --apply <file>` validates the filled `topics` into `Topic`s (slug pattern, no duplicates) and writes `data/vocab.yaml`. `--regenerate` honored.
- The `api` executor (`induce_vocab`) is unchanged. XBrain only moves JSON — no Claude OAuth token handled.
- `enriching-x-knowledge` skill documents the flow.

Mirrors the existing `enrich` / `topics` worksheet pattern exactly. 3 commits, 219 tests, `poe check` green.

Plan: `zz-support-files/docs/implementation-plans/2026-05-19-xbrain-vocab-worksheet.md`. Substantially written with an AI agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)