### PR TITLE
Promote to main: README sentence fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ it through a worksheet hand-off (see [Execution modes](#execution-modes)).
 A personal knowledge base — a "second brain" — captures everything you
 **produce**: your notes, your drafts, your decisions.
 
-But it is worthless if it does not capture almost nothing
-of what you **consume** — the articles you read, the threads you save, the posts
-you write on a platform that is not your vault. That gap is real, and it is
-shaped exactly like everything you found worth keeping.
+But it is worthless if it does not capture what you **consume** — the articles
+you read, the threads you save, the posts you write on a platform that is not
+your vault. That gap is real, and it is shaped exactly like everything you found
+worth keeping.
 
 Months of bookmarks are not noise. Every one was a decision that *this is worth
 coming back to* — a quiet, honest signal about what you care about and how your


### PR DESCRIPTION
Puts the corrected Why-XBrain sentence on the public main. Docs-only, CI-green on PR #12.