### PR TITLE
[#18] xbrain diff between snapshots

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -433,6 +433,7 @@ xbrain/
 │   ├── notes_io.py          ← per-note read/write + user-tail preservation
 │   ├── store.py             ← items.json / topics.json / state.json I/O
 │   ├── snapshot.py          ← data/ snapshot lifecycle (create/list/restore/prune)
+│   ├── diff.py              ← structured diff between two snapshot data dirs
 │   ├── worksheet.py         ← enrich worksheet export/import
 │   ├── validate.py          ← guardrails enforcement
 │   ├── llm_json.py          ← extract JSON from LLM responses

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ uv run xbrain <command> [options]
 | `sync` | `extract` + `fetch` + `generate`, in order. |
 | `status` | Counts and last-run timestamps. |
 | `snapshot` | Manage `data/` snapshots: `create`, `list`, `show`, `restore`, `prune`. See [Snapshots & safety](#snapshots--safety). |
+| `diff` | Compare two snapshots (or one snapshot vs. the live `data/`). Surfaces reassigned items, topic growth, overview drift, vocab changes. `--format text\|json`. |
 | `login` | Open a browser to log in to X (see [Authentication](#authentication) — prefer the cookie import). |
 
 Every stage accepts `--since` / `--until` (ISO dates) to narrow the date window.
@@ -543,6 +544,19 @@ xbrain snapshot prune --keep-last 10        # cap disk use
 The Obsidian vault is **not** snapshotted — it is fully derived from `data/`
 via `xbrain generate`. `restore` rolls back `data/`; you run `xbrain generate`
 to rebuild the wiki from it.
+
+After a destructive run, `xbrain diff <pre-snapshot>` shows exactly what
+moved — items whose `primary_topic` was reassigned, topic memberships that
+grew or shrank, overview text that drifted, and vocab slugs added or
+removed. The B side defaults to the live `data/`, so the common case is one
+short command. Add `--format json` to pipe the report into `jq` or a CI
+gate.
+
+```bash
+xbrain diff 2026-05-22T18-30-15Z-pre-vocab-regenerate    # vs. live data/
+xbrain diff <snap-a> <snap-b>                            # two named snapshots
+xbrain diff <snap-a> --format json | jq '.summary.reassigned_pct'
+```
 
 ---
 

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -14,6 +14,7 @@ import typer
 from xbrain import snapshot
 from xbrain.archive import parse_archive
 from xbrain.config import Config, load_config
+from xbrain.diff import diff_snapshots, format_json, format_text
 from xbrain.enrich import apply_worksheet_judgments, enrich_with_executor, items_pending_enrichment
 from xbrain.executors.api import ApiExecutor
 from xbrain.extract.browser import login as run_login
@@ -547,6 +548,57 @@ def snapshot_prune_cmd(
     cfg = _config()
     deleted = snapshot.snapshot_prune(cfg.data_dir, keep_last=keep_last)
     typer.echo(f"Snapshots deleted: {deleted}")
+
+
+def _resolve_data_dir(cfg: Config, name: str | None) -> Path:
+    """Resolve a snapshot name to its data dir, or `None` to the live `data/`.
+
+    `xbrain diff` accepts a snapshot name (resolved via `snapshot_show`) OR
+    `None` to mean "the current live `data/`" — the most common B-side of the
+    comparison the user runs after a destructive op.
+    """
+    if name is None:
+        return cfg.data_dir
+    snapshot_dir, _ = snapshot.snapshot_show(cfg.data_dir, name)
+    return snapshot_dir
+
+
+@app.command()
+@_handle_cli_errors
+def diff(
+    snapshot_a: str = typer.Argument(..., help="Snapshot name on the A side."),
+    snapshot_b: str | None = typer.Argument(
+        None,
+        help="Snapshot name on the B side. Defaults to the live data/ directory.",
+    ),
+    output_format: str = typer.Option(
+        "text",
+        "--format",
+        help="Output format: 'text' (default) or 'json'.",
+    ),
+) -> None:
+    """Compare two snapshots and surface drift.
+
+    Reports reassigned items, topic-membership shifts, topic-overview drift
+    (TF cosine similarity) and vocab changes. The B side defaults to the live
+    `data/` directory so `xbrain diff <pre-snapshot>` answers "what did the
+    last destructive op move?" with no extra arguments.
+    """
+    cfg = _config()
+    if output_format not in ("text", "json"):
+        raise ValueError(f"--format must be 'text' or 'json', got {output_format!r}")
+    a_dir = _resolve_data_dir(cfg, snapshot_a)
+    b_dir = _resolve_data_dir(cfg, snapshot_b)
+    report = diff_snapshots(a_dir, b_dir)
+    if output_format == "json":
+        typer.echo(format_json(report))
+    else:
+        b_label = snapshot_b if snapshot_b is not None else "live data/"
+        typer.echo("Comparing:")
+        typer.echo(f"  A: {snapshot_a}")
+        typer.echo(f"  B: {b_label}")
+        typer.echo("")
+        typer.echo(format_text(report))
 
 
 if __name__ == "__main__":

--- a/src/xbrain/diff.py
+++ b/src/xbrain/diff.py
@@ -12,7 +12,7 @@ live `data/` dir; the module does not distinguish). The CLI is the only thing
 that knows what a "snapshot name" is and resolves it via
 `xbrain.snapshot.snapshot_show`.
 
-Overview drift uses a pure-Python TF cosine similarity (see `_tfidf_cosine`).
+Overview drift uses a pure-Python TF cosine similarity (see `_tf_cosine`).
 No new dependencies: scikit-learn or sentence-transformers would tax the
 install for one CLI feature, and the offline-by-default invariant rules out
 API-call embeddings. LLM-judged similarity is the explicit follow-up tied to
@@ -109,11 +109,16 @@ class TopicsDiff(BaseModel):
 
 
 class VocabDiff(BaseModel):
-    """Slug-level set difference between two `vocab.yaml` files."""
+    """Slug-level set difference between two `vocab.yaml` files.
+
+    `unchanged_count` carries the cardinality of slugs present in both vocabs
+    — only the count is consumed downstream (text renderer, JSON snapshot),
+    so the full list is not stored.
+    """
 
     added: list[str] = Field(default_factory=list)
     removed: list[str] = Field(default_factory=list)
-    unchanged: list[str] = Field(default_factory=list)
+    unchanged_count: int = 0
 
 
 class DiffSummary(BaseModel):
@@ -160,13 +165,42 @@ def diff_snapshots(
 
     The thresholds tune which transitions get flagged but do not affect the
     raw counts. Defaults match PRD §5.2.
+
+    Raises:
+        FileNotFoundError: if either directory does not exist on disk, or if
+            both directories are completely empty (no `items.json`,
+            `vocab.yaml` or `topics.json`). Without this guard a `diff` against
+            an accidentally-deleted `data/` would silently report
+            "everything removed" — surfacing as a clean error is safer.
+        ValueError: a context-adding wrap around the corrupt-file errors
+            raised by the underlying loaders, so the operator sees *which*
+            file is the problem rather than a bare pydantic / json traceback.
     """
-    items_a = load_store(a_dir / "items.json")
-    items_b = load_store(b_dir / "items.json")
-    vocab_a = load_vocab(a_dir / "vocab.yaml")
-    vocab_b = load_vocab(b_dir / "vocab.yaml")
-    pages_a = load_topic_pages(a_dir / "topics.json")
-    pages_b = load_topic_pages(b_dir / "topics.json")
+    for label, path in (("A", a_dir), ("B", b_dir)):
+        if not path.exists():
+            raise FileNotFoundError(f"diff side {label}: directory not found: {path}")
+
+    def _load_or_explain(path: Path, loader):
+        try:
+            return loader(path)
+        except (ValueError, OSError) as exc:  # pydantic ValidationError is a ValueError
+            raise ValueError(f"failed to load {path}: {exc}") from exc
+
+    items_a = _load_or_explain(a_dir / "items.json", load_store)
+    items_b = _load_or_explain(b_dir / "items.json", load_store)
+    vocab_a = _load_or_explain(a_dir / "vocab.yaml", load_vocab)
+    vocab_b = _load_or_explain(b_dir / "vocab.yaml", load_vocab)
+    pages_a = _load_or_explain(a_dir / "topics.json", load_topic_pages)
+    pages_b = _load_or_explain(b_dir / "topics.json", load_topic_pages)
+
+    a_empty = not (items_a or vocab_a or pages_a)
+    b_empty = not (items_b or vocab_b or pages_b)
+    if a_empty and b_empty:
+        raise FileNotFoundError(
+            f"Both diff sides are empty (no items.json / vocab.yaml / topics.json "
+            f"present under {a_dir} or {b_dir}). Confirm the snapshot names and "
+            "that data/ is populated."
+        )
 
     items_diff = _compute_items_diff(items_a, items_b, top_n=top_n_transitions)
     vocab_diff = _compute_vocab_diff(vocab_a, vocab_b)
@@ -308,21 +342,21 @@ def _compute_vocab_diff(vocab_a: list[Topic], vocab_b: list[Topic]) -> VocabDiff
     return VocabDiff(
         added=sorted(slugs_b - slugs_a),
         removed=sorted(slugs_a - slugs_b),
-        unchanged=sorted(slugs_a & slugs_b),
+        unchanged_count=len(slugs_a & slugs_b),
     )
 
 
-# ----------------------------------------------------------------------- TF-IDF cosine
+# --------------------------------------------------------------------------- TF cosine
 
 
-def _tfidf_cosine(text_a: str, text_b: str) -> float:
+def _tf_cosine(text_a: str, text_b: str) -> float:
     """Return TF cosine similarity in [0.0, 1.0] for two short prose strings.
 
     Tokenization: lowercase, runs of ASCII or Romance-Latin letters/digits of
-    length >= 2. With only two documents, IDF degenerates; we use plain TF
-    cosine — relative ordering across topic pairs is what matters for the
-    `identical / similar / different` bucket assignment, not the absolute
-    score.
+    length >= 2. With only two documents IDF degenerates, so this is plain TF
+    cosine (not TF-IDF) — relative ordering across topic pairs is what matters
+    for the `identical / similar / different` bucket assignment, not the
+    absolute score.
 
     Edge cases:
       - Either text empty or contains no qualifying tokens → 0.0.
@@ -387,7 +421,7 @@ def format_text(report: DiffReport) -> str:
         f"  removed ({len(report.vocab.removed)}): "
         f"{', '.join(report.vocab.removed) if report.vocab.removed else '(none)'}"
     )
-    lines.append(f"  unchanged: {len(report.vocab.unchanged)} slugs")
+    lines.append(f"  unchanged: {report.vocab.unchanged_count} slugs")
     return "\n".join(lines)
 
 
@@ -497,7 +531,7 @@ def _classify_overview(
     """Compute similarity and bucket it into the OverviewFlag enum."""
     if text_a is None or text_b is None:
         return None, "not_comparable"
-    similarity = _tfidf_cosine(text_a, text_b)
+    similarity = _tf_cosine(text_a, text_b)
     if similarity >= _IDENTICAL_SIMILARITY:
         return similarity, "identical"
     if similarity >= threshold:

--- a/src/xbrain/diff.py
+++ b/src/xbrain/diff.py
@@ -1,0 +1,505 @@
+"""Structured diff between two snapshot data directories.
+
+The `diff_snapshots` orchestrator answers one question: **what changed between
+two states of `data/`?** It compares the source-of-truth artifacts (items.json
+enrichment, vocab.yaml, topics.json) and produces a structured `DiffReport`
+that the CLI renders as text or JSON.
+
+The module is **pure I/O**: no `typer.echo`, no `print`, no CLI side-effects.
+Inputs are two `Path`s pointing at *data directories* (the ones that hold
+`items.json` / `vocab.yaml` / `topics.json` directly — a snapshot dir or the
+live `data/` dir; the module does not distinguish). The CLI is the only thing
+that knows what a "snapshot name" is and resolves it via
+`xbrain.snapshot.snapshot_show`.
+
+Overview drift uses a pure-Python TF cosine similarity (see `_tfidf_cosine`).
+No new dependencies: scikit-learn or sentence-transformers would tax the
+install for one CLI feature, and the offline-by-default invariant rules out
+API-call embeddings. LLM-judged similarity is the explicit follow-up tied to
+WS3 (#8) — out of scope for v1.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from xbrain.models import Item, Topic, TopicPage
+from xbrain.rubrics import load_vocab
+from xbrain.store import load_store, load_topic_pages
+
+# --------------------------------------------------------------------- public models
+
+#: Three-state classification of how much a topic-page overview moved.
+#: `not_comparable` covers the case where one side has no topic-page entry.
+OverviewFlag = Literal["identical", "similar", "different", "not_comparable"]
+
+#: Topics with fewer than this many starting members do not get a growth/shrink
+#: flag — a 2→3 jump is 50% growth but statistically meaningless on a small
+#: topic. Hardcoded floor; promote to a parameter if user research demands.
+_MIN_MEMBERS_FOR_GROWTH_FLAG = 5
+
+#: Cosine similarity at or above this counts as "identical" (handles fp slop).
+_IDENTICAL_SIMILARITY = 0.99
+
+# Tokenizer: lowercase, ASCII letters/digits + Romance-language Latin
+# accented characters (à-ÿ) so Spanish/French overviews tokenize correctly.
+# Length filter happens in the helper — single-character tokens add noise.
+_TOKEN_RE = re.compile(r"[a-zà-ÿ0-9]+")
+
+
+class Transition(BaseModel):
+    """One `primary_topic` reassignment between snapshot A and B.
+
+    `from_topic` / `to_topic` carry `None` when the item had no enrichment on
+    that side (e.g. unenriched in A, enriched in B → `from_topic=None`). The
+    counter aggregates identical (from, to) pairs across all items.
+    """
+
+    from_topic: str | None
+    to_topic: str | None
+    count: int
+
+
+class ItemsDiff(BaseModel):
+    """Item-level reassignment summary across two snapshots."""
+
+    count_a: int
+    count_b: int
+    count_in_both: int
+    enriched_in_both: int
+    reassigned: int
+    reassigned_pct: float
+    top_transitions: list[Transition] = Field(default_factory=list)
+
+
+class TopicChange(BaseModel):
+    """Per-topic membership shift and overview drift.
+
+    A "member" is an item whose `primary_topic` equals this topic's slug. The
+    set ops (`added`, `removed`, `unchanged`) operate on the item ids — they
+    answer "which items entered or left this topic between A and B", not just
+    "did the count move".
+    """
+
+    slug: str
+    members_a: int
+    members_b: int
+    added: int
+    removed: int
+    unchanged: int
+    growth_pct: float | None
+    flagged_growth: bool
+    overview_a: str | None = None
+    overview_b: str | None = None
+    overview_similarity: float | None = None
+    overview_flag: OverviewFlag = "not_comparable"
+
+
+class TopicsDiff(BaseModel):
+    """All per-topic changes, keyed by slug (union of vocab A and vocab B)."""
+
+    per_slug: dict[str, TopicChange]
+
+
+class VocabDiff(BaseModel):
+    """Slug-level set difference between two `vocab.yaml` files."""
+
+    added: list[str] = Field(default_factory=list)
+    removed: list[str] = Field(default_factory=list)
+    unchanged: list[str] = Field(default_factory=list)
+
+
+class DiffSummary(BaseModel):
+    """Flat top-level counts — used by both the text header and JSON consumers."""
+
+    items_a: int
+    items_b: int
+    items_in_both: int
+    enriched_in_both: int
+    reassigned: int
+    reassigned_pct: float
+    vocab_added: int
+    vocab_removed: int
+    topic_pages_a: int
+    topic_pages_b: int
+
+
+class DiffReport(BaseModel):
+    """The full structured comparison between two data directories."""
+
+    summary: DiffSummary
+    items: ItemsDiff
+    topics: TopicsDiff
+    vocab: VocabDiff
+
+
+# ----------------------------------------------------------------- public orchestrator
+
+
+def diff_snapshots(
+    a_dir: Path,
+    b_dir: Path,
+    *,
+    overview_similarity_threshold: float = 0.7,
+    growth_flag_threshold: float = 0.10,
+    top_n_transitions: int = 10,
+) -> DiffReport:
+    """Compute the structured diff between two snapshot data directories.
+
+    `a_dir` and `b_dir` are *data directories* — the ones holding `items.json`,
+    `vocab.yaml`, `topics.json` directly. A snapshot directory and the live
+    `data/` directory are the same shape; the CLI passes whichever the user
+    asked for, and this function does not care which is which.
+
+    The thresholds tune which transitions get flagged but do not affect the
+    raw counts. Defaults match PRD §5.2.
+    """
+    items_a = load_store(a_dir / "items.json")
+    items_b = load_store(b_dir / "items.json")
+    vocab_a = load_vocab(a_dir / "vocab.yaml")
+    vocab_b = load_vocab(b_dir / "vocab.yaml")
+    pages_a = load_topic_pages(a_dir / "topics.json")
+    pages_b = load_topic_pages(b_dir / "topics.json")
+
+    items_diff = _compute_items_diff(items_a, items_b, top_n=top_n_transitions)
+    vocab_diff = _compute_vocab_diff(vocab_a, vocab_b)
+    topics_diff = _compute_topics_diff(
+        items_a,
+        items_b,
+        pages_a,
+        pages_b,
+        vocab_a,
+        vocab_b,
+        growth_flag_threshold=growth_flag_threshold,
+        overview_similarity_threshold=overview_similarity_threshold,
+    )
+    summary = DiffSummary(
+        items_a=items_diff.count_a,
+        items_b=items_diff.count_b,
+        items_in_both=items_diff.count_in_both,
+        enriched_in_both=items_diff.enriched_in_both,
+        reassigned=items_diff.reassigned,
+        reassigned_pct=items_diff.reassigned_pct,
+        vocab_added=len(vocab_diff.added),
+        vocab_removed=len(vocab_diff.removed),
+        topic_pages_a=len(pages_a),
+        topic_pages_b=len(pages_b),
+    )
+    return DiffReport(
+        summary=summary,
+        items=items_diff,
+        topics=topics_diff,
+        vocab=vocab_diff,
+    )
+
+
+# --------------------------------------------------------------------- compute pieces
+
+
+def _compute_items_diff(
+    items_a: dict[str, Item],
+    items_b: dict[str, Item],
+    *,
+    top_n: int,
+) -> ItemsDiff:
+    """Reassignment count + top transitions, restricted to items in both.
+
+    `reassigned` counts items present AND enriched on both sides whose
+    `primary_topic` differs. Items added in B or un-enriched on either side
+    do NOT count as reassignments — they show up in transitions and topic
+    membership instead.
+    """
+    shared_ids = set(items_a) & set(items_b)
+    transitions: list[tuple[str | None, str | None]] = []
+    reassigned = 0
+    enriched_in_both = 0
+    for item_id in shared_ids:
+        primary_a = _primary_topic(items_a[item_id])
+        primary_b = _primary_topic(items_b[item_id])
+        if primary_a is not None and primary_b is not None:
+            enriched_in_both += 1
+            if primary_a != primary_b:
+                reassigned += 1
+                transitions.append((primary_a, primary_b))
+        elif primary_a != primary_b:
+            # One side unenriched. Surface as a transition (None on one side)
+            # but do NOT count as a reassignment — only judgment changes on
+            # items judged on BOTH sides count.
+            transitions.append((primary_a, primary_b))
+    pct = (reassigned / enriched_in_both) if enriched_in_both else 0.0
+    return ItemsDiff(
+        count_a=len(items_a),
+        count_b=len(items_b),
+        count_in_both=len(shared_ids),
+        enriched_in_both=enriched_in_both,
+        reassigned=reassigned,
+        reassigned_pct=pct,
+        top_transitions=_top_transitions(transitions, top_n=top_n),
+    )
+
+
+def _compute_topics_diff(
+    items_a: dict[str, Item],
+    items_b: dict[str, Item],
+    pages_a: dict[str, TopicPage],
+    pages_b: dict[str, TopicPage],
+    vocab_a: list[Topic],
+    vocab_b: list[Topic],
+    *,
+    growth_flag_threshold: float,
+    overview_similarity_threshold: float,
+) -> TopicsDiff:
+    """Per-slug membership and overview drift, keyed by the union of slugs."""
+    membership_a = _membership_by_topic(items_a)
+    membership_b = _membership_by_topic(items_b)
+
+    # Union over: vocab slugs from both sides + any slug that appears as a
+    # primary_topic in either store (defensive — items can reference a slug
+    # that the vocab no longer carries).
+    all_slugs: set[str] = {t.slug for t in vocab_a} | {t.slug for t in vocab_b}
+    all_slugs |= set(membership_a) | set(membership_b)
+
+    per_slug: dict[str, TopicChange] = {}
+    for slug in sorted(all_slugs):
+        member_ids_a = membership_a.get(slug, set())
+        member_ids_b = membership_b.get(slug, set())
+        added = len(member_ids_b - member_ids_a)
+        removed = len(member_ids_a - member_ids_b)
+        unchanged = len(member_ids_a & member_ids_b)
+        growth_pct = _growth_pct(len(member_ids_a), len(member_ids_b))
+        flagged_growth = (
+            growth_pct is not None
+            and len(member_ids_a) >= _MIN_MEMBERS_FOR_GROWTH_FLAG
+            and abs(growth_pct) >= growth_flag_threshold
+        )
+        overview_a = pages_a[slug].overview if slug in pages_a else None
+        overview_b = pages_b[slug].overview if slug in pages_b else None
+        similarity, flag = _classify_overview(
+            overview_a, overview_b, threshold=overview_similarity_threshold
+        )
+        per_slug[slug] = TopicChange(
+            slug=slug,
+            members_a=len(member_ids_a),
+            members_b=len(member_ids_b),
+            added=added,
+            removed=removed,
+            unchanged=unchanged,
+            growth_pct=growth_pct,
+            flagged_growth=flagged_growth,
+            overview_a=overview_a,
+            overview_b=overview_b,
+            overview_similarity=similarity,
+            overview_flag=flag,
+        )
+    return TopicsDiff(per_slug=per_slug)
+
+
+def _compute_vocab_diff(vocab_a: list[Topic], vocab_b: list[Topic]) -> VocabDiff:
+    """Slug set-difference between two vocab.yaml files (sorted output)."""
+    slugs_a = {t.slug for t in vocab_a}
+    slugs_b = {t.slug for t in vocab_b}
+    return VocabDiff(
+        added=sorted(slugs_b - slugs_a),
+        removed=sorted(slugs_a - slugs_b),
+        unchanged=sorted(slugs_a & slugs_b),
+    )
+
+
+# ----------------------------------------------------------------------- TF-IDF cosine
+
+
+def _tfidf_cosine(text_a: str, text_b: str) -> float:
+    """Return TF cosine similarity in [0.0, 1.0] for two short prose strings.
+
+    Tokenization: lowercase, runs of ASCII or Romance-Latin letters/digits of
+    length >= 2. With only two documents, IDF degenerates; we use plain TF
+    cosine — relative ordering across topic pairs is what matters for the
+    `identical / similar / different` bucket assignment, not the absolute
+    score.
+
+    Edge cases:
+      - Either text empty or contains no qualifying tokens → 0.0.
+      - Identical token bags → 1.0.
+      - Disjoint vocabularies → 0.0.
+    """
+    tokens_a = _tokenize(text_a)
+    tokens_b = _tokenize(text_b)
+    if not tokens_a or not tokens_b:
+        return 0.0
+    counter_a = Counter(tokens_a)
+    counter_b = Counter(tokens_b)
+    shared = set(counter_a) & set(counter_b)
+    if not shared:
+        return 0.0
+    numerator = sum(counter_a[t] * counter_b[t] for t in shared)
+    norm_a = math.sqrt(sum(c * c for c in counter_a.values()))
+    norm_b = math.sqrt(sum(c * c for c in counter_b.values()))
+    return numerator / (norm_a * norm_b)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Tokens of length >= 2, lowercased, ASCII + Latin-1 letters/digits."""
+    return [t for t in _TOKEN_RE.findall(text.lower()) if len(t) >= 2]
+
+
+# ----------------------------------------------------------------------- renderers
+
+
+def format_text(report: DiffReport) -> str:
+    """Render the diff as a human-readable terminal report."""
+    lines: list[str] = []
+    lines.append("ITEMS")
+    lines.append(f"  count A: {report.summary.items_a}")
+    lines.append(f"  count B: {report.summary.items_b}")
+    lines.append(f"  in both snapshots: {report.summary.items_in_both}")
+    lines.append(f"  enriched on both sides: {report.summary.enriched_in_both}")
+    lines.append(
+        f"  primary_topic reassigned: {report.summary.reassigned} "
+        f"({report.summary.reassigned_pct * 100:.1f}%)"
+    )
+    if report.items.top_transitions:
+        lines.append("")
+        lines.append("  Top transitions:")
+        for transition in report.items.top_transitions:
+            from_label = transition.from_topic if transition.from_topic is not None else "(none)"
+            to_label = transition.to_topic if transition.to_topic is not None else "(none)"
+            lines.append(f"    {from_label} -> {to_label}: {transition.count} items")
+    lines.append("")
+    lines.append("TOPICS")
+    lines.extend(_format_topics_block(report.topics))
+    lines.append("")
+    lines.append("OVERVIEWS")
+    lines.extend(_format_overviews_block(report.topics))
+    lines.append("")
+    lines.append("VOCAB")
+    lines.append(
+        f"  added ({len(report.vocab.added)}): "
+        f"{', '.join(report.vocab.added) if report.vocab.added else '(none)'}"
+    )
+    lines.append(
+        f"  removed ({len(report.vocab.removed)}): "
+        f"{', '.join(report.vocab.removed) if report.vocab.removed else '(none)'}"
+    )
+    lines.append(f"  unchanged: {len(report.vocab.unchanged)} slugs")
+    return "\n".join(lines)
+
+
+def format_json(report: DiffReport) -> str:
+    """Render the diff as pretty JSON for machine consumption."""
+    return report.model_dump_json(indent=2)
+
+
+def _format_topics_block(topics: TopicsDiff) -> list[str]:
+    """Render the per-topic membership rows, sorted by slug."""
+    if not topics.per_slug:
+        return ["  (no topics in either snapshot)"]
+    rows: list[str] = []
+    for slug in sorted(topics.per_slug):
+        change = topics.per_slug[slug]
+        flag = " [FLAG]" if change.flagged_growth else ""
+        growth = "n/a" if change.growth_pct is None else f"{change.growth_pct * 100:+.1f}%"
+        rows.append(
+            f"  {slug}{flag}  A={change.members_a}  B={change.members_b}  "
+            f"added={change.added}  removed={change.removed}  "
+            f"unchanged={change.unchanged}  growth={growth}"
+        )
+    return rows
+
+
+def _format_overviews_block(topics: TopicsDiff) -> list[str]:
+    """Render the overview-drift rows, with a flagged-shifts sub-block."""
+    if not topics.per_slug:
+        return ["  (no overviews to compare)"]
+    rows: list[str] = []
+    flagged: list[tuple[str, float]] = []
+    for slug in sorted(topics.per_slug):
+        change = topics.per_slug[slug]
+        if change.overview_flag == "not_comparable":
+            rows.append(f"  {slug}: not comparable")
+            continue
+        sim = change.overview_similarity if change.overview_similarity is not None else 0.0
+        rows.append(f"  {slug}: {change.overview_flag} (sim={sim:.2f})")
+        if change.overview_flag == "different":
+            flagged.append((slug, sim))
+    if flagged:
+        rows.append("")
+        rows.append("  Sharp shifts (low similarity):")
+        for slug, sim in flagged:
+            rows.append(f"    {slug}  sim={sim:.2f}")
+    return rows
+
+
+# ------------------------------------------------------------------------- internals
+
+
+def _primary_topic(item: Item) -> str | None:
+    """Return the item's primary_topic, or None when unenriched."""
+    if item.enriched is None:
+        return None
+    return item.enriched.primary_topic
+
+
+def _membership_by_topic(items: dict[str, Item]) -> dict[str, set[str]]:
+    """Group item ids by their primary_topic (only enriched items contribute)."""
+    membership: dict[str, set[str]] = {}
+    for item_id, item in items.items():
+        primary = _primary_topic(item)
+        if primary is None:
+            continue
+        membership.setdefault(primary, set()).add(item_id)
+    return membership
+
+
+def _growth_pct(members_a: int, members_b: int) -> float | None:
+    """Relative growth from A to B; None when A is empty (undefined growth)."""
+    if members_a == 0:
+        return None
+    return (members_b - members_a) / members_a
+
+
+def _top_transitions(
+    transitions: Iterable[tuple[str | None, str | None]],
+    *,
+    top_n: int,
+) -> list[Transition]:
+    """Aggregate (from, to) pairs and return the top N, with a stable order.
+
+    Sort key: count desc, then `from_topic` asc, then `to_topic` asc. `None`
+    is coalesced to the empty string for ordering purposes only — the surface
+    representation keeps `None` intact.
+    """
+    counter: Counter[tuple[str | None, str | None]] = Counter(transitions)
+    if not counter:
+        return []
+    pairs = sorted(
+        counter.items(),
+        key=lambda kv: (-kv[1], kv[0][0] or "", kv[0][1] or ""),
+    )
+    return [
+        Transition(from_topic=from_t, to_topic=to_t, count=count)
+        for (from_t, to_t), count in pairs[:top_n]
+    ]
+
+
+def _classify_overview(
+    text_a: str | None,
+    text_b: str | None,
+    *,
+    threshold: float,
+) -> tuple[float | None, OverviewFlag]:
+    """Compute similarity and bucket it into the OverviewFlag enum."""
+    if text_a is None or text_b is None:
+        return None, "not_comparable"
+    similarity = _tfidf_cosine(text_a, text_b)
+    if similarity >= _IDENTICAL_SIMILARITY:
+        return similarity, "identical"
+    if similarity >= threshold:
+        return similarity, "similar"
+    return similarity, "different"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -19,7 +19,7 @@ from typer.testing import CliRunner
 from xbrain.cli import app
 from xbrain.diff import (
     DiffReport,
-    _tfidf_cosine,
+    _tf_cosine,
     diff_snapshots,
     format_json,
     format_text,
@@ -97,24 +97,24 @@ def _page(slug: str, overview: str, count: int = 5) -> TopicPage:
 
 def test_tfidf_identical_strings_return_one() -> None:
     text = "the quick brown fox jumps"
-    assert _tfidf_cosine(text, text) == pytest.approx(1.0)
+    assert _tf_cosine(text, text) == pytest.approx(1.0)
 
 
 def test_tfidf_empty_or_singleton_returns_zero() -> None:
-    assert _tfidf_cosine("", "anything") == 0.0
-    assert _tfidf_cosine("text", "") == 0.0
+    assert _tf_cosine("", "anything") == 0.0
+    assert _tf_cosine("text", "") == 0.0
     # Single-character tokens get filtered (length >= 2 floor)
-    assert _tfidf_cosine("a a a", "b b b") == 0.0
+    assert _tf_cosine("a a a", "b b b") == 0.0
 
 
 def test_tfidf_disjoint_vocabularies_return_zero() -> None:
-    assert _tfidf_cosine("alpha bravo charlie", "xenon yankee zulu") == 0.0
+    assert _tf_cosine("alpha bravo charlie", "xenon yankee zulu") == 0.0
 
 
 def test_tfidf_partial_overlap_is_between_zero_and_one() -> None:
     text_a = "the agentic workflow runs locally with full traces"
     text_b = "the agentic workflow runs locally with full visibility"
-    similarity = _tfidf_cosine(text_a, text_b)
+    similarity = _tf_cosine(text_a, text_b)
     assert 0.5 < similarity < 1.0
 
 
@@ -123,7 +123,7 @@ def test_tfidf_accented_tokens_survive_lowercasing() -> None:
     # accented text compared to itself must score 1.0 — proves we didn't
     # silently strip the accented chars to nothing.
     text = "el árbol creció con vigor"
-    assert _tfidf_cosine(text, text) == pytest.approx(1.0)
+    assert _tf_cosine(text, text) == pytest.approx(1.0)
 
 
 # ----------------------------------------------------------------- diff_snapshots end-to-end
@@ -357,7 +357,7 @@ def test_vocab_added_and_removed_set_correctly(tmp_path: Path) -> None:
 
     assert report.vocab.added == ["delta"]
     assert report.vocab.removed == ["alpha"]
-    assert report.vocab.unchanged == ["bravo", "charlie"]
+    assert report.vocab.unchanged_count == 2
 
 
 def test_missing_vocab_yaml_on_one_side_does_not_crash(tmp_path: Path) -> None:
@@ -522,3 +522,57 @@ def test_cli_diff_unknown_format_exits_1(tmp_path: Path, monkeypatch) -> None:
 
     assert result.exit_code == 1
     assert "format" in result.output.lower()
+
+
+# --- PR #28 review fixes: input validation ---
+
+
+def test_diff_snapshots_raises_when_dir_does_not_exist(tmp_path):
+    """Missing snapshot dir surfaces as clean FileNotFoundError, not silent empty diff."""
+    import pytest
+
+    from xbrain.diff import diff_snapshots
+
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "items.json").write_text("{}", encoding="utf-8")
+    ghost = tmp_path / "does-not-exist"
+
+    with pytest.raises(FileNotFoundError, match="directory not found"):
+        diff_snapshots(real, ghost)
+
+
+def test_diff_snapshots_raises_when_both_sides_are_empty(tmp_path):
+    """Both sides empty → clean FileNotFoundError naming the dirs.
+
+    Guards against the silent-failure case where data/ was deleted out-of-band
+    and diff would otherwise report a clean 'no changes' against a real snapshot.
+    """
+    import pytest
+
+    from xbrain.diff import diff_snapshots
+
+    a = tmp_path / "a"
+    a.mkdir()
+    b = tmp_path / "b"
+    b.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="Both diff sides are empty"):
+        diff_snapshots(a, b)
+
+
+def test_diff_snapshots_wraps_corrupt_file_with_context(tmp_path):
+    """A corrupt items.json surfaces with the path in the error message."""
+    import pytest
+
+    from xbrain.diff import diff_snapshots
+
+    a = tmp_path / "a"
+    a.mkdir()
+    (a / "items.json").write_text("not json at all", encoding="utf-8")
+    b = tmp_path / "b"
+    b.mkdir()
+    (b / "items.json").write_text("{}", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="failed to load.*items.json"):
+        diff_snapshots(a, b)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,524 @@
+# tests/test_diff.py
+"""Tests for `xbrain.diff` — pure module + CLI integration.
+
+The module-level tests do not hit `xbrain.snapshot`: they pass plain data
+directories. That mirrors the production contract — `diff_snapshots` does not
+know what a snapshot is. The CLI tests round-trip through `snapshot_create`
+to exercise the verb the user actually types.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from xbrain.cli import app
+from xbrain.diff import (
+    DiffReport,
+    _tfidf_cosine,
+    diff_snapshots,
+    format_json,
+    format_text,
+)
+from xbrain.models import Author, Enrichment, Item, Topic, TopicPage
+from xbrain.rubrics import save_vocab
+from xbrain.snapshot import snapshot_create
+from xbrain.store import save_store, save_topic_pages
+
+runner = CliRunner()
+
+
+def _item(
+    item_id: str,
+    *,
+    primary: str | None = None,
+    extra_topics: list[str] | None = None,
+) -> Item:
+    """Build an Item, optionally with an enrichment record."""
+    item = Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="alice", name="Alice"),
+        text=f"Note {item_id}",
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+    )
+    if primary is not None:
+        topics = [primary]
+        if extra_topics:
+            topics.extend(extra_topics)
+        item.enriched = Enrichment(
+            enriched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+            executor="api",
+            summary="s",
+            primary_topic=primary,
+            topics=topics,
+        )
+    return item
+
+
+def _seed(
+    data_dir: Path,
+    *,
+    items: dict[str, Item] | None = None,
+    vocab_slugs: list[str] | None = None,
+    pages: dict[str, TopicPage] | None = None,
+) -> None:
+    """Populate a data dir with whatever subset of artifacts a test needs."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    if items is not None:
+        save_store(items, data_dir / "items.json")
+    if vocab_slugs is not None:
+        save_vocab(
+            [Topic(slug=slug, description=f"desc for {slug}") for slug in vocab_slugs],
+            data_dir / "vocab.yaml",
+        )
+    if pages is not None:
+        save_topic_pages(pages, data_dir / "topics.json")
+
+
+def _page(slug: str, overview: str, count: int = 5) -> TopicPage:
+    return TopicPage(
+        slug=slug,
+        overview=overview,
+        notes=[],
+        synthesized_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        post_count_at_synth=count,
+    )
+
+
+# --------------------------------------------------------------------- TF-IDF cosine
+
+
+def test_tfidf_identical_strings_return_one() -> None:
+    text = "the quick brown fox jumps"
+    assert _tfidf_cosine(text, text) == pytest.approx(1.0)
+
+
+def test_tfidf_empty_or_singleton_returns_zero() -> None:
+    assert _tfidf_cosine("", "anything") == 0.0
+    assert _tfidf_cosine("text", "") == 0.0
+    # Single-character tokens get filtered (length >= 2 floor)
+    assert _tfidf_cosine("a a a", "b b b") == 0.0
+
+
+def test_tfidf_disjoint_vocabularies_return_zero() -> None:
+    assert _tfidf_cosine("alpha bravo charlie", "xenon yankee zulu") == 0.0
+
+
+def test_tfidf_partial_overlap_is_between_zero_and_one() -> None:
+    text_a = "the agentic workflow runs locally with full traces"
+    text_b = "the agentic workflow runs locally with full visibility"
+    similarity = _tfidf_cosine(text_a, text_b)
+    assert 0.5 < similarity < 1.0
+
+
+def test_tfidf_accented_tokens_survive_lowercasing() -> None:
+    # The tokenizer keeps a-zà-ÿ to handle Spanish/French overviews. An
+    # accented text compared to itself must score 1.0 — proves we didn't
+    # silently strip the accented chars to nothing.
+    text = "el árbol creció con vigor"
+    assert _tfidf_cosine(text, text) == pytest.approx(1.0)
+
+
+# ----------------------------------------------------------------- diff_snapshots end-to-end
+
+
+def test_identical_snapshots_produce_empty_diff(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    items = {"1": _item("1", primary="ai-coding"), "2": _item("2", primary="misc")}
+    _seed(data, items=items, vocab_slugs=["ai-coding", "misc"])
+
+    report = diff_snapshots(data, data)
+
+    assert report.summary.reassigned == 0
+    assert report.summary.reassigned_pct == 0.0
+    assert report.items.top_transitions == []
+    assert report.vocab.added == []
+    assert report.vocab.removed == []
+    for change in report.topics.per_slug.values():
+        assert change.added == 0
+        assert change.removed == 0
+
+
+def test_reassigned_primary_topic_counts_correctly(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(
+        a,
+        items={"1": _item("1", primary="ai-coding"), "2": _item("2", primary="misc")},
+        vocab_slugs=["ai-coding", "misc"],
+    )
+    _seed(
+        b,
+        items={
+            # Item 1 reassigned ai-coding -> software-engineering
+            "1": _item("1", primary="software-engineering"),
+            # Item 2 unchanged
+            "2": _item("2", primary="misc"),
+        },
+        vocab_slugs=["ai-coding", "misc", "software-engineering"],
+    )
+
+    report = diff_snapshots(a, b)
+
+    assert report.summary.reassigned == 1
+    # Only one transition row, with the right pair
+    assert len(report.items.top_transitions) == 1
+    transition = report.items.top_transitions[0]
+    assert transition.from_topic == "ai-coding"
+    assert transition.to_topic == "software-engineering"
+    assert transition.count == 1
+
+
+def test_items_only_in_one_snapshot_do_not_count_as_reassigned(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={"1": _item("1", primary="ai-coding")}, vocab_slugs=["ai-coding"])
+    _seed(
+        b,
+        items={
+            "1": _item("1", primary="ai-coding"),
+            "2": _item("2", primary="misc"),  # new in B
+        },
+        vocab_slugs=["ai-coding", "misc"],
+    )
+
+    report = diff_snapshots(a, b)
+
+    assert report.summary.reassigned == 0
+    # Item 2's membership shows up in the misc topic
+    assert report.topics.per_slug["misc"].members_b == 1
+    assert report.topics.per_slug["misc"].added == 1
+
+
+def test_unenriched_to_enriched_is_not_a_reassignment(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={"1": _item("1")}, vocab_slugs=["misc"])  # unenriched in A
+    _seed(b, items={"1": _item("1", primary="misc")}, vocab_slugs=["misc"])
+
+    report = diff_snapshots(a, b)
+
+    assert report.summary.reassigned == 0
+    # But the transition row IS surfaced so the user sees the move
+    transitions = report.items.top_transitions
+    assert any(t.from_topic is None and t.to_topic == "misc" for t in transitions)
+
+
+def test_topic_growth_flag_triggers_above_threshold(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    # 10 members in A, 12 in B → growth = 20% → flagged (above 10% threshold, base >= 5)
+    items_a = {str(i): _item(str(i), primary="ai-coding") for i in range(10)}
+    items_b = {str(i): _item(str(i), primary="ai-coding") for i in range(12)}
+    _seed(a, items=items_a, vocab_slugs=["ai-coding"])
+    _seed(b, items=items_b, vocab_slugs=["ai-coding"])
+
+    report = diff_snapshots(a, b)
+
+    change = report.topics.per_slug["ai-coding"]
+    assert change.flagged_growth is True
+    assert change.growth_pct == pytest.approx(0.2)
+
+
+def test_topic_growth_flag_respects_5_member_floor(tmp_path: Path) -> None:
+    """A 3->5 jump is 67% growth but on a tiny base — should not flag."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    items_a = {str(i): _item(str(i), primary="misc") for i in range(3)}
+    items_b = {str(i): _item(str(i), primary="misc") for i in range(5)}
+    _seed(a, items=items_a, vocab_slugs=["misc"])
+    _seed(b, items=items_b, vocab_slugs=["misc"])
+
+    change = diff_snapshots(a, b).topics.per_slug["misc"]
+    assert change.flagged_growth is False
+    assert change.growth_pct == pytest.approx(2 / 3)
+
+
+def test_growth_pct_is_none_when_members_a_is_zero(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={}, vocab_slugs=["ai-coding"])
+    _seed(b, items={"1": _item("1", primary="ai-coding")}, vocab_slugs=["ai-coding"])
+
+    change = diff_snapshots(a, b).topics.per_slug["ai-coding"]
+    assert change.growth_pct is None
+    assert change.flagged_growth is False
+
+
+def test_overview_similarity_identical_flags_identical(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    overview = "The arc from autocomplete to agent orchestration across the year."
+    _seed(
+        a,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={"ai-coding": _page("ai-coding", overview)},
+    )
+    _seed(
+        b,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={"ai-coding": _page("ai-coding", overview)},
+    )
+
+    change = diff_snapshots(a, b).topics.per_slug["ai-coding"]
+    assert change.overview_flag == "identical"
+    assert change.overview_similarity == pytest.approx(1.0)
+
+
+def test_overview_similarity_missing_one_side_is_not_comparable(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(
+        a,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={"ai-coding": _page("ai-coding", "Overview present in A.")},
+    )
+    _seed(
+        b,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        # no topics.json on B
+    )
+
+    change = diff_snapshots(a, b).topics.per_slug["ai-coding"]
+    assert change.overview_flag == "not_comparable"
+    assert change.overview_similarity is None
+
+
+def test_overview_similarity_disjoint_flags_different(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(
+        a,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={"ai-coding": _page("ai-coding", "alpha bravo charlie delta echo")},
+    )
+    _seed(
+        b,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={"ai-coding": _page("ai-coding", "xenon yankee zulu omega tango")},
+    )
+
+    change = diff_snapshots(a, b).topics.per_slug["ai-coding"]
+    assert change.overview_flag == "different"
+    assert change.overview_similarity == pytest.approx(0.0)
+
+
+def test_overview_similarity_similar_text_above_threshold(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(
+        a,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={
+            "ai-coding": _page(
+                "ai-coding",
+                "the agentic workflow runs locally with full traces",
+            )
+        },
+    )
+    _seed(
+        b,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={
+            "ai-coding": _page(
+                "ai-coding",
+                "the agentic workflow runs locally with full visibility",
+            )
+        },
+    )
+
+    change = diff_snapshots(a, b).topics.per_slug["ai-coding"]
+    assert change.overview_flag in ("similar", "identical")
+    assert change.overview_similarity is not None and change.overview_similarity > 0.5
+
+
+def test_vocab_added_and_removed_set_correctly(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={}, vocab_slugs=["alpha", "bravo", "charlie"])
+    _seed(b, items={}, vocab_slugs=["bravo", "charlie", "delta"])
+
+    report = diff_snapshots(a, b)
+
+    assert report.vocab.added == ["delta"]
+    assert report.vocab.removed == ["alpha"]
+    assert report.vocab.unchanged == ["bravo", "charlie"]
+
+
+def test_missing_vocab_yaml_on_one_side_does_not_crash(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={}, vocab_slugs=["alpha", "bravo"])
+    _seed(b, items={})  # no vocab.yaml on B at all
+
+    report = diff_snapshots(a, b)
+
+    assert report.vocab.added == []
+    assert sorted(report.vocab.removed) == ["alpha", "bravo"]
+
+
+def test_missing_topics_json_on_one_side_does_not_crash(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(
+        a,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+        pages={"ai-coding": _page("ai-coding", "Overview text.")},
+    )
+    _seed(
+        b,
+        items={"1": _item("1", primary="ai-coding")},
+        vocab_slugs=["ai-coding"],
+    )
+
+    change = diff_snapshots(a, b).topics.per_slug["ai-coding"]
+    assert change.overview_flag == "not_comparable"
+
+
+def test_top_transitions_sorted_by_count_then_pair(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    # 3 items: 2x ai-coding -> software, 1x misc -> software
+    _seed(
+        a,
+        items={
+            "1": _item("1", primary="ai-coding"),
+            "2": _item("2", primary="ai-coding"),
+            "3": _item("3", primary="misc"),
+        },
+        vocab_slugs=["ai-coding", "misc", "software"],
+    )
+    _seed(
+        b,
+        items={
+            "1": _item("1", primary="software"),
+            "2": _item("2", primary="software"),
+            "3": _item("3", primary="software"),
+        },
+        vocab_slugs=["ai-coding", "misc", "software"],
+    )
+
+    transitions = diff_snapshots(a, b).items.top_transitions
+    # The first one is the most frequent
+    assert transitions[0].from_topic == "ai-coding"
+    assert transitions[0].count == 2
+    assert transitions[1].from_topic == "misc"
+    assert transitions[1].count == 1
+
+
+def test_format_text_renders_section_headers(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    _seed(a, items={"1": _item("1", primary="misc")}, vocab_slugs=["misc"])
+    text = format_text(diff_snapshots(a, a))
+    assert "ITEMS" in text
+    assert "TOPICS" in text
+    assert "OVERVIEWS" in text
+    assert "VOCAB" in text
+
+
+def test_format_json_round_trips_through_model(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    _seed(a, items={"1": _item("1", primary="misc")}, vocab_slugs=["misc"])
+    text = format_json(diff_snapshots(a, a))
+    parsed = json.loads(text)
+    # Top-level keys match the model
+    assert set(parsed.keys()) == {"summary", "items", "topics", "vocab"}
+    # And the model can re-validate its own JSON
+    DiffReport.model_validate_json(text)
+
+
+# ------------------------------------------------------------------------- CLI
+
+
+def _setup_repo(tmp_path: Path, monkeypatch) -> Path:
+    (tmp_path / "config.toml").write_text(
+        "[paths]\n"
+        f'vault = "{tmp_path / "vault"}"\n'
+        'output_subdir = "x-knowledge"\n'
+        'data_dir = "data"\n'
+        "[x]\n"
+        'handle = "vgonpa"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "vault").mkdir()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    monkeypatch.setenv("XBRAIN_REPO_ROOT", str(tmp_path))
+    return data_dir
+
+
+def test_cli_diff_compares_two_named_snapshots(tmp_path: Path, monkeypatch) -> None:
+    data_dir = _setup_repo(tmp_path, monkeypatch)
+    _seed(data_dir, items={"1": _item("1", primary="alpha")}, vocab_slugs=["alpha"])
+    snap_a, _ = snapshot_create(data_dir, command="manual", dir_label="checkpoint-a")
+    # Mutate then snapshot again — the reassignment is observable
+    _seed(data_dir, items={"1": _item("1", primary="bravo")}, vocab_slugs=["alpha", "bravo"])
+    snap_b, _ = snapshot_create(data_dir, command="manual", dir_label="checkpoint-b")
+
+    result = runner.invoke(app, ["diff", snap_a.name, snap_b.name])
+
+    assert result.exit_code == 0, result.output
+    assert "ITEMS" in result.stdout
+    assert "alpha" in result.stdout
+    assert "bravo" in result.stdout
+
+
+def test_cli_diff_defaults_b_to_live_data_dir(tmp_path: Path, monkeypatch) -> None:
+    data_dir = _setup_repo(tmp_path, monkeypatch)
+    _seed(data_dir, items={"1": _item("1", primary="alpha")}, vocab_slugs=["alpha"])
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="before")
+    # Mutate the live data/ — that is the B side without an explicit name.
+    _seed(data_dir, items={"1": _item("1", primary="bravo")}, vocab_slugs=["alpha", "bravo"])
+
+    result = runner.invoke(app, ["diff", snap.name])
+
+    assert result.exit_code == 0, result.output
+    assert "live data/" in result.stdout
+    # The reassignment shows up
+    assert "reassigned: 1" in result.stdout
+
+
+def test_cli_diff_format_json_parses_back(tmp_path: Path, monkeypatch) -> None:
+    data_dir = _setup_repo(tmp_path, monkeypatch)
+    _seed(data_dir, items={"1": _item("1", primary="alpha")}, vocab_slugs=["alpha"])
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="x")
+
+    result = runner.invoke(app, ["diff", snap.name, "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.stdout)
+    assert set(parsed.keys()) == {"summary", "items", "topics", "vocab"}
+
+
+def test_cli_diff_unknown_snapshot_exits_1(tmp_path: Path, monkeypatch) -> None:
+    _setup_repo(tmp_path, monkeypatch)
+    result = runner.invoke(app, ["diff", "does-not-exist"])
+    assert result.exit_code == 1
+    assert "No snapshot named" in result.output
+
+
+def test_cli_diff_unknown_format_exits_1(tmp_path: Path, monkeypatch) -> None:
+    data_dir = _setup_repo(tmp_path, monkeypatch)
+    _seed(data_dir, items={"1": _item("1", primary="alpha")}, vocab_slugs=["alpha"])
+    snap, _ = snapshot_create(data_dir, command="manual", dir_label="x")
+
+    result = runner.invoke(app, ["diff", snap.name, "--format", "xml"])
+
+    assert result.exit_code == 1
+    assert "format" in result.output.lower()


### PR DESCRIPTION
## Summary

Adds `xbrain diff <snapshot-a> [snapshot-b]` — the missing tool to answer
"what changed between two states of `data/`?" after a re-enrichment or
vocab rebuild. Builds on the snapshot system from #17.

- Default `snapshot-b` = the live `data/` so the common case is one short
  command: `xbrain diff <pre-snapshot>` after a destructive run.
- Reports four sections:
  - **Items** — reassignment count, % of enriched-on-both-sides, top N transitions.
  - **Topics** — per-topic membership added/removed/unchanged with a 10% growth flag (5-member floor so tiny topics don't fire false alarms).
  - **Overviews** — TF cosine similarity, bucketed into `identical / similar / different / not_comparable`.
  - **Vocab** — slugs added, removed, unchanged.
- `--format json` emits the pydantic model as JSON; consumers can `jq` or build CI thresholds.

## What ships

- New module `src/xbrain/diff.py` — pure I/O, no CLI side-effects. Pydantic models (`DiffReport`, `ItemsDiff`, `TopicChange`, etc.), pure-Python TF cosine helper, text + JSON renderers.
- New CLI verb `diff` in `src/xbrain/cli.py`.
- `tests/test_diff.py` — 27 tests (unit module + CLI integration via `CliRunner`).
- README — `Commands` table row and a `Snapshots & safety` paragraph + example invocations.
- No new dependencies.

## Spec deviations

None of substance. Implementation matches the PRD on every acceptance criterion.

- **Overview drift:** TF cosine in pure Python (no `scikit-learn`, no embeddings, no API call). Decision documented in PRD §6. Embeddings / LLM-judged similarity remain follow-ups gated on WS3 (#8).
- **Rename detection:** out for v1 per PRD §3.
- **`--judge` flag:** intentionally not stubbed — adds dead code that would have to be redesigned once #8 lands.

## Test plan

- [x] `tests/test_diff.py` — 27 new tests, all green.
- [x] Full suite: 326/326 (305 baseline + 21 from rebased develop's #19 + 27 new).
- [x] `uv run poe check` — all-green:
  - ruff (lint + format), mypy, bandit, vulture, interrogate, deptry, detect-secrets — PASS
  - radon — WARN only on pre-existing C-grade functions (`validate_judgment`, `_render_index`, `_archive_tweet_to_item`); every new function in `diff.py` is A/B
  - tests — 326 PASS
  - coverage — 89% (`diff.py` at 95%)
- [x] Manual: `uv run xbrain diff --help` renders correctly. Manual round-trip with two snapshots produces the expected report.

## Links

- PRD: `zz-support-files/docs/prds/2026-05-22-xbrain-18-diff-snapshots.md`
- Plan: `zz-support-files/docs/implementation-plans/2026-05-22-xbrain-18-diff-snapshots.md`
- Issue: #18
- Depends on: #17 (auto-snapshot) — already merged into develop