### PR TITLE
[#13] Optional: render topics as Obsidian #hashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,11 @@ Code Is Cheap Now. Software Isn't.  https://t.co/J9m5RzQNbW
 Everything above the `xbrain:generated` marker is regenerated on every run;
 anything *you* write below it is preserved.
 
+> Set `[output] topic_style = "hashtag"` in `config.toml` to render the
+> in-body `**Topics:**` line as `#ai-coding #software-engineering` instead of
+> wikilinks — useful if you navigate primarily via Obsidian's tag pane. The
+> frontmatter `tags:` are native Obsidian tags in either mode.
+
 ### Layer 2 — Topics
 
 The layer that makes XBrain more than a tidy backup. **A topic page is not a
@@ -377,6 +382,7 @@ resynth_threshold = 25                    # re-synthesise an overview after N ne
 
 [output]
 language = "English"                      # English | Spanish
+topic_style = "wikilink"                  # wikilink | hashtag (in-body Topics: line)
 ```
 
 | Section | Key | Default | Purpose |
@@ -390,6 +396,7 @@ language = "English"                      # English | Spanish
 | `[vocab]` | `target_count` | `30` | Number of topics the `vocab` stage induces. |
 | `[topics]` | `resynth_threshold` | `25` | Post growth that marks a topic overview stale. |
 | `[output]` | `language` | `English` | Output language for LLM summaries/overviews AND wiki section headers. `English` or `Spanish`. |
+| `[output]` | `topic_style` | `wikilink` | How the in-body `**Topics:**` line is rendered: `wikilink` (`[[slug]] · [[slug]]`) or `hashtag` (`#slug #slug`). Frontmatter `tags:` are unaffected. |
 
 Switching `[output].language` after the corpus is already enriched is supported
 — but does not retroactively translate existing summaries. To convert the

--- a/config.toml.example
+++ b/config.toml.example
@@ -34,3 +34,8 @@ resynth_threshold = 25
 #   "English" - default
 #   "Spanish"
 language = "English"
+# How the in-body `**Topics:**` line is rendered on each item note.
+# Frontmatter `tags:` are unaffected by this setting. Supported values:
+#   "wikilink" - **Topics:** [[ai-coding]] · [[software-engineering]]  (default)
+#   "hashtag"  - **Topics:** #ai-coding #software-engineering
+topic_style = "wikilink"

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -191,7 +191,7 @@ def _run_fetch(cfg: Config, since: datetime | None, until: datetime | None, forc
 
 def _run_generate(cfg: Config, since: datetime | None, until: datetime | None) -> None:
     store = load_store(cfg.items_path)
-    run_generate(store, cfg.output_dir, since, until, cfg.output_language)
+    run_generate(store, cfg.output_dir, since, until, cfg.output_language, cfg.topic_style)
     typer.echo(f"Markdown generado en {cfg.output_dir}")
 
 

--- a/src/xbrain/config.py
+++ b/src/xbrain/config.py
@@ -10,6 +10,11 @@ from typing import get_args
 from xbrain.i18n import strings_for
 from xbrain.models import ExecutorName
 
+# In-body `**Topics:**` line styles. `wikilink` (default) keeps the current
+# navigation-first behaviour; `hashtag` emits Obsidian tags so the line pivots
+# into the tag pane. Frontmatter `tags:` are unaffected by this toggle.
+SUPPORTED_TOPIC_STYLES: tuple[str, ...] = ("wikilink", "hashtag")
+
 
 @dataclass(frozen=True)
 class Config:
@@ -23,6 +28,7 @@ class Config:
     vocab_target_count: int
     topics_resynth_threshold: int
     output_language: str  # one of xbrain.i18n.SUPPORTED_LANGUAGES
+    topic_style: str  # one of xbrain.config.SUPPORTED_TOPIC_STYLES
 
     @property
     def items_path(self) -> Path:
@@ -64,10 +70,17 @@ def load_config(repo_root: Path) -> Config:
     resynth_threshold = int(topics.get("resynth_threshold", 25))
     if resynth_threshold < 1:
         raise ValueError("config.toml: [topics].resynth_threshold must be >= 1")
-    output_language = settings.get("output", {}).get("language", "English")
+    output = settings.get("output", {})
+    output_language = output.get("language", "English")
     # Validate via strings_for: it already raises ValueError listing supported
     # languages on an unknown value. Single source of truth for the check.
     strings_for(output_language)
+    topic_style = output.get("topic_style", "wikilink")
+    if topic_style not in SUPPORTED_TOPIC_STYLES:
+        raise ValueError(
+            f"config.toml: [output].topic_style must be one of "
+            f"{list(SUPPORTED_TOPIC_STYLES)}, got {topic_style!r}"
+        )
     return Config(
         repo_root=repo_root,
         vault=vault,
@@ -79,4 +92,5 @@ def load_config(repo_root: Path) -> Config:
         vocab_target_count=target_count,
         topics_resynth_threshold=resynth_threshold,
         output_language=output_language,
+        topic_style=topic_style,
     )

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -6,6 +6,7 @@ import logging
 from datetime import datetime, timezone
 from pathlib import Path
 
+from xbrain.config import SUPPORTED_TOPIC_STYLES
 from xbrain.i18n import Strings, strings_for
 from xbrain.models import Content, ContentSource, FailureReason, Item
 from xbrain.notes_io import DEFAULT_TAIL, note_filename, slugify, title_of, user_tail, wrap
@@ -41,6 +42,7 @@ def generate(
     since: datetime | None = None,
     until: datetime | None = None,
     output_language: str = "English",
+    topic_style: str = "wikilink",
 ) -> None:
     """Write _index.md, log.md and one note per noted item.
 
@@ -48,7 +50,17 @@ def generate(
     index and log always reflect the whole store; `since`/`until` only narrow
     which item notes are (re)generated. `output_language` drives the section
     headers (Topics:, Content:, Summary, ...) via `xbrain.i18n`.
+
+    `topic_style` controls how the in-body ``**Topics:**`` line is rendered:
+    ``"wikilink"`` (default) emits ``[[slug]]`` links, ``"hashtag"`` emits
+    Obsidian ``#slug`` tags. The toggle does not affect frontmatter ``tags:``,
+    the index ``## Topics`` section, or the topic-page post lists — those
+    stay wikilinks by design.
     """
+    if topic_style not in SUPPORTED_TOPIC_STYLES:
+        raise ValueError(
+            f"Unsupported topic_style: {topic_style!r}. Supported: {SUPPORTED_TOPIC_STYLES}"
+        )
     strings = strings_for(output_language)
     items = sorted(store.values(), key=lambda i: i.created_at, reverse=True)
     items_dir = output_dir / "items"
@@ -57,7 +69,7 @@ def generate(
     (output_dir / "log.md").write_text(_render_log(items), encoding="utf-8")
     for item in items:
         if _has_note(item) and _in_range(item, since, until):
-            _write_note(items_dir, item, strings)
+            _write_note(items_dir, item, strings, topic_style)
 
 
 def _has_note(item: Item) -> bool:
@@ -73,7 +85,7 @@ def _in_range(item: Item, since: datetime | None, until: datetime | None) -> boo
     return True
 
 
-def _write_note(items_dir: Path, item: Item, strings: Strings) -> None:
+def _write_note(items_dir: Path, item: Item, strings: Strings, topic_style: str) -> None:
     """Write an item's note, replacing only the generated region.
 
     The filename ends with the item's globally unique ``id``. That makes
@@ -83,7 +95,7 @@ def _write_note(items_dir: Path, item: Item, strings: Strings) -> None:
     orphaned.
     """
     path = items_dir / note_filename(item)
-    block = wrap(_render_note(item, strings))
+    block = wrap(_render_note(item, strings, topic_style))
     source = path if path.exists() else _stale_note(items_dir, item, path)
     if source is not None:
         tail = user_tail(source.read_text(encoding="utf-8"), DEFAULT_TAIL)
@@ -109,16 +121,29 @@ def _stale_note(items_dir: Path, item: Item, current: Path) -> Path | None:
     return None
 
 
-def _enrichment_lines(item: Item, strings: Strings) -> list[str]:
-    """Summary + topic links for an enriched item (empty if not enriched)."""
+def _enrichment_lines(item: Item, strings: Strings, topic_style: str) -> list[str]:
+    """Summary + topic refs for an enriched item (empty if not enriched).
+
+    `topic_style` selects the in-body topic-line rendering:
+    - ``"wikilink"`` → ``**Topics:** [[ai-coding]] · [[software-engineering]]``
+    - ``"hashtag"``  → ``**Topics:** #ai-coding #software-engineering``
+
+    The hashtag mode uses a bare space as separator: Obsidian's tag parser
+    consumes a trailing middle-dot as part of the tag boundary on some
+    renderers, which produces broken tags. Frontmatter ``tags:`` are emitted
+    by ``_frontmatter`` and are independent of this toggle.
+    """
     if not item.enriched:
         return []
     lines: list[str] = []
     if item.enriched.summary:
         lines += [item.enriched.summary, ""]
     if item.enriched.topics:
-        links = " · ".join(f"[[{t}]]" for t in item.enriched.topics)
-        lines += [f"**{strings.topics_label}:** {links}", ""]
+        if topic_style == "hashtag":
+            refs = " ".join(f"#{t}" for t in item.enriched.topics)
+        else:
+            refs = " · ".join(f"[[{t}]]" for t in item.enriched.topics)
+        lines += [f"**{strings.topics_label}:** {refs}", ""]
     return lines
 
 
@@ -134,9 +159,9 @@ def _content_lines(content: Content, strings: Strings) -> list[str]:
     return lines
 
 
-def _render_note(item: Item, strings: Strings) -> str:
+def _render_note(item: Item, strings: Strings, topic_style: str) -> str:
     lines = [_frontmatter(item), "", f"# {title_of(item)}", ""]
-    lines += _enrichment_lines(item, strings)
+    lines += _enrichment_lines(item, strings, topic_style)
     lines += ["## Tweet", "", item.text, ""]
     if item.links:
         lines.append("## Enlaces")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -154,3 +154,44 @@ def test_config_topics_threshold_is_configurable(tmp_path):
         encoding="utf-8",
     )
     assert load_config(tmp_path).topics_resynth_threshold == 50
+
+
+def test_load_config_defaults_topic_style_to_wikilink(tmp_path: Path):
+    """No `[output] topic_style` key → wikilink default (backwards-compat)."""
+    _write_repo(tmp_path)
+    cfg = load_config(tmp_path)
+    assert cfg.topic_style == "wikilink"
+
+
+def test_load_config_round_trips_hashtag_topic_style(tmp_path: Path):
+    """Explicit `topic_style = "hashtag"` round-trips."""
+    (tmp_path / "config.toml").write_text(
+        "[paths]\n"
+        'vault = "/tmp/vault"\n'
+        'output_subdir = "learnings/x-knowledge"\n'
+        'data_dir = "data"\n'
+        "[x]\n"
+        'handle = "vgonpa"\n'
+        "[output]\n"
+        'topic_style = "hashtag"\n',
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.topic_style == "hashtag"
+
+
+def test_load_config_rejects_unknown_topic_style(tmp_path: Path):
+    """Unknown topic_style fails fast with the supported list in the message."""
+    (tmp_path / "config.toml").write_text(
+        "[paths]\n"
+        'vault = "/tmp/vault"\n'
+        'output_subdir = "learnings/x-knowledge"\n'
+        'data_dir = "data"\n'
+        "[x]\n"
+        'handle = "vgonpa"\n'
+        "[output]\n"
+        'topic_style = "bogus"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="topic_style"):
+        load_config(tmp_path)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -267,3 +267,67 @@ def test_generate_rejects_unsupported_language(tmp_path: Path):
 
     with pytest.raises(ValueError, match="Klingon"):
         generate({"9": _enriched_item()}, tmp_path, output_language="Klingon")
+
+
+# --------------------------------------------------------------- topic_style
+
+
+def _hashtag_item() -> Item:
+    """Enriched item with two topics — exercises the topic-line rendering."""
+    return Item(
+        id="42",
+        source="bookmark",
+        url="https://x.com/a/status/42",
+        author=Author(handle="alice", name="Alice"),
+        text="Body 42",
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url="https://example.com/p", domain="example.com")],
+        enriched=Enrichment(
+            enriched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            executor="api",
+            summary="Resumen.",
+            primary_topic="ai-coding",
+            topics=["ai-coding", "software-engineering"],
+        ),
+    )
+
+
+def test_generate_renders_topics_as_wikilinks_by_default(tmp_path: Path):
+    """Default `topic_style` keeps the byte-for-byte current wikilink form."""
+    generate({"42": _hashtag_item()}, tmp_path)
+    note = next((tmp_path / "items").glob("*-42.md")).read_text(encoding="utf-8")
+    assert "**Topics:** [[ai-coding]] · [[software-engineering]]" in note
+    assert "#ai-coding" not in note
+    assert "#software-engineering" not in note
+
+
+def test_generate_renders_topics_as_hashtags_when_requested(tmp_path: Path):
+    """`topic_style="hashtag"` emits Obsidian tags space-separated on the line."""
+    generate({"42": _hashtag_item()}, tmp_path, topic_style="hashtag")
+    note = next((tmp_path / "items").glob("*-42.md")).read_text(encoding="utf-8")
+    assert "**Topics:** #ai-coding #software-engineering" in note
+    assert "[[ai-coding]]" not in note
+    assert "[[software-engineering]]" not in note
+    # Orthogonality invariant: frontmatter `tags:` are unchanged across modes.
+    # Both slugs must still be present in the frontmatter as native Obsidian tags.
+    assert "tags: [x-knowledge, ai-coding, software-engineering]" in note
+
+
+def test_generate_hashtag_mode_does_not_affect_index_or_topic_page_lists(tmp_path: Path):
+    """Hashtag mode is in-body-only — the `_index.md` ## Topics section stays wikilinks."""
+    generate({"42": _hashtag_item()}, tmp_path, topic_style="hashtag")
+    index = (tmp_path / "_index.md").read_text(encoding="utf-8")
+    # The index ranks topics with wikilink-plus-count — independent of topic_style.
+    assert "[[ai-coding]] (1)" in index
+    assert "[[software-engineering]] (1)" in index
+    # And the index never carries the in-body `**Topics:**` line at all.
+    assert "**Topics:**" not in index
+
+
+def test_generate_rejects_unknown_topic_style(tmp_path: Path):
+    """Unknown topic_style at the generator boundary surfaces a ValueError."""
+    import pytest
+
+    with pytest.raises(ValueError, match="topic_style"):
+        generate({"42": _hashtag_item()}, tmp_path, topic_style="bogus")


### PR DESCRIPTION
Closes #13.

## Summary

Adds an opt-in config flag, `[output] topic_style = "wikilink" | "hashtag"`, so
the in-body `**Topics:**` line on each item note can be rendered as Obsidian
hashtags instead of wikilinks. Default is `wikilink` — fully
backwards-compatible.

- `wikilink` (default): `**Topics:** [[ai-coding]] · [[software-engineering]]`
- `hashtag`: `**Topics:** #ai-coding #software-engineering`

Frontmatter `tags:`, the `_index.md` `## Topics` ranking and the topic-page
post lists are unchanged — those are navigational by design and stay
wikilinks regardless of `topic_style`.

## Decisions (resolved in the PRD)

1. **Replace, not alongside.** Hashtags already navigate when a same-named
   note exists (every topic page is `topics/<slug>.md`); "alongside" doubled
   the line noise without paying for itself.
2. **Flag name:** `[output] topic_style` — sits next to the existing
   `[output] language`. Backwards-compatible default `"wikilink"`.
3. **Slug compatibility:** kebab-case slugs (`^[a-z0-9]+(?:-[a-z0-9]+)*$`,
   per `models.py:Topic.slug`) are a strict subset of Obsidian's tag
   charset `[A-Za-z0-9/_-]`, so no slug change is needed.
4. **Frontmatter:** unchanged in both modes (the orthogonality invariant is
   asserted in `test_generate_renders_topics_as_hashtags_when_requested`).

## Implementation

- `Config.topic_style: str` (`src/xbrain/config.py`) — read from
  `[output].topic_style`, defaults to `"wikilink"`, validated against
  `SUPPORTED_TOPIC_STYLES = ("wikilink", "hashtag")`. Unknown value →
  clean `ValueError` listing the supported set.
- `generate(..., topic_style: str = "wikilink")` — threads the value
  through to `_enrichment_lines`. Defensive `ValueError` at the entry
  point for programmatic callers (mirrors how `output_language` is
  validated by `strings_for()` on entry).
- `cli.py:_run_generate` passes `cfg.topic_style` through.
- `config.toml.example` and the README config table + TOML block document
  the new key. README Layer 1 gets a one-sentence note pointing to the
  hashtag mode near the existing example.
- No new module — `topic_style` is a layout choice, not a locale concern,
  so it stays on `Config` rather than entering `xbrain.i18n`.

## Tests

7 new tests, all green:

- `tests/test_generate.py`
  - `test_generate_renders_topics_as_wikilinks_by_default` — default mode
    keeps the exact current line.
  - `test_generate_renders_topics_as_hashtags_when_requested` — same
    item, hashtag mode, asserts the body line + frontmatter unchanged.
  - `test_generate_hashtag_mode_does_not_affect_index_or_topic_page_lists`
    — the `## Topics` ranking still uses wikilinks.
  - `test_generate_rejects_unknown_topic_style` — `ValueError` listing
    supported values.
- `tests/test_config.py`
  - `test_load_config_defaults_topic_style_to_wikilink`
  - `test_load_config_round_trips_hashtag_topic_style`
  - `test_load_config_rejects_unknown_topic_style`

## Quality gate (`uv run poe check`)

```
✅ Ruff (linting)       PASS
✅ Ruff (format)        PASS
✅ Mypy (types)         PASS
⚠️  Radon (complexity)   WARN - Has grade C   (pre-existing, not introduced by this PR)
✅ Bandit (security)    PASS
✅ Vulture (dead code)  PASS
✅ Interrogate (docs)   PASS - 73.5%
✅ Detect-secrets       PASS
✅ Tests                PASS - 306 tests
✅ Coverage             88%
✅ Deptry (deps)        PASS
ALL CRITICAL CHECKS PASSED
```

## Out of scope

- CLI flag `--topic-style` for one-off overrides (file a follow-up issue if
  needed).
- Switching the default from `wikilink` to `hashtag`.
- Changing topic-page or index rendering.