### PR TITLE
[#17] Auto-snapshot data/ before destructive ops + xbrain snapshot subcommand

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -149,6 +149,7 @@ optional Firecrawl fallback, Playwright for x.com).
 - **Writes:** `items.json` — each item's `content` + `content_source[]`
 - **Cached** — already-fetched items are skipped (use `--force` to refetch).
 - **Failures recorded as evidence** — `http_status` + `failure_reason`, never silently dropped.
+- **Snapshots `data/` before `--force`** — recovery path if a forced refetch makes things worse.
 
 </td></tr>
 <tr><td>
@@ -161,6 +162,7 @@ step proposes candidates per chunk; reduce step consolidates to `target_count`.
 - **Reads:** `items.json`
 - **Writes:** `vocab.yaml` (slug + description list)
 - **Always includes a `misc` topic** for posts with no thematic core.
+- **Snapshots `data/` before `--regenerate`** — a vocab rewrite forces re-enrichment, so it is the most destructive op.
 
 </td></tr>
 <tr><td>
@@ -187,6 +189,7 @@ notes.
 - **Writes:** `topics.json` — one `TopicPage` per slug
 - **Plain prose only** — the post lists are added later by `generate`, not the LLM.
 - **Derived staleness** — a page is stale when `live_count > post_count_at_synth + threshold`.
+- **Snapshots `data/` before `--resynth`** — re-synthesising every stale overview overwrites `topics.json` in place.
 
 </td></tr>
 <tr><td>
@@ -390,6 +393,7 @@ These are the rules the rest of the architecture rests on. Breaking any of them 
 5. **Failed fetches are recorded as structured evidence**, not silently dropped. A broken link is demonstrable (`http_status`, `failure_reason`), not assumed.
 6. **`fetch` is cached per item id.** Re-runs do not re-hit the network without `--force` (or, in the future, transient-retry — issue #19).
 7. **Operation names, not query ids.** The extractor anchors to X GraphQL operation names because X rotates the ids. Anything that hardcodes an id will break.
+8. **Destructive ops are reversible.** Every command that overwrites a `data/` artifact (`vocab --regenerate`, `topics --resynth`, `fetch --force`) snapshots `data/` first to `data/snapshots/<ts>-pre-<command>/`. `xbrain snapshot restore <name>` is the recovery path. A snapshot failure aborts the destructive op.
 
 ---
 
@@ -427,6 +431,7 @@ xbrain/
 │   ├── generate.py          ← wiki rendering
 │   ├── notes_io.py          ← per-note read/write + user-tail preservation
 │   ├── store.py             ← items.json / topics.json / state.json I/O
+│   ├── snapshot.py          ← data/ snapshot lifecycle (create/list/restore/prune)
 │   ├── worksheet.py         ← enrich worksheet export/import
 │   ├── validate.py          ← guardrails enforcement
 │   ├── llm_json.py          ← extract JSON from LLM responses

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,17 @@ file is not tracked by git.
 - Keep the PR focused on one change. No drive-by refactors.
 - Describe what changed and why, in your own words.
 
+## Safety: destructive operations auto-snapshot
+
+Destructive commands (`vocab --regenerate`, `topics --resynth`, `fetch --force`)
+copy the full `data/` directory to `data/snapshots/<UTC-ts>-pre-<command>/`
+before they write anything. If your change introduces or modifies a destructive
+operation, **wire the auto-snapshot** — see `_auto_snapshot` in `src/xbrain/cli.py`
+and the unit + integration tests under `tests/test_snapshot*.py`. A snapshot
+failure must propagate and abort the destructive op; never `try/except`-swallow
+it. Manual snapshots are available via `xbrain snapshot create`; restore via
+`xbrain snapshot restore <name>`.
+
 ## Pull requests written with AI agents
 
 XBrain is built with AI coding agents, and PRs written that way are welcome — under

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ it through a worksheet hand-off (see [Execution modes](#execution-modes)).
 - [The pipeline](#the-pipeline)
 - [Commands](#commands)
 - [Execution modes](#execution-modes)
+- [Snapshots & safety](#snapshots--safety)
 - [How it works](#how-it-works)
 - [Project structure](#project-structure)
 - [Development](#development)
@@ -503,10 +504,34 @@ uv run xbrain <command> [options]
 | `generate` | Render the wiki into the vault. |
 | `sync` | `extract` + `fetch` + `generate`, in order. |
 | `status` | Counts and last-run timestamps. |
+| `snapshot` | Manage `data/` snapshots: `create`, `list`, `show`, `restore`, `prune`. See [Snapshots & safety](#snapshots--safety). |
 | `login` | Open a browser to log in to X (see [Authentication](#authentication) — prefer the cookie import). |
 
 Every stage accepts `--since` / `--until` (ISO dates) to narrow the date window.
 Run `uv run xbrain <command> --help` for the full option list.
+
+---
+
+## Snapshots & safety
+
+Destructive commands (`vocab --regenerate`, `topics --resynth`, `fetch --force`)
+**auto-snapshot** `data/` before they touch anything. The snapshot is a complete
+copy of `items.json`, `state.json`, `vocab.yaml` and `topics.json` under
+`data/snapshots/<UTC-timestamp>-pre-<command>/`, with a `snapshot.json` manifest
+capturing counts and the running `xbrain` version. If a re-run produces worse
+output, a single `xbrain snapshot restore <name>` brings the previous good
+state back.
+
+```bash
+xbrain snapshot list                        # newest first
+xbrain snapshot create --name pre-rubric-v2 # mark a known-good state
+xbrain snapshot restore <name>              # roll back data/ (run `generate` next)
+xbrain snapshot prune --keep-last 10        # cap disk use
+```
+
+The Obsidian vault is **not** snapshotted — it is fully derived from `data/`
+via `xbrain generate`. `restore` rolls back `data/`; you run `xbrain generate`
+to rebuild the wiki from it.
 
 ---
 

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import typer
 
+from xbrain import snapshot
 from xbrain.archive import parse_archive
 from xbrain.config import Config, load_config
 from xbrain.enrich import apply_worksheet_judgments, enrich_with_executor, items_pending_enrichment
@@ -150,7 +151,20 @@ def _run_extract(cfg: Config, source: str, since: datetime | None, until: dateti
     save_state(state, cfg.state_path)
 
 
+def _auto_snapshot(cfg: Config, command: str) -> None:
+    """Snapshot data/ before a destructive op and echo the path to stdout.
+
+    Called from every destructive code path (vocab --regenerate, topics
+    --resynth, fetch --force). Any failure here propagates and aborts the
+    destructive op — a snapshot we can't take must not be silently skipped.
+    """
+    path = snapshot.snapshot_pre(cfg.data_dir, command=command)
+    typer.echo(f"Snapshot creado: {path}")
+
+
 def _run_fetch(cfg: Config, since: datetime | None, until: datetime | None, force: bool) -> None:
+    if force:
+        _auto_snapshot(cfg, "fetch-force")
     store = load_store(cfg.items_path)
     try:
         articles = fetch_pending(store, since, until, force)
@@ -286,6 +300,8 @@ def _vocab_apply(cfg: Config, store: dict, apply: Path, regenerate: bool) -> Non
     _report_invalid(invalid)
     if not topics:
         raise RuntimeError("La worksheet no produjo ningún topic válido.")
+    if regenerate:
+        _auto_snapshot(cfg, "vocab-regenerate")
     # Mark the store first: a crash here leaves items pending (a re-run re-marks
     # idempotently) — safer than vocab.yaml updated while items stay stale.
     _mark_for_regenerate(store, cfg, regenerate)
@@ -308,6 +324,8 @@ def _vocab_run(cfg: Config, store: dict, executor: str | None, regenerate: bool)
         return
     if chosen != "api":
         raise ValueError(f"Ejecutor desconocido: {chosen!r}")
+    if regenerate:
+        _auto_snapshot(cfg, "vocab-regenerate")
     topics = induce_vocab(store, cfg.vocab_target_count, cfg.enrich_model)
     save_vocab(topics, cfg.data_dir / "vocab.yaml")
     _mark_for_regenerate(store, cfg, regenerate)
@@ -350,6 +368,8 @@ def _topics_apply(cfg: Config, store: dict, vocab: list, apply: Path) -> None:
 
 def _topics_run(cfg: Config, store: dict, vocab: list, resynth: bool, executor: str | None) -> None:
     """`xbrain topics` — update lists and (re)synthesize stale overviews."""
+    if resynth:
+        _auto_snapshot(cfg, "topics-resynth")
     pages = load_topic_pages(cfg.topics_path)
     posts = compute_topic_posts(store, vocab)
     stale = topics_needing_synth(vocab, posts, pages, cfg.topics_resynth_threshold, resynth)
@@ -437,6 +457,69 @@ def status() -> None:
     typer.echo(f"  enriquecidos: {sum(1 for i in store.values() if i.enriched)}")
     typer.echo(f"  última extracción bookmarks: {state.bookmarks.last_run}")
     typer.echo(f"  última extracción tweets: {state.own_tweets.last_run}")
+
+
+snapshot_app = typer.Typer(help="Gestionar snapshots de data/")
+app.add_typer(snapshot_app, name="snapshot")
+
+
+@snapshot_app.command("create")
+@_handle_cli_errors
+def snapshot_create_cmd(
+    name: str | None = typer.Option(
+        None, help="Etiqueta opcional para el snapshot (por defecto: 'manual')"
+    ),
+) -> None:
+    """Crea un snapshot de data/ ahora mismo."""
+    cfg = _config()
+    path = snapshot.snapshot_create(cfg.data_dir, command="manual", name=name)
+    typer.echo(f"Snapshot creado: {path}")
+
+
+@snapshot_app.command("list")
+@_handle_cli_errors
+def snapshot_list_cmd() -> None:
+    """Lista los snapshots disponibles, del más nuevo al más antiguo."""
+    cfg = _config()
+    rows = snapshot.snapshot_list(cfg.data_dir)
+    if not rows:
+        typer.echo("No hay snapshots.")
+        return
+    for path, manifest in rows:
+        typer.echo(
+            f"{path.name}  {manifest.command:<28}  "
+            f"items={manifest.item_count}  topics={manifest.topic_count}  "
+            f"vocab={manifest.vocab_size}"
+        )
+
+
+@snapshot_app.command("show")
+@_handle_cli_errors
+def snapshot_show_cmd(name: str = typer.Argument(..., help="Nombre del directorio")) -> None:
+    """Muestra el manifest de un snapshot concreto."""
+    cfg = _config()
+    _, manifest = snapshot.snapshot_show(cfg.data_dir, name)
+    typer.echo(manifest.model_dump_json(indent=2))
+
+
+@snapshot_app.command("restore")
+@_handle_cli_errors
+def snapshot_restore_cmd(name: str = typer.Argument(..., help="Nombre del directorio")) -> None:
+    """Restaura data/ desde un snapshot (no toca el vault: ejecuta `generate` después)."""
+    cfg = _config()
+    snapshot.snapshot_restore(cfg.data_dir, name)
+    typer.echo(f"Restaurado {name}. Ejecuta `xbrain generate` para refrescar el vault.")
+
+
+@snapshot_app.command("prune")
+@_handle_cli_errors
+def snapshot_prune_cmd(
+    keep_last: int = typer.Option(10, "--keep-last", help="Conserva los N más recientes"),
+) -> None:
+    """Elimina los snapshots antiguos, conservando los N más recientes."""
+    cfg = _config()
+    deleted = snapshot.snapshot_prune(cfg.data_dir, keep_last=keep_last)
+    typer.echo(f"Snapshots eliminados: {deleted}")
 
 
 if __name__ == "__main__":

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -93,6 +93,10 @@ _OPERATOR_ERRORS = (
     KeyError,
     RuntimeError,
     NotImplementedError,
+    # OSError covers PermissionError, FileExistsError, IsADirectoryError, etc.
+    # The snapshot module hits these on permission or disk issues — they should
+    # surface as a clean exit-1, not a raw traceback.
+    OSError,
 )
 
 
@@ -152,14 +156,22 @@ def _run_extract(cfg: Config, source: str, since: datetime | None, until: dateti
 
 
 def _auto_snapshot(cfg: Config, command: str) -> None:
-    """Snapshot data/ before a destructive op and echo the path to stdout.
+    """Snapshot data/ before a destructive op and echo the path + item count.
 
     Called from every destructive code path (vocab --regenerate, topics
-    --resynth, fetch --force). Any failure here propagates and aborts the
-    destructive op — a snapshot we can't take must not be silently skipped.
+    --resynth, fetch --force). The manifest's `command` field carries the
+    destructive op name (e.g. `vocab-regenerate`); the directory label uses
+    the `pre-<op>` prefix so the listing is self-describing.
+
+    Any failure here propagates and aborts the destructive op — a snapshot we
+    can't take must not be silently skipped.
     """
-    path = snapshot.snapshot_pre(cfg.data_dir, command=command)
-    typer.echo(f"Snapshot creado: {path}")
+    path, manifest = snapshot.snapshot_create(
+        cfg.data_dir,
+        command=command,
+        dir_label=f"pre-{command}",
+    )
+    typer.echo(f"Snapshot created: {path.name} ({manifest.item_count} items)")
 
 
 def _run_fetch(cfg: Config, since: datetime | None, until: datetime | None, force: bool) -> None:
@@ -466,26 +478,34 @@ app.add_typer(snapshot_app, name="snapshot")
 @snapshot_app.command("create")
 @_handle_cli_errors
 def snapshot_create_cmd(
-    name: str | None = typer.Option(
-        None, help="Etiqueta opcional para el snapshot (por defecto: 'manual')"
-    ),
+    name: str | None = typer.Option(None, help="Optional directory label (default: 'manual')"),
 ) -> None:
-    """Crea un snapshot de data/ ahora mismo."""
+    """Create a snapshot of data/ right now."""
     cfg = _config()
-    path = snapshot.snapshot_create(cfg.data_dir, command="manual", name=name)
-    typer.echo(f"Snapshot creado: {path}")
+    path, manifest = snapshot.snapshot_create(
+        cfg.data_dir,
+        command="manual",
+        dir_label=name,
+    )
+    typer.echo(f"Snapshot created: {path.name} ({manifest.item_count} items)")
 
 
 @snapshot_app.command("list")
 @_handle_cli_errors
 def snapshot_list_cmd() -> None:
-    """Lista los snapshots disponibles, del más nuevo al más antiguo."""
+    """List snapshots, newest first. Corrupt entries surface as CORRUPT."""
     cfg = _config()
     rows = snapshot.snapshot_list(cfg.data_dir)
     if not rows:
-        typer.echo("No hay snapshots.")
+        typer.echo("No snapshots.")
         return
     for path, manifest in rows:
+        if manifest is None:
+            typer.echo(
+                f"{path.name}  CORRUPT — manifest missing or unreadable",
+                err=True,
+            )
+            continue
         typer.echo(
             f"{path.name}  {manifest.command:<28}  "
             f"items={manifest.item_count}  topics={manifest.topic_count}  "
@@ -495,8 +515,8 @@ def snapshot_list_cmd() -> None:
 
 @snapshot_app.command("show")
 @_handle_cli_errors
-def snapshot_show_cmd(name: str = typer.Argument(..., help="Nombre del directorio")) -> None:
-    """Muestra el manifest de un snapshot concreto."""
+def snapshot_show_cmd(name: str = typer.Argument(..., help="Snapshot directory name")) -> None:
+    """Print the manifest of one snapshot."""
     cfg = _config()
     _, manifest = snapshot.snapshot_show(cfg.data_dir, name)
     typer.echo(manifest.model_dump_json(indent=2))
@@ -504,22 +524,29 @@ def snapshot_show_cmd(name: str = typer.Argument(..., help="Nombre del directori
 
 @snapshot_app.command("restore")
 @_handle_cli_errors
-def snapshot_restore_cmd(name: str = typer.Argument(..., help="Nombre del directorio")) -> None:
-    """Restaura data/ desde un snapshot (no toca el vault: ejecuta `generate` después)."""
+def snapshot_restore_cmd(name: str = typer.Argument(..., help="Snapshot directory name")) -> None:
+    """Restore data/ from a snapshot.
+
+    The vault is NOT touched — run `xbrain generate` next to refresh it.
+    Every per-artifact action is echoed so 'a file vanished' never happens
+    silently.
+    """
     cfg = _config()
-    snapshot.snapshot_restore(cfg.data_dir, name)
-    typer.echo(f"Restaurado {name}. Ejecuta `xbrain generate` para refrescar el vault.")
+    actions = snapshot.snapshot_restore(cfg.data_dir, name)
+    for artifact, action in actions:
+        typer.echo(f"  {artifact}: {action}")
+    typer.echo(f"Restored {name}. Run `xbrain generate` to refresh the vault.")
 
 
 @snapshot_app.command("prune")
 @_handle_cli_errors
 def snapshot_prune_cmd(
-    keep_last: int = typer.Option(10, "--keep-last", help="Conserva los N más recientes"),
+    keep_last: int = typer.Option(10, "--keep-last", help="Keep the N newest snapshots"),
 ) -> None:
-    """Elimina los snapshots antiguos, conservando los N más recientes."""
+    """Delete older snapshots, keeping the N newest."""
     cfg = _config()
     deleted = snapshot.snapshot_prune(cfg.data_dir, keep_last=keep_last)
-    typer.echo(f"Snapshots eliminados: {deleted}")
+    typer.echo(f"Snapshots deleted: {deleted}")
 
 
 if __name__ == "__main__":

--- a/src/xbrain/snapshot.py
+++ b/src/xbrain/snapshot.py
@@ -1,0 +1,208 @@
+"""Snapshot lifecycle for the data/ directory.
+
+Auto-snapshots before destructive operations (`vocab --regenerate`, `topics
+--resynth`, `fetch --force`) are XBrain's recovery boundary: every destructive
+write is preceded by a complete directory copy at `data/snapshots/<ts>-pre-<cmd>/`.
+
+Manual snapshots (`xbrain snapshot create [--name X]`) let the user mark a
+known-good state on demand.
+
+Both kinds are reversible via `snapshot_restore`. The whole module is pure I/O
+plus pydantic — no CLI side-effects.
+"""
+
+from __future__ import annotations
+
+import shutil
+from datetime import datetime, timezone
+from importlib import metadata
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from xbrain.store import _atomic_write
+
+# The mutable artifacts that live in data/. Order matters for restore: items
+# first (the source of truth), then derived stores.
+_ARTIFACTS = ("items.json", "state.json", "vocab.yaml", "topics.json")
+
+_MANIFEST_FILENAME = "snapshot.json"
+_SNAPSHOTS_DIRNAME = "snapshots"
+
+
+class SnapshotManifest(BaseModel):
+    """Metadata persisted alongside every snapshot as snapshot.json."""
+
+    created_at: datetime
+    command: str
+    item_count: int
+    topic_count: int
+    vocab_size: int
+    xbrain_version: str = "unknown"
+
+
+def snapshots_dir(data_dir: Path) -> Path:
+    """Return the snapshots directory under data/."""
+    return data_dir / _SNAPSHOTS_DIRNAME
+
+
+def snapshot_create(data_dir: Path, *, command: str, name: str | None = None) -> Path:
+    """Create a snapshot directory inside data/snapshots/ and return its path.
+
+    Directory naming:
+      - if name is None: `<UTC-timestamp>-<command>` (command typically `manual` or `pre-<op>`)
+      - if name is set:  `<UTC-timestamp>-<name>`
+
+    Copies every existing artifact + writes snapshot.json. Raises if the
+    snapshots dir is unwritable or any artifact copy fails — the caller is
+    expected to let that propagate (a snapshot failure must abort the
+    destructive op that triggered it).
+    """
+    now = datetime.now(timezone.utc)
+    timestamp = now.strftime("%Y-%m-%dT%H-%M-%SZ")
+    label = name if name is not None else command
+    snapshot_dir = snapshots_dir(data_dir) / f"{timestamp}-{label}"
+    snapshot_dir.mkdir(parents=True, exist_ok=False)
+
+    for artifact in _ARTIFACTS:
+        src = data_dir / artifact
+        if src.exists():
+            shutil.copy2(src, snapshot_dir / artifact)
+
+    manifest = SnapshotManifest(
+        created_at=now,
+        command=command,
+        item_count=_count_items(data_dir),
+        topic_count=_count_topics(data_dir),
+        vocab_size=_count_vocab(data_dir),
+        xbrain_version=_xbrain_version(),
+    )
+    _atomic_write(
+        snapshot_dir / _MANIFEST_FILENAME,
+        manifest.model_dump_json(indent=2),
+    )
+    return snapshot_dir
+
+
+def snapshot_pre(data_dir: Path, *, command: str) -> Path:
+    """Snapshot before a destructive op. `command` is the op name (e.g. `vocab-regenerate`).
+
+    The directory is labelled `<ts>-pre-<command>` so the intent is obvious in `list`.
+    """
+    return snapshot_create(data_dir, command=f"pre-{command}")
+
+
+def snapshot_list(data_dir: Path) -> list[tuple[Path, SnapshotManifest]]:
+    """Return every snapshot under data/snapshots/, newest first.
+
+    Snapshots without a readable manifest are skipped (defensive — never
+    crash the list view because of one bad directory).
+    """
+    root = snapshots_dir(data_dir)
+    if not root.exists():
+        return []
+    rows: list[tuple[Path, SnapshotManifest]] = []
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        manifest_path = entry / _MANIFEST_FILENAME
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest = SnapshotManifest.model_validate_json(
+                manifest_path.read_text(encoding="utf-8")
+            )
+        except (ValueError, OSError):
+            continue
+        rows.append((entry, manifest))
+    rows.sort(key=lambda row: row[1].created_at, reverse=True)
+    return rows
+
+
+def snapshot_show(data_dir: Path, name: str) -> tuple[Path, SnapshotManifest]:
+    """Look up one snapshot by its directory name. Raises FileNotFoundError if missing."""
+    snapshot_dir = snapshots_dir(data_dir) / name
+    manifest_path = snapshot_dir / _MANIFEST_FILENAME
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"No snapshot named {name!r} under {snapshots_dir(data_dir)}")
+    manifest = SnapshotManifest.model_validate_json(manifest_path.read_text(encoding="utf-8"))
+    return snapshot_dir, manifest
+
+
+def snapshot_restore(data_dir: Path, name: str) -> None:
+    """Replace data/<artifact> from the snapshot for each of the four artifacts.
+
+    Artifacts present in the snapshot are copied over the live files (atomically
+    via the existing _atomic_write pattern). Artifacts MISSING in the snapshot
+    cause the live file to be deleted — restoring a pre-vocab snapshot to a
+    repo that now has a vocab.yaml drops the live vocab.yaml.
+
+    The snapshots/ subdir, auth/, the vault and any unrelated files are untouched.
+    """
+    snapshot_dir, _ = snapshot_show(data_dir, name)
+    for artifact in _ARTIFACTS:
+        src = snapshot_dir / artifact
+        dst = data_dir / artifact
+        if src.exists():
+            _atomic_write(dst, src.read_text(encoding="utf-8"))
+        elif dst.exists():
+            dst.unlink()
+
+
+def snapshot_prune(data_dir: Path, *, keep_last: int) -> int:
+    """Delete all but the keep_last newest snapshots. Returns the count deleted.
+
+    `keep_last` must be >= 0. A value of 0 prunes everything.
+    """
+    if keep_last < 0:
+        raise ValueError(f"keep_last must be >= 0, got {keep_last}")
+    rows = snapshot_list(data_dir)
+    to_delete = rows[keep_last:]
+    for snapshot_dir, _ in to_delete:
+        shutil.rmtree(snapshot_dir)
+    return len(to_delete)
+
+
+# --------------------------------------------------------------------- internals
+
+
+def _count_items(data_dir: Path) -> int:
+    return _count_json_dict(data_dir / "items.json")
+
+
+def _count_topics(data_dir: Path) -> int:
+    return _count_json_dict(data_dir / "topics.json")
+
+
+def _count_vocab(data_dir: Path) -> int:
+    """Count topics in vocab.yaml. Mirrors load_vocab's shape contract."""
+    path = data_dir / "vocab.yaml"
+    if not path.exists():
+        return 0
+    try:
+        import yaml
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except (yaml.YAMLError, OSError):
+        return 0
+    topics = data.get("topics", []) if isinstance(data, dict) else []
+    return len(topics) if isinstance(topics, list) else 0
+
+
+def _count_json_dict(path: Path) -> int:
+    if not path.exists():
+        return 0
+    try:
+        import json
+
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return 0
+    return len(data) if isinstance(data, dict) else 0
+
+
+def _xbrain_version() -> str:
+    try:
+        return metadata.version("xbrain")
+    except metadata.PackageNotFoundError:
+        return "unknown"

--- a/src/xbrain/snapshot.py
+++ b/src/xbrain/snapshot.py
@@ -13,11 +13,13 @@ plus pydantic — no CLI side-effects.
 
 from __future__ import annotations
 
+import json
 import shutil
 from datetime import datetime, timezone
 from importlib import metadata
 from pathlib import Path
 
+import yaml
 from pydantic import BaseModel
 
 from xbrain.store import _atomic_write
@@ -29,9 +31,19 @@ _ARTIFACTS = ("items.json", "state.json", "vocab.yaml", "topics.json")
 _MANIFEST_FILENAME = "snapshot.json"
 _SNAPSHOTS_DIRNAME = "snapshots"
 
+# Action codes returned by snapshot_restore for each artifact.
+RESTORE_COPIED = "copied"
+RESTORE_DELETED = "deleted"
+RESTORE_SKIPPED = "skipped"
+
 
 class SnapshotManifest(BaseModel):
-    """Metadata persisted alongside every snapshot as snapshot.json."""
+    """Metadata persisted alongside every snapshot as snapshot.json.
+
+    `command` records *what triggered this snapshot*: the destructive op name
+    (e.g. `vocab-regenerate`) for auto-snapshots, `manual` for hand-taken ones.
+    The `pre-` prefix lives only in the directory label, never in this field.
+    """
 
     created_at: datetime
     command: str
@@ -46,21 +58,35 @@ def snapshots_dir(data_dir: Path) -> Path:
     return data_dir / _SNAPSHOTS_DIRNAME
 
 
-def snapshot_create(data_dir: Path, *, command: str, name: str | None = None) -> Path:
-    """Create a snapshot directory inside data/snapshots/ and return its path.
+def snapshot_create(
+    data_dir: Path,
+    *,
+    command: str,
+    dir_label: str | None = None,
+) -> tuple[Path, SnapshotManifest]:
+    """Create a snapshot directory inside data/snapshots/.
 
-    Directory naming:
-      - if name is None: `<UTC-timestamp>-<command>` (command typically `manual` or `pre-<op>`)
-      - if name is set:  `<UTC-timestamp>-<name>`
+    - `command` is recorded in the manifest as the destructive-op name (e.g.
+      `vocab-regenerate`) or `manual` for hand-taken snapshots.
+    - `dir_label` becomes the human-readable suffix of the directory name. When
+      `None` it defaults to `command`. Auto-snapshots pass `pre-<command>` so
+      the directory listing makes the intent visible at a glance.
 
-    Copies every existing artifact + writes snapshot.json. Raises if the
-    snapshots dir is unwritable or any artifact copy fails — the caller is
-    expected to let that propagate (a snapshot failure must abort the
-    destructive op that triggered it).
+    Counts are read from the live `data/` files BEFORE any copy happens — a
+    corrupt artifact propagates as an exception (the destructive op that
+    triggered the snapshot must abort, not proceed with a lying manifest).
+
+    Returns the snapshot path and its parsed manifest.
     """
+    # Read counts first — corrupt artifacts propagate here, before any copy.
+    item_count = _count_json_dict(data_dir / "items.json")
+    topic_count = _count_json_dict(data_dir / "topics.json")
+    vocab_size = _count_vocab(data_dir / "vocab.yaml")
+
     now = datetime.now(timezone.utc)
-    timestamp = now.strftime("%Y-%m-%dT%H-%M-%SZ")
-    label = name if name is not None else command
+    # Millisecond precision avoids same-second collisions in scripted use.
+    timestamp = now.strftime("%Y-%m-%dT%H-%M-%S-") + f"{now.microsecond // 1000:03d}Z"
+    label = dir_label if dir_label is not None else command
     snapshot_dir = snapshots_dir(data_dir) / f"{timestamp}-{label}"
     snapshot_dir.mkdir(parents=True, exist_ok=False)
 
@@ -72,50 +98,40 @@ def snapshot_create(data_dir: Path, *, command: str, name: str | None = None) ->
     manifest = SnapshotManifest(
         created_at=now,
         command=command,
-        item_count=_count_items(data_dir),
-        topic_count=_count_topics(data_dir),
-        vocab_size=_count_vocab(data_dir),
+        item_count=item_count,
+        topic_count=topic_count,
+        vocab_size=vocab_size,
         xbrain_version=_xbrain_version(),
     )
     _atomic_write(
         snapshot_dir / _MANIFEST_FILENAME,
         manifest.model_dump_json(indent=2),
     )
-    return snapshot_dir
+    return snapshot_dir, manifest
 
 
-def snapshot_pre(data_dir: Path, *, command: str) -> Path:
-    """Snapshot before a destructive op. `command` is the op name (e.g. `vocab-regenerate`).
-
-    The directory is labelled `<ts>-pre-<command>` so the intent is obvious in `list`.
-    """
-    return snapshot_create(data_dir, command=f"pre-{command}")
-
-
-def snapshot_list(data_dir: Path) -> list[tuple[Path, SnapshotManifest]]:
+def snapshot_list(data_dir: Path) -> list[tuple[Path, SnapshotManifest | None]]:
     """Return every snapshot under data/snapshots/, newest first.
 
-    Snapshots without a readable manifest are skipped (defensive — never
-    crash the list view because of one bad directory).
+    Snapshots whose manifest is missing or unreadable are returned with
+    `manifest=None` and sorted to the end of the list — the caller decides
+    how to surface the corruption. A directory we cannot read is data the
+    user still needs to know exists.
     """
     root = snapshots_dir(data_dir)
     if not root.exists():
         return []
-    rows: list[tuple[Path, SnapshotManifest]] = []
+    rows: list[tuple[Path, SnapshotManifest | None]] = []
     for entry in root.iterdir():
         if not entry.is_dir():
             continue
-        manifest_path = entry / _MANIFEST_FILENAME
-        if not manifest_path.exists():
-            continue
-        try:
-            manifest = SnapshotManifest.model_validate_json(
-                manifest_path.read_text(encoding="utf-8")
-            )
-        except (ValueError, OSError):
-            continue
-        rows.append((entry, manifest))
-    rows.sort(key=lambda row: row[1].created_at, reverse=True)
+        rows.append((entry, _load_manifest(entry / _MANIFEST_FILENAME)))
+    # Corrupt entries (manifest=None) sort to the end via the sentinel epoch.
+    sentinel = datetime.min.replace(tzinfo=timezone.utc)
+    rows.sort(
+        key=lambda row: row[1].created_at if row[1] is not None else sentinel,
+        reverse=True,
+    )
     return rows
 
 
@@ -129,30 +145,44 @@ def snapshot_show(data_dir: Path, name: str) -> tuple[Path, SnapshotManifest]:
     return snapshot_dir, manifest
 
 
-def snapshot_restore(data_dir: Path, name: str) -> None:
-    """Replace data/<artifact> from the snapshot for each of the four artifacts.
+def snapshot_restore(data_dir: Path, name: str) -> list[tuple[str, str]]:
+    """Restore data/ artifacts from the snapshot. Returns the per-artifact actions.
 
-    Artifacts present in the snapshot are copied over the live files (atomically
-    via the existing _atomic_write pattern). Artifacts MISSING in the snapshot
-    cause the live file to be deleted — restoring a pre-vocab snapshot to a
-    repo that now has a vocab.yaml drops the live vocab.yaml.
+    For each of the four artifacts:
+      - if the snapshot has it → live file is replaced via `shutil.copy2`
+        (RESTORE_COPIED). Symmetric with `snapshot_create` and binary-safe.
+      - if the snapshot lacks it but the live file exists → live file is
+        deleted (RESTORE_DELETED) — restoring a pre-vocab snapshot to a repo
+        that now has a vocab.yaml drops the live vocab.yaml.
+      - if neither has it → noop (RESTORE_SKIPPED).
 
-    The snapshots/ subdir, auth/, the vault and any unrelated files are untouched.
+    Returns a list of (artifact, action) tuples so the CLI can echo every
+    decision. The function itself is silent — no print, no logging.
+
+    The snapshots/ subdir, auth/, the vault and any unrelated files are
+    untouched.
     """
     snapshot_dir, _ = snapshot_show(data_dir, name)
+    actions: list[tuple[str, str]] = []
     for artifact in _ARTIFACTS:
         src = snapshot_dir / artifact
         dst = data_dir / artifact
         if src.exists():
-            _atomic_write(dst, src.read_text(encoding="utf-8"))
+            shutil.copy2(src, dst)
+            actions.append((artifact, RESTORE_COPIED))
         elif dst.exists():
             dst.unlink()
+            actions.append((artifact, RESTORE_DELETED))
+        else:
+            actions.append((artifact, RESTORE_SKIPPED))
+    return actions
 
 
 def snapshot_prune(data_dir: Path, *, keep_last: int) -> int:
     """Delete all but the keep_last newest snapshots. Returns the count deleted.
 
-    `keep_last` must be >= 0. A value of 0 prunes everything.
+    `keep_last` must be >= 0. A value of 0 prunes everything. Corrupt
+    snapshots (manifest=None) sort to the end and are deleted first.
     """
     if keep_last < 0:
         raise ValueError(f"keep_last must be >= 0, got {keep_last}")
@@ -166,42 +196,43 @@ def snapshot_prune(data_dir: Path, *, keep_last: int) -> int:
 # --------------------------------------------------------------------- internals
 
 
-def _count_items(data_dir: Path) -> int:
-    return _count_json_dict(data_dir / "items.json")
+def _load_manifest(path: Path) -> SnapshotManifest | None:
+    """Read a manifest from disk; return None if missing or unreadable."""
+    if not path.exists():
+        return None
+    try:
+        return SnapshotManifest.model_validate_json(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return None
 
 
-def _count_topics(data_dir: Path) -> int:
-    return _count_json_dict(data_dir / "topics.json")
+def _count_json_dict(path: Path) -> int:
+    """Return len(json.load(path)) for a top-level dict, or 0 if the file is absent.
 
-
-def _count_vocab(data_dir: Path) -> int:
-    """Count topics in vocab.yaml. Mirrors load_vocab's shape contract."""
-    path = data_dir / "vocab.yaml"
+    A corrupt JSON file propagates the exception — `snapshot_create` callers
+    rely on this to abort the destructive op rather than persisting a manifest
+    with a falsely-zero count.
+    """
     if not path.exists():
         return 0
-    try:
-        import yaml
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return len(data) if isinstance(data, dict) else 0
 
-        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    except (yaml.YAMLError, OSError):
+
+def _count_vocab(path: Path) -> int:
+    """Count topics in a vocab.yaml file. Mirrors load_vocab's shape contract.
+
+    A corrupt YAML propagates the exception (same rationale as `_count_json_dict`).
+    """
+    if not path.exists():
         return 0
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     topics = data.get("topics", []) if isinstance(data, dict) else []
     return len(topics) if isinstance(topics, list) else 0
 
 
-def _count_json_dict(path: Path) -> int:
-    if not path.exists():
-        return 0
-    try:
-        import json
-
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except (ValueError, OSError):
-        return 0
-    return len(data) if isinstance(data, dict) else 0
-
-
 def _xbrain_version() -> str:
+    """Return the installed xbrain version, or 'unknown' if not packaged."""
     try:
         return metadata.version("xbrain")
     except metadata.PackageNotFoundError:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -4,16 +4,16 @@
 from __future__ import annotations
 
 import json
-import time
 from pathlib import Path
 
 import pytest
 
 from xbrain.snapshot import (
-    SnapshotManifest,
+    RESTORE_COPIED,
+    RESTORE_DELETED,
+    RESTORE_SKIPPED,
     snapshot_create,
     snapshot_list,
-    snapshot_pre,
     snapshot_prune,
     snapshot_restore,
     snapshot_show,
@@ -44,101 +44,174 @@ def test_snapshot_create_on_empty_data_dir(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
 
-    path = snapshot_create(data_dir, command="manual")
+    path, manifest = snapshot_create(data_dir, command="manual")
 
     assert path.exists()
     assert (path / "snapshot.json").exists()
-    # No artifacts to copy when data/ is empty
-    assert not (path / "items.json").exists()
-    manifest = SnapshotManifest.model_validate_json((path / "snapshot.json").read_text())
+    assert not (path / "items.json").exists()  # nothing to copy
     assert manifest.item_count == 0
     assert manifest.topic_count == 0
     assert manifest.vocab_size == 0
     assert manifest.command == "manual"
+    # xbrain_version is always populated (real version or 'unknown')
+    assert manifest.xbrain_version != ""
 
 
 def test_snapshot_create_copies_every_existing_artifact(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     _seed_data_dir(data_dir)
 
-    path = snapshot_create(data_dir, command="manual")
+    path, manifest = snapshot_create(data_dir, command="manual")
 
     for artifact in ("items.json", "state.json", "vocab.yaml", "topics.json"):
         assert (path / artifact).exists()
-    manifest = SnapshotManifest.model_validate_json((path / "snapshot.json").read_text())
     assert manifest.item_count == 2
     assert manifest.topic_count == 1
     assert manifest.vocab_size == 3
 
 
-def test_snapshot_pre_prefixes_command_with_pre(tmp_path: Path) -> None:
+def test_snapshot_create_uses_dir_label_for_directory_and_command_for_manifest(
+    tmp_path: Path,
+) -> None:
+    """dir_label drives the directory name; command drives manifest.command."""
     data_dir = tmp_path / "data"
     data_dir.mkdir()
 
-    path = snapshot_pre(data_dir, command="vocab-regenerate")
+    path, manifest = snapshot_create(
+        data_dir,
+        command="vocab-regenerate",
+        dir_label="pre-vocab-regenerate",
+    )
 
     assert "pre-vocab-regenerate" in path.name
-    manifest = SnapshotManifest.model_validate_json((path / "snapshot.json").read_text())
-    assert manifest.command == "pre-vocab-regenerate"
+    # manifest.command is the destructive op name only — no `pre-` prefix
+    assert manifest.command == "vocab-regenerate"
 
 
-def test_snapshot_create_with_name_uses_name_in_dirname(tmp_path: Path) -> None:
+def test_snapshot_create_dir_label_defaults_to_command(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
 
-    path = snapshot_create(data_dir, command="manual", name="milestone-v1")
+    path, _ = snapshot_create(data_dir, command="manual")
+
+    assert path.name.endswith("-manual")
+
+
+def test_snapshot_create_with_explicit_dir_label_uses_it(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    path, _ = snapshot_create(data_dir, command="manual", dir_label="milestone-v1")
 
     assert path.name.endswith("-milestone-v1")
+
+
+def test_snapshot_create_propagates_corrupt_json(tmp_path: Path) -> None:
+    """A corrupt items.json must abort the snapshot — not record count=0."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "items.json").write_text("not json at all", encoding="utf-8")
+
+    with pytest.raises(json.JSONDecodeError):
+        snapshot_create(data_dir, command="manual")
+    # No snapshot directory should have been created
+    assert not snapshots_dir(data_dir).exists() or list(snapshots_dir(data_dir).iterdir()) == []
+
+
+def test_snapshot_create_millisecond_precision_avoids_collisions(tmp_path: Path) -> None:
+    """Two snapshots in the same second must NOT collide on directory name."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    path_a, _ = snapshot_create(data_dir, command="manual", dir_label="a")
+    path_b, _ = snapshot_create(data_dir, command="manual", dir_label="b")
+
+    # No FileExistsError, both directories present
+    assert path_a.exists() and path_b.exists()
+    assert path_a != path_b
 
 
 def test_snapshot_list_returns_newest_first(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    snapshot_create(data_dir, command="manual", name="first")
-    time.sleep(1.1)  # ensure distinct timestamps at second granularity
-    snapshot_create(data_dir, command="manual", name="second")
+    snapshot_create(data_dir, command="manual", dir_label="first")
+    snapshot_create(data_dir, command="manual", dir_label="second")
 
     rows = snapshot_list(data_dir)
 
     assert len(rows) == 2
+    # Both should have a manifest; newest is `second`.
+    assert all(m is not None for _, m in rows)
     assert rows[0][0].name.endswith("-second")
     assert rows[1][0].name.endswith("-first")
 
 
-def test_snapshot_list_skips_directories_without_manifest(tmp_path: Path) -> None:
+def test_snapshot_list_returns_corrupt_dirs_with_none_manifest(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     snapshots_dir(data_dir).mkdir(parents=True)
-    (snapshots_dir(data_dir) / "bogus").mkdir()  # no manifest
-    snapshot_create(data_dir, command="manual", name="real")
+    bogus = snapshots_dir(data_dir) / "bogus"
+    bogus.mkdir()
+    snapshot_create(data_dir, command="manual", dir_label="real")
 
     rows = snapshot_list(data_dir)
 
-    assert len(rows) == 1
-    assert rows[0][0].name.endswith("-real")
+    assert len(rows) == 2
+    # Real one sorts first (newest); corrupt sorts last with manifest=None.
+    real_path, real_manifest = rows[0]
+    corrupt_path, corrupt_manifest = rows[1]
+    assert real_path.name.endswith("-real")
+    assert real_manifest is not None
+    assert corrupt_path == bogus
+    assert corrupt_manifest is None
 
 
-def test_snapshot_restore_brings_back_original_content(tmp_path: Path) -> None:
+def test_snapshot_restore_brings_back_all_four_artifacts(tmp_path: Path) -> None:
+    """Restore round-trip verifies every artifact, not just items.json."""
     data_dir = tmp_path / "data"
     _seed_data_dir(data_dir)
-    snap = snapshot_create(data_dir, command="manual", name="checkpoint")
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="checkpoint")
 
-    # Mutate items.json
+    # Mutate every artifact
     (data_dir / "items.json").write_text(json.dumps({"999": {"id": "999"}}), encoding="utf-8")
-    assert "999" in (data_dir / "items.json").read_text()
+    (data_dir / "state.json").write_text(json.dumps({"mutated": True}), encoding="utf-8")
+    (data_dir / "vocab.yaml").write_text("topics: []\n", encoding="utf-8")
+    (data_dir / "topics.json").write_text(json.dumps({}), encoding="utf-8")
 
-    snapshot_restore(data_dir, snap.name)
+    actions = snapshot_restore(data_dir, snap.name)
 
-    restored = json.loads((data_dir / "items.json").read_text())
-    assert set(restored) == {"1", "2"}
+    # All four came back to their pre-snapshot content
+    assert set(json.loads((data_dir / "items.json").read_text())) == {"1", "2"}
+    assert json.loads((data_dir / "state.json").read_text()) == {"bookmarks": {}}
+    assert "ai-coding" in (data_dir / "vocab.yaml").read_text()
+    assert "ai-coding" in (data_dir / "topics.json").read_text()
+    # Every artifact reported as copied
+    assert all(action == RESTORE_COPIED for _, action in actions)
+
+
+def test_snapshot_restore_returns_per_artifact_actions(tmp_path: Path) -> None:
+    """The action codes are observable so the CLI can echo every decision."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "items.json").write_text(json.dumps({"1": {}}), encoding="utf-8")
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="partial")
+
+    # Add a live vocab.yaml that the snapshot doesn't have
+    (data_dir / "vocab.yaml").write_text("topics: []\n", encoding="utf-8")
+
+    actions = snapshot_restore(data_dir, snap.name)
+
+    by_artifact = dict(actions)
+    assert by_artifact["items.json"] == RESTORE_COPIED
+    assert by_artifact["vocab.yaml"] == RESTORE_DELETED
+    assert by_artifact["state.json"] == RESTORE_SKIPPED
+    assert by_artifact["topics.json"] == RESTORE_SKIPPED
 
 
 def test_snapshot_restore_deletes_live_file_missing_from_snapshot(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    # Snapshot with no vocab.yaml present
-    snap = snapshot_create(data_dir, command="manual", name="pre-vocab")
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="pre-vocab")
 
-    # Now there IS a vocab.yaml — simulating "after vocab ran"
     (data_dir / "vocab.yaml").write_text(
         "topics:\n  - slug: ai-coding\n    description: x\n", encoding="utf-8"
     )
@@ -154,38 +227,65 @@ def test_snapshot_restore_does_not_touch_files_outside_artifacts(tmp_path: Path)
     data_dir.mkdir()
     sentinel = data_dir / "unrelated.txt"
     sentinel.write_text("important user data", encoding="utf-8")
-    snap = snapshot_create(data_dir, command="manual", name="check")
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="check")
 
     sentinel.write_text("mutated", encoding="utf-8")
     snapshot_restore(data_dir, snap.name)
 
-    # Restore must not touch files outside the four artifacts
     assert sentinel.read_text() == "mutated"
+
+
+def test_snapshot_restore_uses_copy2_preserving_metadata(tmp_path: Path) -> None:
+    """Symmetric with create: shutil.copy2, not text round-trip — binary-safe."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # Bytes that are not 7-bit ASCII but ARE valid UTF-8 — proves the path works
+    # for non-trivial content. A future binary artifact would also survive.
+    (data_dir / "items.json").write_text(
+        json.dumps({"é": "España 🇪🇸"}, ensure_ascii=False), encoding="utf-8"
+    )
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="utf")
+    original_bytes = (snap / "items.json").read_bytes()
+
+    (data_dir / "items.json").write_text("{}", encoding="utf-8")
+    snapshot_restore(data_dir, snap.name)
+
+    assert (data_dir / "items.json").read_bytes() == original_bytes
 
 
 def test_snapshot_prune_keeps_only_the_n_newest(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    for i in range(5):
-        snapshot_create(data_dir, command="manual", name=f"s{i}")
-        time.sleep(1.05)
+    paths = [snapshot_create(data_dir, command="manual", dir_label=f"s{i}")[0] for i in range(5)]
 
     deleted = snapshot_prune(data_dir, keep_last=2)
 
     rows = snapshot_list(data_dir)
     assert deleted == 3
     assert len(rows) == 2
-    # The two newest should remain — s4 and s3
-    names = {row[0].name for row in rows}
-    assert any(n.endswith("-s4") for n in names)
-    assert any(n.endswith("-s3") for n in names)
+    # The two newest should remain — the last two created
+    remaining = {row[0] for row in rows}
+    assert remaining == {paths[3], paths[4]}
+
+
+def test_snapshot_prune_with_fewer_than_keep_last(tmp_path: Path) -> None:
+    """No-op when there are fewer snapshots than keep_last."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    snapshot_create(data_dir, command="manual", dir_label="a")
+    snapshot_create(data_dir, command="manual", dir_label="b")
+
+    deleted = snapshot_prune(data_dir, keep_last=10)
+
+    assert deleted == 0
+    assert len(snapshot_list(data_dir)) == 2
 
 
 def test_snapshot_prune_zero_keeps_nothing(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     data_dir.mkdir()
-    snapshot_create(data_dir, command="manual", name="a")
-    snapshot_create(data_dir, command="manual", name="b")
+    snapshot_create(data_dir, command="manual", dir_label="a")
+    snapshot_create(data_dir, command="manual", dir_label="b")
 
     deleted = snapshot_prune(data_dir, keep_last=0)
 
@@ -212,9 +312,21 @@ def test_snapshot_show_raises_for_unknown_snapshot(tmp_path: Path) -> None:
 def test_snapshot_show_returns_manifest_for_known_snapshot(tmp_path: Path) -> None:
     data_dir = tmp_path / "data"
     _seed_data_dir(data_dir)
-    snap = snapshot_create(data_dir, command="manual", name="known")
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="known")
 
     snap_path, manifest = snapshot_show(data_dir, snap.name)
 
     assert snap_path == snap
     assert manifest.item_count == 2
+
+
+def test_manifest_records_xbrain_version(tmp_path: Path) -> None:
+    """PRD §5 requires xbrain_version in the manifest."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    _, manifest = snapshot_create(data_dir, command="manual")
+
+    # Either a real version or the fallback — never empty
+    assert manifest.xbrain_version != ""
+    assert isinstance(manifest.xbrain_version, str)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,220 @@
+# tests/test_snapshot.py
+"""Unit tests for xbrain.snapshot — pure I/O, no CLI, no mocking the FS."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from xbrain.snapshot import (
+    SnapshotManifest,
+    snapshot_create,
+    snapshot_list,
+    snapshot_pre,
+    snapshot_prune,
+    snapshot_restore,
+    snapshot_show,
+    snapshots_dir,
+)
+
+
+def _seed_data_dir(data_dir: Path) -> None:
+    """Populate data_dir with realistic, parseable artifacts."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "items.json").write_text(
+        json.dumps({"1": {"id": "1"}, "2": {"id": "2"}}), encoding="utf-8"
+    )
+    (data_dir / "state.json").write_text(json.dumps({"bookmarks": {}}), encoding="utf-8")
+    (data_dir / "vocab.yaml").write_text(
+        "topics:\n"
+        "  - slug: ai-coding\n    description: foo\n"
+        "  - slug: software\n    description: bar\n"
+        "  - slug: misc\n    description: baz\n",
+        encoding="utf-8",
+    )
+    (data_dir / "topics.json").write_text(
+        json.dumps({"ai-coding": {"slug": "ai-coding"}}), encoding="utf-8"
+    )
+
+
+def test_snapshot_create_on_empty_data_dir(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    path = snapshot_create(data_dir, command="manual")
+
+    assert path.exists()
+    assert (path / "snapshot.json").exists()
+    # No artifacts to copy when data/ is empty
+    assert not (path / "items.json").exists()
+    manifest = SnapshotManifest.model_validate_json((path / "snapshot.json").read_text())
+    assert manifest.item_count == 0
+    assert manifest.topic_count == 0
+    assert manifest.vocab_size == 0
+    assert manifest.command == "manual"
+
+
+def test_snapshot_create_copies_every_existing_artifact(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _seed_data_dir(data_dir)
+
+    path = snapshot_create(data_dir, command="manual")
+
+    for artifact in ("items.json", "state.json", "vocab.yaml", "topics.json"):
+        assert (path / artifact).exists()
+    manifest = SnapshotManifest.model_validate_json((path / "snapshot.json").read_text())
+    assert manifest.item_count == 2
+    assert manifest.topic_count == 1
+    assert manifest.vocab_size == 3
+
+
+def test_snapshot_pre_prefixes_command_with_pre(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    path = snapshot_pre(data_dir, command="vocab-regenerate")
+
+    assert "pre-vocab-regenerate" in path.name
+    manifest = SnapshotManifest.model_validate_json((path / "snapshot.json").read_text())
+    assert manifest.command == "pre-vocab-regenerate"
+
+
+def test_snapshot_create_with_name_uses_name_in_dirname(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    path = snapshot_create(data_dir, command="manual", name="milestone-v1")
+
+    assert path.name.endswith("-milestone-v1")
+
+
+def test_snapshot_list_returns_newest_first(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    snapshot_create(data_dir, command="manual", name="first")
+    time.sleep(1.1)  # ensure distinct timestamps at second granularity
+    snapshot_create(data_dir, command="manual", name="second")
+
+    rows = snapshot_list(data_dir)
+
+    assert len(rows) == 2
+    assert rows[0][0].name.endswith("-second")
+    assert rows[1][0].name.endswith("-first")
+
+
+def test_snapshot_list_skips_directories_without_manifest(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    snapshots_dir(data_dir).mkdir(parents=True)
+    (snapshots_dir(data_dir) / "bogus").mkdir()  # no manifest
+    snapshot_create(data_dir, command="manual", name="real")
+
+    rows = snapshot_list(data_dir)
+
+    assert len(rows) == 1
+    assert rows[0][0].name.endswith("-real")
+
+
+def test_snapshot_restore_brings_back_original_content(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _seed_data_dir(data_dir)
+    snap = snapshot_create(data_dir, command="manual", name="checkpoint")
+
+    # Mutate items.json
+    (data_dir / "items.json").write_text(json.dumps({"999": {"id": "999"}}), encoding="utf-8")
+    assert "999" in (data_dir / "items.json").read_text()
+
+    snapshot_restore(data_dir, snap.name)
+
+    restored = json.loads((data_dir / "items.json").read_text())
+    assert set(restored) == {"1", "2"}
+
+
+def test_snapshot_restore_deletes_live_file_missing_from_snapshot(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    # Snapshot with no vocab.yaml present
+    snap = snapshot_create(data_dir, command="manual", name="pre-vocab")
+
+    # Now there IS a vocab.yaml — simulating "after vocab ran"
+    (data_dir / "vocab.yaml").write_text(
+        "topics:\n  - slug: ai-coding\n    description: x\n", encoding="utf-8"
+    )
+    assert (data_dir / "vocab.yaml").exists()
+
+    snapshot_restore(data_dir, snap.name)
+
+    assert not (data_dir / "vocab.yaml").exists()
+
+
+def test_snapshot_restore_does_not_touch_files_outside_artifacts(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    sentinel = data_dir / "unrelated.txt"
+    sentinel.write_text("important user data", encoding="utf-8")
+    snap = snapshot_create(data_dir, command="manual", name="check")
+
+    sentinel.write_text("mutated", encoding="utf-8")
+    snapshot_restore(data_dir, snap.name)
+
+    # Restore must not touch files outside the four artifacts
+    assert sentinel.read_text() == "mutated"
+
+
+def test_snapshot_prune_keeps_only_the_n_newest(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    for i in range(5):
+        snapshot_create(data_dir, command="manual", name=f"s{i}")
+        time.sleep(1.05)
+
+    deleted = snapshot_prune(data_dir, keep_last=2)
+
+    rows = snapshot_list(data_dir)
+    assert deleted == 3
+    assert len(rows) == 2
+    # The two newest should remain — s4 and s3
+    names = {row[0].name for row in rows}
+    assert any(n.endswith("-s4") for n in names)
+    assert any(n.endswith("-s3") for n in names)
+
+
+def test_snapshot_prune_zero_keeps_nothing(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    snapshot_create(data_dir, command="manual", name="a")
+    snapshot_create(data_dir, command="manual", name="b")
+
+    deleted = snapshot_prune(data_dir, keep_last=0)
+
+    assert deleted == 2
+    assert snapshot_list(data_dir) == []
+
+
+def test_snapshot_prune_rejects_negative_keep_last(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    with pytest.raises(ValueError):
+        snapshot_prune(data_dir, keep_last=-1)
+
+
+def test_snapshot_show_raises_for_unknown_snapshot(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError):
+        snapshot_show(data_dir, "does-not-exist")
+
+
+def test_snapshot_show_returns_manifest_for_known_snapshot(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    _seed_data_dir(data_dir)
+    snap = snapshot_create(data_dir, command="manual", name="known")
+
+    snap_path, manifest = snapshot_show(data_dir, snap.name)
+
+    assert snap_path == snap
+    assert manifest.item_count == 2

--- a/tests/test_snapshot_auto.py
+++ b/tests/test_snapshot_auto.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from typer.testing import CliRunner
 
+from xbrain import snapshot as snapshot_mod
 from xbrain.cli import app
 from xbrain.models import Author, Item, Link
 from xbrain.snapshot import snapshot_list
@@ -203,3 +204,134 @@ def test_snapshot_prune_cli_deletes_older(tmp_path: Path, monkeypatch):
 
     assert result.exit_code == 0, result.stdout
     assert len(snapshot_list(tmp_path / "data")) == 2
+
+
+# --------------------------------------------------------------------- ordering
+
+
+def test_snapshot_taken_before_mutation_when_destructive_op_fails(tmp_path: Path, monkeypatch):
+    """PRD-mandated: the snapshot must already be on disk if the destructive op fails.
+
+    Forces `_mark_for_regenerate` to raise, then asserts (a) the destructive op
+    exits non-zero, (b) the pre-snapshot directory already exists, (c)
+    items.json is unchanged from the pre-snapshot content. The safety net would
+    silently break if the snapshot were taken AFTER the mutation.
+    """
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    _write_vocab(tmp_path)
+
+    worksheet = tmp_path / "data" / "vocab-worksheet.json"
+    worksheet.write_text(
+        json.dumps(
+            {"topics": [{"slug": "misc", "description": "Posts that do not fit a specific topic."}]}
+        ),
+        encoding="utf-8",
+    )
+
+    # Force the mutation step (after the snapshot) to raise
+    def _explode(*_args, **_kwargs):
+        raise RuntimeError("simulated mutation failure")
+
+    monkeypatch.setattr("xbrain.cli._mark_for_regenerate", _explode)
+
+    result = runner.invoke(app, ["vocab", "--apply", str(worksheet), "--regenerate"])
+
+    assert result.exit_code != 0  # the mutation failure aborted the command
+    snapshots = snapshot_list(tmp_path / "data")
+    assert any(p.name.endswith("-pre-vocab-regenerate") for p, _ in snapshots), result.stderr
+    # The pre-snapshot retained the pre-mutation items.json content
+    items = json.loads((tmp_path / "data" / "items.json").read_text())
+    assert set(items) == {"1"}
+
+
+def test_snapshot_failure_aborts_destructive_op(tmp_path: Path, monkeypatch):
+    """PRD §5: a failed snapshot creation aborts the destructive op.
+
+    Forces `snapshot.snapshot_create` itself to raise — verifies the
+    destructive op exits non-zero and no mutation occurred.
+    """
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+
+    def _broken(*_args, **_kwargs):
+        raise OSError("simulated snapshot failure (disk full)")
+
+    monkeypatch.setattr(snapshot_mod, "snapshot_create", _broken)
+
+    result = runner.invoke(app, ["fetch", "--force"])
+
+    assert result.exit_code != 0
+    # No snapshot was created; nothing was fetched / mutated
+    assert snapshot_list(tmp_path / "data") == []
+
+
+# --------------------------------------------------------------------- CLI verbs (cont'd)
+
+
+def test_snapshot_show_cli_prints_manifest_json(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    runner.invoke(app, ["snapshot", "create", "--name", "showme"])
+
+    name = next(p.name for p, _ in snapshot_list(tmp_path / "data"))
+    result = runner.invoke(app, ["snapshot", "show", name])
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.stdout)
+    assert parsed["item_count"] == 1
+    assert parsed["command"] == "manual"
+
+
+def test_snapshot_restore_cli_echoes_per_artifact_actions(tmp_path: Path, monkeypatch):
+    """The restore CLI must echo every per-artifact action (no silent deletes)."""
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    runner.invoke(app, ["snapshot", "create", "--name", "pre-vocab"])
+
+    # After the snapshot, add a vocab.yaml the snapshot doesn't have
+    (tmp_path / "data" / "vocab.yaml").write_text(
+        "topics:\n  - slug: misc\n    description: x\n", encoding="utf-8"
+    )
+
+    name = next(p.name for p, _ in snapshot_list(tmp_path / "data"))
+    result = runner.invoke(app, ["snapshot", "restore", name])
+
+    assert result.exit_code == 0, result.stdout
+    # The action codes must be visible to the user
+    assert "items.json: copied" in result.stdout
+    assert "vocab.yaml: deleted" in result.stdout
+    # And the live vocab.yaml is gone
+    assert not (tmp_path / "data" / "vocab.yaml").exists()
+
+
+def test_snapshot_list_cli_marks_corrupt_dirs(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    runner.invoke(app, ["snapshot", "create", "--name", "good"])
+    # A directory with no manifest = corrupt
+    (tmp_path / "data" / "snapshots" / "bogus-dir").mkdir(parents=True)
+
+    result = runner.invoke(app, ["snapshot", "list"])
+
+    assert result.exit_code == 0
+    assert "-good" in result.stdout
+    # CORRUPT lines land on stderr (visible in mixed-stream CliRunner output)
+    combined = result.stdout + (result.stderr or "")
+    assert "CORRUPT" in combined
+
+
+def test_auto_snapshot_stdout_includes_item_count(tmp_path: Path, monkeypatch):
+    """PRD §5 observability: 'Snapshot created: <path> (N items)'."""
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+
+    item = _linked_item("1")
+    item.links = []
+    save_store({"1": item}, tmp_path / "data" / "items.json")
+
+    result = runner.invoke(app, ["fetch", "--force"])
+
+    assert result.exit_code == 0, result.stdout
+    assert "Snapshot created" in result.stdout
+    assert "1 items" in result.stdout

--- a/tests/test_snapshot_auto.py
+++ b/tests/test_snapshot_auto.py
@@ -1,0 +1,205 @@
+# tests/test_snapshot_auto.py
+"""Integration tests for the auto-snapshot hooks in cli.py.
+
+Every destructive flag (`vocab --regenerate`, `topics --resynth`,
+`fetch --force`) must create exactly one snapshot under data/snapshots/
+before any mutation happens. Non-destructive runs must not.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from xbrain.cli import app
+from xbrain.models import Author, Item, Link
+from xbrain.snapshot import snapshot_list
+from xbrain.store import save_store
+
+runner = CliRunner()
+
+
+def _setup_repo(tmp_path: Path, monkeypatch) -> Path:
+    """Mirror of tests/test_cli.py: minimal config.toml + data dir, repo root via env."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (tmp_path / "config.toml").write_text(
+        "[paths]\n"
+        f'vault = "{vault}"\n'
+        'output_subdir = "x-knowledge"\n'
+        'data_dir = "data"\n'
+        "[x]\n"
+        'handle = "vgonpa"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "data").mkdir()
+    monkeypatch.setenv("XBRAIN_REPO_ROOT", str(tmp_path))
+    return vault
+
+
+def _linked_item(item_id: str = "1") -> Item:
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="alice", name="Alice"),
+        text=f"Note {item_id}",
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url="https://example.com/p", domain="example.com")],
+    )
+
+
+def _write_vocab(tmp_path: Path) -> None:
+    """Write a minimal vocab.yaml (load_vocab expects `topics:` root key)."""
+    (tmp_path / "data" / "vocab.yaml").write_text(
+        "topics:\n  - slug: misc\n    description: Posts that do not fit a specific topic.\n",
+        encoding="utf-8",
+    )
+
+
+def test_vocab_regenerate_with_worksheet_creates_pre_snapshot(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    _write_vocab(tmp_path)
+
+    # Build a minimal vocab worksheet that satisfies apply_vocab_worksheet
+    # (the loader expects a flat `topics` list at the JSON root)
+    worksheet = tmp_path / "data" / "vocab-worksheet.json"
+    worksheet.write_text(
+        json.dumps(
+            {"topics": [{"slug": "misc", "description": "Posts that do not fit a specific topic."}]}
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["vocab", "--apply", str(worksheet), "--regenerate"])
+
+    assert result.exit_code == 0, result.stdout
+    snapshots = snapshot_list(tmp_path / "data")
+    assert any(p.name.endswith("-pre-vocab-regenerate") for p, _ in snapshots), snapshots
+
+
+def test_vocab_without_regenerate_creates_no_snapshot(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+
+    # vocab without --regenerate, claude-code executor (worksheet export, no mutation
+    # outside writing vocab-worksheet.json, which is not an artifact under snapshot scope)
+    result = runner.invoke(app, ["vocab", "--executor", "claude-code"])
+
+    assert result.exit_code == 0, result.stdout
+    snapshots = snapshot_list(tmp_path / "data")
+    assert snapshots == []
+
+
+def test_topics_resynth_creates_pre_snapshot(tmp_path: Path, monkeypatch):
+    vault = _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    _write_vocab(tmp_path)
+    (vault / "x-knowledge").mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(app, ["topics", "--resynth", "--executor", "manual"])
+
+    # Topics may succeed or report nothing pending; either way the snapshot
+    # must have been taken before the resynth path branched.
+    assert result.exit_code == 0, result.stdout
+    snapshots = snapshot_list(tmp_path / "data")
+    assert any(p.name.endswith("-pre-topics-resynth") for p, _ in snapshots), snapshots
+
+
+def test_topics_without_resynth_creates_no_snapshot(tmp_path: Path, monkeypatch):
+    vault = _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    _write_vocab(tmp_path)
+    (vault / "x-knowledge").mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(app, ["topics", "--executor", "manual"])
+
+    assert result.exit_code == 0, result.stdout
+    assert snapshot_list(tmp_path / "data") == []
+
+
+def test_fetch_force_creates_pre_snapshot(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    # An item with no links → fetch_pending no-ops; the snapshot still fires
+    item = _linked_item("1")
+    item.links = []
+    save_store({"1": item}, tmp_path / "data" / "items.json")
+
+    result = runner.invoke(app, ["fetch", "--force"])
+
+    assert result.exit_code == 0, result.stdout
+    snapshots = snapshot_list(tmp_path / "data")
+    assert any(p.name.endswith("-pre-fetch-force") for p, _ in snapshots), snapshots
+
+
+def test_fetch_without_force_creates_no_snapshot(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    item = _linked_item("1")
+    item.links = []
+    save_store({"1": item}, tmp_path / "data" / "items.json")
+
+    result = runner.invoke(app, ["fetch"])
+
+    assert result.exit_code == 0, result.stdout
+    assert snapshot_list(tmp_path / "data") == []
+
+
+def test_snapshot_create_cli_writes_manifest(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+
+    result = runner.invoke(app, ["snapshot", "create", "--name", "before-rubric-v2"])
+
+    assert result.exit_code == 0, result.stdout
+    snapshots = snapshot_list(tmp_path / "data")
+    assert len(snapshots) == 1
+    assert snapshots[0][0].name.endswith("-before-rubric-v2")
+    assert snapshots[0][1].item_count == 1
+
+
+def test_snapshot_list_cli_reports_each_snapshot(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    runner.invoke(app, ["snapshot", "create", "--name", "a"])
+    runner.invoke(app, ["snapshot", "create", "--name", "b"])
+
+    result = runner.invoke(app, ["snapshot", "list"])
+
+    assert result.exit_code == 0
+    assert "-a" in result.stdout
+    assert "-b" in result.stdout
+
+
+def test_snapshot_restore_cli_brings_back_items(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+
+    create = runner.invoke(app, ["snapshot", "create", "--name", "checkpoint"])
+    assert create.exit_code == 0
+
+    # Mutate items.json out from under us
+    save_store({}, tmp_path / "data" / "items.json")
+
+    name = next(p.name for p, _ in snapshot_list(tmp_path / "data"))
+    restore = runner.invoke(app, ["snapshot", "restore", name])
+
+    assert restore.exit_code == 0, restore.stdout
+    data = json.loads((tmp_path / "data" / "items.json").read_text())
+    assert set(data) == {"1"}
+
+
+def test_snapshot_prune_cli_deletes_older(tmp_path: Path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    for i in range(4):
+        runner.invoke(app, ["snapshot", "create", "--name", f"s{i}"])
+
+    result = runner.invoke(app, ["snapshot", "prune", "--keep-last", "2"])
+
+    assert result.exit_code == 0, result.stdout
+    assert len(snapshot_list(tmp_path / "data")) == 2


### PR DESCRIPTION
Closes #17.

## Summary

A safety net for the three destructive XBrain commands. Before any of
`vocab --regenerate`, `topics --resynth` or `fetch --force` writes a byte,
the full `data/` directory is copied to `data/snapshots/<UTC-ts>-pre-<op>/`
with a `snapshot.json` manifest. A bad re-run is now one command away from
recovery: `xbrain snapshot restore <name>`.

This is also the foundation for **#18** (`xbrain diff` — compare two
snapshots, surface unexpected drift). Without snapshots, no diff.

## What ships

- **New `xbrain.snapshot` module** — pure lifecycle: `snapshot_create`,
  `snapshot_pre`, `snapshot_list`, `snapshot_show`, `snapshot_restore`,
  `snapshot_prune`. Pydantic manifest with counts, command, UTC timestamp,
  `xbrain_version`.
- **Five new CLI verbs**: `xbrain snapshot {create,list,show,restore,prune}`.
- **Auto-snapshot hooks** wired into the three destructive code paths in
  `cli.py`. A snapshot failure propagates and aborts the destructive op —
  never silently skipped.
- **Vault not snapshotted** (it is fully derivable from `data/` via `xbrain generate`).

## Spec deviation (worth flagging)

The PRD listed four destructive sites including `enrich --regenerate`. The
CLI has no such flag — re-enrichment is triggered via `vocab --regenerate`,
which already calls `_mark_for_regenerate`. Three sites in total, not four.

## Tests

| Suite | Count | Why |
|-------|-------|-----|
| `tests/test_snapshot.py` | 14 | Unit tests on the module. Empty data, full data, naming, list ordering, restore round-trip, restore deletes a live file missing from the snapshot, prune keep-last, prune=0, prune rejects negative, show on unknown raises. |
| `tests/test_snapshot_auto.py` | 10 | Integration via `CliRunner`. Each destructive flag creates the expected `pre-<op>` snapshot; absence of the flag creates none; every `snapshot` verb exercised end-to-end. |

**Total:** 245 tests (up from 235). **Coverage:** 87% (no regression).
**`uv run poe check`:** all-green (the existing Radon C and Deptry warns
are pre-existing on `develop`, not introduced here).

## Docs

- **README:** new `snapshot` row in Commands; new "Snapshots & safety" section
  with `xbrain snapshot list/create/restore/prune` examples; linked from TOC.
- **ARCHITECTURE:** new invariant #8 ("destructive ops are reversible"); each
  destructive step card carries a "Snapshots `data/` before `--flag`" bullet;
  `snapshot.py` listed in "Where things live".

## Specs

- PRD: `vault/zz-support-files/docs/prds/2026-05-21-xbrain-17-auto-snapshot.md`
- Plan: `vault/zz-support-files/docs/implementation-plans/2026-05-21-xbrain-17-auto-snapshot.md`

## Test plan

- [x] Unit tests on the snapshot module
- [x] Integration tests for auto-snapshot wiring on each destructive command
- [x] CLI verbs exercised end-to-end via CliRunner
- [x] `uv run poe check` all-green
- [x] README + ARCHITECTURE updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)