### PR TITLE
[#33] Phase A: download X-post photos and render in notes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -248,21 +248,23 @@ The numbered stages above are summarised; the sections below cover each one in d
 
 ### media
 
-**What it does.** Downloads X-post photos referenced in `Item.media` and persists the bytes locally so the wiki can render them inline. Phase A scope (issue #33) — photos only; videos remain in `video_pending` for a later phase. Walks every `MediaPhotoPending` entry, downloads from `pbs.twimg.com` with a cascading size fallback (`name=orig` → `name=large` → `name=medium`), validates the bytes with Pillow, and atomically writes the file under `data/media/<item-id>/<index>.<ext>`.
+**What it does.** Downloads X-post photos referenced in `Item.media` and persists the bytes locally so the wiki can render them inline. Photos only; videos remain in `video_pending` for a future iteration. Walks every `MediaPhotoPending` entry, downloads from `pbs.twimg.com` with a cascading size fallback (`name=orig` → `name=large` → `name=medium`), validates the bytes with Pillow, and atomically writes the file under `data/media/<item-id>/<index>.<ext>`.
 
 **Reads.** `data/items.json` (the URLs to download).
 
 **Writes.** `data/items.json` (each photo entry transitions to `MediaPhotoDownloaded` or `MediaPhotoFailed`) and `data/media/<item-id>/<index>.<ext>` (the bytes).
 
-**State machine.** Photos pass through one of two terminal-ish states per run:
+**State machine.** Each `xbrain media` run advances eligible photo entries:
 - `Pending` → `Downloaded` (bytes on disk, dimensions + size recorded).
 - `Pending` → `Failed(reason)` (no bytes; reason categorised).
 
-A subsequent run re-attempts `Failed` entries whose reason is in `_TRANSIENT_MEDIA_FAILURES` (`http_5xx`, `timeout`, `unknown_error`) — same retry contract as `fetch` (#19). Permanent failures (`http_4xx`, `format_error`) only retry with `--force`. Already-downloaded photos are skipped unless `--force`.
+`Failed(transient)` is not a terminal state — the next run auto-retries it. A subsequent run re-attempts `Failed` entries whose reason is in `_TRANSIENT_MEDIA_FAILURES` (`http_5xx`, `timeout`, `unknown_error`) — same retry contract as `fetch`. Permanent failures (`http_4xx`, `format_error`) only retry with `--force`. Already-downloaded photos are skipped unless `--force`.
+
+**Storage layout.** Photo bytes live under `data/media/<item-id>/<index>.<ext>` (gitignored). The atomic write uses a sibling `<n>.<ext>.part` tmp file; orphan `.part` files left by SIGKILL/OOM are swept on the next `download_all` entry. The vault mirror at `<output_subdir>/_media/<item-id>/<index>.<ext>` is written by `generate`, not by `media`, so the vault stays in sync with whichever subset of items `--since`/`--until` is regenerating.
 
 **Ctrl-C safety.** The orchestrator calls a per-photo `on_progress` callback that writes `items.json` atomically between photos. A Ctrl-C mid-batch leaves a coherent store and the next run picks up where it left off.
 
-**Snapshot trigger.** `xbrain media` always snapshots `data/` first (label `pre-media`), mirroring the #17 destructive-op recovery boundary.
+**Snapshot trigger.** `xbrain media` always snapshots `data/` first (label `pre-media`), mirroring the destructive-op recovery boundary. The snapshot covers `items.json` / `state.json` / `vocab.yaml` / `topics.json` only — the binary photo bytes under `data/media/` are NOT included; re-downloading via `xbrain media` is the recovery path.
 
 ### vocab
 
@@ -335,7 +337,7 @@ Everything XBrain knows lives in four files inside `data/` (gitignored). They ar
 | `state.json` | JSON | Extractor cursors (`last_seen_id`, `last_run`) per source, archive-import marker | `extract`, `import-archive` |
 | `vocab.yaml` | YAML list of `Topic` | The controlled topic taxonomy — closed list of slugs + descriptions | `vocab` |
 | `topics.json` | JSON dict of `TopicPage` | The synthesized topic-page overviews and notes, keyed by slug | `topics` |
-| `media/<id>/<n>.<ext>` | binary (jpg/png/webp) | Downloaded photo bytes for each `MediaPhotoDownloaded` entry in `items.json` (#33) | `media` |
+| `media/<id>/<n>.<ext>` | binary (jpg/png/webp) | Downloaded photo bytes for each `MediaPhotoDownloaded` entry in `items.json` | `media` |
 
 The shapes are defined as pydantic models in [`src/xbrain/models.py`](src/xbrain/models.py). Reading those is the fastest way to understand the data layer in full.
 
@@ -436,7 +438,7 @@ These are the rules the rest of the architecture rests on. Breaking any of them 
 7. **Operation names, not query ids.** The extractor anchors to X GraphQL operation names because X rotates the ids. Anything that hardcodes an id will break.
 8. **Destructive ops are reversible.** Every command that overwrites a `data/` artifact (`vocab --regenerate`, `topics --resynth`, `fetch --force`) snapshots `data/` first to `data/snapshots/<ts>-pre-<command>/`. `xbrain snapshot restore <name>` is the recovery path. A snapshot failure aborts the destructive op.
 9. **Fetch records are tagged unions.** A `ContentSource` on `items.json` is either a `Success` (with required `text`) or a `Failure` (with required `failure_reason`). Mixed shapes are not representable — pydantic rejects them at construction, and mypy rejects them statically (via the `pydantic.mypy` plugin). Legacy records with `ok: bool` (pre-#20) are normalised on read by a `BeforeValidator` on the union, so existing `data/items.json` files keep working without a manual migration. The static contract is pinned by `tests/type_probes/illegal_states.py`.
-10. **Media variants are mutually exclusive states.** A `MediaEntry` on `items.json` is one of `MediaPhotoPending` / `MediaPhotoDownloaded` / `MediaPhotoFailed` / `MediaVideoPending`, discriminated by the `kind` field. A photo is in exactly one state at a time — never both "downloaded" and "failed". State transitions happen only via `xbrain media`: `Pending` → `Downloaded` (bytes on disk, dimensions + size recorded) or `Pending` → `Failed` (categorised reason recorded). Transient failures (`http_5xx`, `timeout`, `unknown_error`) are auto-retried on the next run, mirroring #19. Permanent failures (`http_4xx`, `format_error`) only retry with `--force`. Videos remain in `video_pending` for the whole of Phase A (#33). Legacy records with the flat `{type, url}` shape (pre-#33) are normalised on read by a `BeforeValidator` on the union — no manual migration needed. Photo bytes live under `data/media/<item-id>/<index>.<ext>` (gitignored) and are mirrored into `<vault>/<output_subdir>/_media/` at `xbrain generate` time so the vault is self-contained.
+10. **Media variants are mutually exclusive states.** A `MediaEntry` on `items.json` is one of `MediaPhotoPending` / `MediaPhotoDownloaded` / `MediaPhotoFailed` / `MediaVideoPending`, discriminated by `kind`. State transitions happen only via `xbrain media`. Legacy records with the flat `{type, url}` shape are normalised on read by a `BeforeValidator` on the union — no manual migration needed. (See the `### media` section above for the retry contract and storage layout.)
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -246,6 +246,24 @@ The numbered stages above are summarised; the sections below cover each one in d
 
 **Caching.** `fetch` is cached per item id — it does not re-fetch items that already have a `ContentSource` (success or recorded failure). Use `--force` to re-fetch everything. (Selective retry of transient failures is a planned improvement — issue #19.)
 
+### media
+
+**What it does.** Downloads X-post photos referenced in `Item.media` and persists the bytes locally so the wiki can render them inline. Phase A scope (issue #33) — photos only; videos remain in `video_pending` for a later phase. Walks every `MediaPhotoPending` entry, downloads from `pbs.twimg.com` with a cascading size fallback (`name=orig` → `name=large` → `name=medium`), validates the bytes with Pillow, and atomically writes the file under `data/media/<item-id>/<index>.<ext>`.
+
+**Reads.** `data/items.json` (the URLs to download).
+
+**Writes.** `data/items.json` (each photo entry transitions to `MediaPhotoDownloaded` or `MediaPhotoFailed`) and `data/media/<item-id>/<index>.<ext>` (the bytes).
+
+**State machine.** Photos pass through one of two terminal-ish states per run:
+- `Pending` → `Downloaded` (bytes on disk, dimensions + size recorded).
+- `Pending` → `Failed(reason)` (no bytes; reason categorised).
+
+A subsequent run re-attempts `Failed` entries whose reason is in `_TRANSIENT_MEDIA_FAILURES` (`http_5xx`, `timeout`, `unknown_error`) — same retry contract as `fetch` (#19). Permanent failures (`http_4xx`, `format_error`) only retry with `--force`. Already-downloaded photos are skipped unless `--force`.
+
+**Ctrl-C safety.** The orchestrator calls a per-photo `on_progress` callback that writes `items.json` atomically between photos. A Ctrl-C mid-batch leaves a coherent store and the next run picks up where it left off.
+
+**Snapshot trigger.** `xbrain media` always snapshots `data/` first (label `pre-media`), mirroring the #17 destructive-op recovery boundary.
+
 ### vocab
 
 **What it does.** Induces a closed taxonomy of ~30-45 topics from the whole corpus. Map step: chunks the corpus, asks an LLM to propose candidate topics per chunk. Reduce step: asks the LLM to consolidate the union of candidates down to `vocab.target_count` topics. Always includes a `misc` topic for posts with no thematic core.
@@ -309,14 +327,15 @@ You can annotate, link, and write below the marker — `generate` never touches 
 
 ## Artifacts: the data layer
 
-Everything XBrain knows lives in four files inside `data/` (gitignored). They are JSON or YAML, plain text, human-readable, and small enough that you can `jq` them.
+Everything XBrain knows lives in four files inside `data/` (gitignored). They are JSON or YAML, plain text, human-readable, and small enough that you can `jq` them. Binary assets (photo bytes from `xbrain media`) live alongside under `data/media/<id>/`.
 
 | File | Format | What it is | Mutated by |
 |------|--------|------------|------------|
-| `items.json` | JSON array of `Item` | The source of truth — every post XBrain has ever seen, with all fetched content and enrichment | `extract`, `fetch`, `enrich` |
+| `items.json` | JSON array of `Item` | The source of truth — every post XBrain has ever seen, with all fetched content and enrichment | `extract`, `fetch`, `enrich`, `media` |
 | `state.json` | JSON | Extractor cursors (`last_seen_id`, `last_run`) per source, archive-import marker | `extract`, `import-archive` |
 | `vocab.yaml` | YAML list of `Topic` | The controlled topic taxonomy — closed list of slugs + descriptions | `vocab` |
 | `topics.json` | JSON dict of `TopicPage` | The synthesized topic-page overviews and notes, keyed by slug | `topics` |
+| `media/<id>/<n>.<ext>` | binary (jpg/png/webp) | Downloaded photo bytes for each `MediaPhotoDownloaded` entry in `items.json` (#33) | `media` |
 
 The shapes are defined as pydantic models in [`src/xbrain/models.py`](src/xbrain/models.py). Reading those is the fastest way to understand the data layer in full.
 
@@ -417,6 +436,7 @@ These are the rules the rest of the architecture rests on. Breaking any of them 
 7. **Operation names, not query ids.** The extractor anchors to X GraphQL operation names because X rotates the ids. Anything that hardcodes an id will break.
 8. **Destructive ops are reversible.** Every command that overwrites a `data/` artifact (`vocab --regenerate`, `topics --resynth`, `fetch --force`) snapshots `data/` first to `data/snapshots/<ts>-pre-<command>/`. `xbrain snapshot restore <name>` is the recovery path. A snapshot failure aborts the destructive op.
 9. **Fetch records are tagged unions.** A `ContentSource` on `items.json` is either a `Success` (with required `text`) or a `Failure` (with required `failure_reason`). Mixed shapes are not representable — pydantic rejects them at construction, and mypy rejects them statically (via the `pydantic.mypy` plugin). Legacy records with `ok: bool` (pre-#20) are normalised on read by a `BeforeValidator` on the union, so existing `data/items.json` files keep working without a manual migration. The static contract is pinned by `tests/type_probes/illegal_states.py`.
+10. **Media variants are mutually exclusive states.** A `MediaEntry` on `items.json` is one of `MediaPhotoPending` / `MediaPhotoDownloaded` / `MediaPhotoFailed` / `MediaVideoPending`, discriminated by the `kind` field. A photo is in exactly one state at a time — never both "downloaded" and "failed". State transitions happen only via `xbrain media`: `Pending` → `Downloaded` (bytes on disk, dimensions + size recorded) or `Pending` → `Failed` (categorised reason recorded). Transient failures (`http_5xx`, `timeout`, `unknown_error`) are auto-retried on the next run, mirroring #19. Permanent failures (`http_4xx`, `format_error`) only retry with `--force`. Videos remain in `video_pending` for the whole of Phase A (#33). Legacy records with the flat `{type, url}` shape (pre-#33) are normalised on read by a `BeforeValidator` on the union — no manual migration needed. Photo bytes live under `data/media/<item-id>/<index>.<ext>` (gitignored) and are mirrored into `<vault>/<output_subdir>/_media/` at `xbrain generate` time so the vault is self-contained.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ uv run xbrain <command> [options]
 | `extract` | Extract bookmarks and/or own tweets from X. `--source bookmarks\|tweets\|all`. |
 | `import-archive <zip>` | Backfill the full own-tweet history from the official X data archive. |
 | `fetch` | Download linked article content, expand threads, fetch linked X content. By default, items whose only previous failures were transient (`timeout`, `dns_error`) are re-fetched automatically; terminal failures (`not_found`, `paywall`, `forbidden`, `js_required`, `empty_content`) stay skipped until `--force`. `--force` re-fetches every external_article source regardless of state. |
+| `media` | Download X-post photos referenced in `Item.media` and persist the bytes under `data/media/<item-id>/<index>.<ext>`. Idempotent — already-downloaded photos are skipped unless `--force`. Transient failures (HTTP 5xx, timeout, unknown errors) are auto-retried on the next run; permanent failures (HTTP 4xx, format errors) only with `--force`. `--limit N` caps the download count for a single run; `--items <a,b,c>` restricts the run to specific item IDs. Videos remain in their `video_pending` state — Phase A is photos only. See [Local media storage](#local-media-storage). |
 | `vocab` | Induce the topic taxonomy. `--executor`, `--apply <file>`, `--regenerate`. |
 | `enrich` | Enrich items with a summary + topics. `--executor`, `--apply <file>`. |
 | `topics` | Synthesise topic pages. `--executor`, `--apply <file>`, `--resynth`. |
@@ -528,6 +529,61 @@ uv run xbrain <command> [options]
 
 Every stage accepts `--since` / `--until` (ISO dates) to narrow the date window.
 Run `uv run xbrain <command> --help` for the full option list.
+
+---
+
+## Local media storage
+
+`xbrain media` (Phase A — issue #33) downloads X-post photos and persists
+the bytes locally so the generated wiki shows the images inline.
+
+**Layout**
+
+```
+data/
+└── media/
+    ├── 1234567890/    # one directory per item id
+    │   ├── 0.jpg      # one file per photo, indexed by media position
+    │   ├── 1.jpg
+    │   └── 2.png
+    └── ...
+```
+
+Files are stored under `data/media/<item-id>/<index>.<ext>`; the extension
+matches the format the X CDN sent us (`.jpg`, `.png`, or `.webp`).
+`data/` is gitignored — the bytes never enter the repo.
+
+**Vault rendering**
+
+`xbrain generate` mirrors each downloaded photo from `data/media/` into
+`<vault>/<output_subdir>/_media/<item-id>/<index>.<ext>` at render time
+and emits Obsidian wikilink embeds (`![[_media/<id>/<n>.<ext>]]`) so the
+vault is fully self-contained. No symlinks, no Obsidian config needed.
+
+**Disk budget**
+
+Empirically ~300 KB per photo (X serves `name=orig` JPEGs in the
+1-2 MP range). A corpus of ~2,000 items with an average of one photo
+per item lands at roughly 300-500 MB on disk — well within personal-machine
+scale. `--limit N` caps a single run if you want to throttle the first
+backfill.
+
+**Throttling**
+
+The downloader sleeps 0.5 s between requests by default and uses a
+browser-style User-Agent. pbs.twimg.com tolerates that pattern; bursting
+from a fresh IP earns a 429.
+
+**Failure handling**
+
+Failures are categorised on the item itself
+(`MediaPhotoFailed.failure_reason`):
+- `http_4xx`, `format_error` — permanent; only `--force` retries.
+- `http_5xx`, `timeout`, `unknown_error` — transient; auto-retried on
+  the next `xbrain media` run.
+
+Run `xbrain diff <snapshot>` after a media run to see how many photos
+moved from `pending` / `failed` into `downloaded`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -516,7 +516,7 @@ uv run xbrain <command> [options]
 | `extract` | Extract bookmarks and/or own tweets from X. `--source bookmarks\|tweets\|all`. |
 | `import-archive <zip>` | Backfill the full own-tweet history from the official X data archive. |
 | `fetch` | Download linked article content, expand threads, fetch linked X content. By default, items whose only previous failures were transient (`timeout`, `dns_error`) are re-fetched automatically; terminal failures (`not_found`, `paywall`, `forbidden`, `js_required`, `empty_content`) stay skipped until `--force`. `--force` re-fetches every external_article source regardless of state. |
-| `media` | Download X-post photos referenced in `Item.media` and persist the bytes under `data/media/<item-id>/<index>.<ext>`. Idempotent — already-downloaded photos are skipped unless `--force`. Transient failures (HTTP 5xx, timeout, unknown errors) are auto-retried on the next run; permanent failures (HTTP 4xx, format errors) only with `--force`. `--limit N` caps the download count for a single run; `--items <a,b,c>` restricts the run to specific item IDs. Videos remain in their `video_pending` state — Phase A is photos only. See [Local media storage](#local-media-storage). |
+| `media` | Download X-post photos referenced in `Item.media` and render them inline in the wiki. `--force`, `--limit N`, `--items <a,b,c>`, `--verbose`. See [Local media storage](#local-media-storage). |
 | `vocab` | Induce the topic taxonomy. `--executor`, `--apply <file>`, `--regenerate`. |
 | `enrich` | Enrich items with a summary + topics. `--executor`, `--apply <file>`. |
 | `topics` | Synthesise topic pages. `--executor`, `--apply <file>`, `--resynth`. |
@@ -534,8 +534,8 @@ Run `uv run xbrain <command> --help` for the full option list.
 
 ## Local media storage
 
-`xbrain media` (Phase A — issue #33) downloads X-post photos and persists
-the bytes locally so the generated wiki shows the images inline.
+`xbrain media` downloads X-post photos and persists the bytes locally so
+the generated wiki shows the images inline.
 
 **Layout**
 
@@ -560,13 +560,13 @@ matches the format the X CDN sent us (`.jpg`, `.png`, or `.webp`).
 and emits Obsidian wikilink embeds (`![[_media/<id>/<n>.<ext>]]`) so the
 vault is fully self-contained. No symlinks, no Obsidian config needed.
 
-**Disk budget**
+**Disk budget (approximate)**
 
-Empirically ~300 KB per photo (X serves `name=orig` JPEGs in the
-1-2 MP range). A corpus of ~2,000 items with an average of one photo
-per item lands at roughly 300-500 MB on disk — well within personal-machine
-scale. `--limit N` caps a single run if you want to throttle the first
-backfill.
+X serves `name=orig` JPEGs typically in the 1-2 MP range, averaging
+~300 KB per photo on our corpora. A library of ~2,000 items with roughly
+one photo per item lands in the ballpark of 300-500 MB on disk —
+comfortably within personal-machine scale. Use `--limit N` to throttle
+the first backfill.
 
 **Throttling**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "trafilatura>=1.9",
     "anthropic>=0.39",
     "pyyaml>=6.0",
+    "pillow>=12.2.0",
 ]
 
 [project.scripts]
@@ -121,3 +122,8 @@ docs       = "interrogate src/xbrain"
 deps       = "deptry ."
 test       = "pytest -q"
 check      = "bash scripts/check.sh"
+
+[dependency-groups]
+dev = [
+    "requests-mock>=1.12.1",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "anthropic>=0.39",
     "pyyaml>=6.0",
     "pillow>=12.2.0",
+    "requests>=2.34.2",
 ]
 
 [project.scripts]

--- a/src/xbrain/archive.py
+++ b/src/xbrain/archive.py
@@ -11,7 +11,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from xbrain.extract.graphql import _parse_x_date
-from xbrain.models import Author, Item, Link, Media
+from xbrain.models import Author, Item, Link, Media, MediaEntry
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +71,7 @@ def _archive_tweet_to_item(entry: dict[str, Any], author: Author) -> Item | None
     media_entries = tweet.get("extended_entities", {}).get("media") or tweet.get(
         "entities", {}
     ).get("media", [])
-    media = [
+    media: list[MediaEntry] = [
         Media(
             type="video" if media_entity.get("type") in ("video", "animated_gif") else "photo",
             url=media_entity.get("media_url_https") or media_entity["expanded_url"],

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -24,6 +24,8 @@ from xbrain.extract.threads import expand_threads
 from xbrain.fetch import fetch_pending
 from xbrain.fetch_x import fetch_x_articles
 from xbrain.generate import generate as run_generate
+from xbrain.media import download_all as run_media_download
+from xbrain.media import emit_summary_line as media_emit_summary_line
 from xbrain.models import ArchiveImport, Author, SourceName
 from xbrain.rubrics import load_vocab, save_vocab
 from xbrain.store import (
@@ -238,6 +240,84 @@ def fetch(
 ) -> None:
     """Descarga el contenido de los artículos enlazados."""
     _run_fetch(_config(), _parse_date(since), _parse_date(until), force)
+
+
+def _run_media(
+    cfg: Config,
+    *,
+    force: bool,
+    limit: int | None,
+    items_filter: list[str] | None,
+) -> None:
+    """Run the photo downloader: snapshot, load, download, persist, summarise.
+
+    Always snapshots `data/` first (the same recovery boundary as
+    `vocab --regenerate` etc, #17): a botched run can be undone with
+    `xbrain snapshot restore`.
+
+    Persistence happens twice: once after every photo transition (the
+    `on_progress` callback writes the store atomically, so Ctrl-C mid-run
+    leaves `items.json` coherent), and once unconditionally at the end so
+    the elapsed timestamp on the last `MediaPhotoDownloaded` is captured
+    even if no transition fired (e.g. a `--limit 0` no-op).
+    """
+    _auto_snapshot(cfg, "media")
+    store = load_store(cfg.items_path)
+
+    def _persist() -> None:
+        save_store(store, cfg.items_path)
+
+    try:
+        report = run_media_download(
+            store,
+            cfg.media_dir,
+            force=force,
+            limit=limit,
+            items_filter=items_filter,
+            on_progress=_persist,
+        )
+    finally:
+        # Persist whatever changed, even if `download_all` raised. A
+        # RuntimeError on total failure must not discard the per-photo
+        # MediaPhotoFailed records that landed before the raise.
+        save_store(store, cfg.items_path)
+    media_emit_summary_line(report)
+    typer.echo(
+        f"Media: descargadas {report.photos_downloaded}, "
+        f"fallidas {report.photos_failed_permanent + report.photos_failed_transient}, "
+        f"saltadas {report.photos_skipped_already_downloaded}"
+    )
+
+
+@app.command()
+@_handle_cli_errors
+def media(
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Re-descargar todas las fotos, incluso las ya descargadas o permanentemente "
+        "fallidas (HTTP 4xx, format_error).",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        help="Máximo número de descargas a intentar en esta ejecución.",
+    ),
+    items: str | None = typer.Option(
+        None,
+        "--items",
+        help="IDs de items separados por comas para limitar el alcance del run.",
+    ),
+) -> None:
+    """Descarga las fotos de los X-posts referenciadas en `items.json`.
+
+    Solo descarga fotos (`MediaPhotoPending` + reintentos transient). Los
+    vídeos quedan en su variante `MediaVideoPending` para una fase posterior
+    — la opción `--force` NO los descarga.
+    """
+    cfg = _config()
+    items_filter = [s.strip() for s in items.split(",") if s.strip()] if items else None
+    _run_media(cfg, force=force, limit=limit, items_filter=items_filter)
 
 
 @app.command()

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -256,11 +256,12 @@ def _run_media(
     force: bool,
     limit: int | None,
     items_filter: list[str] | None,
+    verbose: bool = False,
 ) -> None:
     """Run the photo downloader: snapshot, load, download, persist, summarise.
 
     Always snapshots `data/` first (the same recovery boundary as
-    `vocab --regenerate` etc, #17): a botched run can be undone with
+    `vocab --regenerate` etc): a botched run can be undone with
     `xbrain snapshot restore`.
 
     Persistence happens twice: once after every photo transition (the
@@ -268,7 +269,27 @@ def _run_media(
     leaves `items.json` coherent), and once unconditionally at the end so
     the elapsed timestamp on the last `MediaPhotoDownloaded` is captured
     even if no transition fired (e.g. a `--limit 0` no-op).
+
+    Persistence failure semantics: if `save_store` raises inside the
+    `on_progress` callback (e.g. disk full), the exception propagates and
+    aborts the run. The state of `items.json` for the photo currently
+    being processed is whatever the previous successful write captured;
+    later items remain in their pre-run variant. The `finally` block
+    below still attempts a final write, but on a disk-full condition that
+    too may fail — in which case the in-memory transitions for the
+    interrupted batch are lost. This is acceptable: a re-run after the
+    operator clears the disk picks up every still-pending photo cleanly.
     """
+    if items_filter:
+        target = set(items_filter)
+        store_ids = set(load_store(cfg.items_path))
+        missing = target - store_ids
+        if missing and not (target & store_ids):
+            typer.echo(
+                f"AVISO: --items {','.join(items_filter)} no coincide con ningún item "
+                f"del store ({len(store_ids)} items). El run será un no-op.",
+                err=True,
+            )
     _auto_snapshot(cfg, "media")
     store = load_store(cfg.items_path)
 
@@ -295,6 +316,11 @@ def _run_media(
         f"fallidas {report.photos_failed_permanent + report.photos_failed_transient}, "
         f"saltadas {report.photos_skipped_already_downloaded}"
     )
+    if verbose and report.per_item_failures:
+        typer.echo("Failed photos:", err=True)
+        for item_id, failures in sorted(report.per_item_failures.items()):
+            for url, reason in failures:
+                typer.echo(f"  {item_id}  {reason:<14}  {url}", err=True)
 
 
 @app.command()
@@ -316,6 +342,11 @@ def media(
         "--items",
         help="IDs de items separados por comas para limitar el alcance del run.",
     ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        help="Imprime cada foto fallida (item_id, motivo, URL) al final del run.",
+    ),
 ) -> None:
     """Descarga las fotos de los X-posts referenciadas en `items.json`.
 
@@ -325,7 +356,7 @@ def media(
     """
     cfg = _config()
     items_filter = [s.strip() for s in items.split(",") if s.strip()] if items else None
-    _run_media(cfg, force=force, limit=limit, items_filter=items_filter)
+    _run_media(cfg, force=force, limit=limit, items_filter=items_filter, verbose=verbose)
 
 
 @app.command()

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -194,7 +194,15 @@ def _run_fetch(cfg: Config, since: datetime | None, until: datetime | None, forc
 
 def _run_generate(cfg: Config, since: datetime | None, until: datetime | None) -> None:
     store = load_store(cfg.items_path)
-    run_generate(store, cfg.output_dir, since, until, cfg.output_language, cfg.topic_style)
+    run_generate(
+        store,
+        cfg.output_dir,
+        since,
+        until,
+        cfg.output_language,
+        cfg.topic_style,
+        media_root=cfg.media_dir,
+    )
     typer.echo(f"Markdown generado en {cfg.output_dir}")
 
 

--- a/src/xbrain/config.py
+++ b/src/xbrain/config.py
@@ -35,6 +35,18 @@ class Config:
         return self.data_dir / "items.json"
 
     @property
+    def media_dir(self) -> Path:
+        """Root directory for downloaded photo bytes (Phase A — issue #33).
+
+        Photos are stored at ``<media_dir>/<item-id>/<index>.<ext>``. Lives
+        under `data/` so it shares the gitignore with the rest of the
+        artifact tree, and so `xbrain snapshot` would naturally bundle it
+        with a future copy step (out of scope for #33 — snapshots cover
+        the JSON store, not the media bytes).
+        """
+        return self.data_dir / "media"
+
+    @property
     def state_path(self) -> Path:
         return self.data_dir / "state.json"
 

--- a/src/xbrain/config.py
+++ b/src/xbrain/config.py
@@ -36,13 +36,15 @@ class Config:
 
     @property
     def media_dir(self) -> Path:
-        """Root directory for downloaded photo bytes (Phase A — issue #33).
+        """Root directory for downloaded photo bytes.
 
         Photos are stored at ``<media_dir>/<item-id>/<index>.<ext>``. Lives
         under `data/` so it shares the gitignore with the rest of the
-        artifact tree, and so `xbrain snapshot` would naturally bundle it
-        with a future copy step (out of scope for #33 — snapshots cover
-        the JSON store, not the media bytes).
+        artifact tree. The snapshot lifecycle in `xbrain.snapshot`
+        currently covers only the JSON store (`items.json`, `state.json`,
+        `vocab.yaml`, `topics.json`) — the binary photo bytes are NOT
+        snapshotted today. A re-download via `xbrain media` is the
+        recovery path if `data/media/` is lost.
         """
         return self.data_dir / "media"
 

--- a/src/xbrain/diff.py
+++ b/src/xbrain/diff.py
@@ -130,7 +130,7 @@ class VocabDiff(BaseModel):
 
 
 class MediaStateCounts(BaseModel):
-    """Counts of media variants on one side of a diff (#33 Phase A).
+    """Counts of media variants on one side of a diff.
 
     Mirrors the four-variant union: downloaded / pending / failed
     / video_pending. Counts are global across all items in the store —
@@ -145,7 +145,7 @@ class MediaStateCounts(BaseModel):
 
 
 class MediaDiff(BaseModel):
-    """Side-by-side media state counts + deltas (#33 Phase A).
+    """Side-by-side media state counts + deltas.
 
     `delta_downloaded = b.downloaded - a.downloaded` answers the
     operator's first question after `xbrain media`: "how many new photos
@@ -387,7 +387,7 @@ def _compute_media_diff(
     items_a: dict[str, Item],
     items_b: dict[str, Item],
 ) -> MediaDiff:
-    """Count media variants on each side and return the deltas (#33 Phase A).
+    """Count media variants on each side and return the deltas.
 
     Walks every media entry on every item — not just the ones in both
     sides, because the question "how many new photos landed?" applies
@@ -518,7 +518,7 @@ def format_text(report: DiffReport) -> str:
 
 
 def _format_media_block(media: MediaDiff) -> list[str]:
-    """Render the per-variant media state counts + deltas (#33 Phase A).
+    """Render the per-variant media state counts + deltas.
 
     The `+N` / `-N` deltas answer the most common operator question after
     `xbrain media`: "did this run move the needle?" Negative deltas show

--- a/src/xbrain/diff.py
+++ b/src/xbrain/diff.py
@@ -26,7 +26,7 @@ import re
 from collections import Counter
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Literal
+from typing import Literal, assert_never
 
 from pydantic import BaseModel, Field
 
@@ -419,6 +419,8 @@ def _count_media_variants(items: dict[str, Item]) -> MediaStateCounts:
                 counts.failed += 1
             elif isinstance(entry, MediaVideoPending):
                 counts.video_pending += 1
+            else:
+                assert_never(entry)
     return counts
 
 

--- a/src/xbrain/diff.py
+++ b/src/xbrain/diff.py
@@ -30,7 +30,15 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from xbrain.models import Item, Topic, TopicPage
+from xbrain.models import (
+    Item,
+    MediaPhotoDownloaded,
+    MediaPhotoFailed,
+    MediaPhotoPending,
+    MediaVideoPending,
+    Topic,
+    TopicPage,
+)
 from xbrain.rubrics import load_vocab
 from xbrain.store import load_store, load_topic_pages
 
@@ -121,6 +129,39 @@ class VocabDiff(BaseModel):
     unchanged_count: int = 0
 
 
+class MediaStateCounts(BaseModel):
+    """Counts of media variants on one side of a diff (#33 Phase A).
+
+    Mirrors the four-variant union: downloaded / pending / failed
+    / video_pending. Counts are global across all items in the store —
+    per-item resolution lives on the items themselves (already
+    diff-able via the items round-trip).
+    """
+
+    downloaded: int = 0
+    pending: int = 0
+    failed: int = 0
+    video_pending: int = 0
+
+
+class MediaDiff(BaseModel):
+    """Side-by-side media state counts + deltas (#33 Phase A).
+
+    `delta_downloaded = b.downloaded - a.downloaded` answers the
+    operator's first question after `xbrain media`: "how many new photos
+    landed?" Same for the other three variants. Negative deltas are
+    legal — `xbrain media --force` can move a previously-downloaded
+    photo back to `failed` if the URL turned 404 in the meantime.
+    """
+
+    a: MediaStateCounts = Field(default_factory=MediaStateCounts)
+    b: MediaStateCounts = Field(default_factory=MediaStateCounts)
+    delta_downloaded: int = 0
+    delta_pending: int = 0
+    delta_failed: int = 0
+    delta_video_pending: int = 0
+
+
 class DiffSummary(BaseModel):
     """Flat top-level counts — used by both the text header and JSON consumers."""
 
@@ -134,6 +175,8 @@ class DiffSummary(BaseModel):
     vocab_removed: int
     topic_pages_a: int
     topic_pages_b: int
+    media_delta_downloaded: int = 0
+    media_delta_failed: int = 0
 
 
 class DiffReport(BaseModel):
@@ -143,6 +186,7 @@ class DiffReport(BaseModel):
     items: ItemsDiff
     topics: TopicsDiff
     vocab: VocabDiff
+    media: MediaDiff = Field(default_factory=MediaDiff)
 
 
 # ----------------------------------------------------------------- public orchestrator
@@ -214,6 +258,7 @@ def diff_snapshots(
         growth_flag_threshold=growth_flag_threshold,
         overview_similarity_threshold=overview_similarity_threshold,
     )
+    media_diff = _compute_media_diff(items_a, items_b)
     summary = DiffSummary(
         items_a=items_diff.count_a,
         items_b=items_diff.count_b,
@@ -225,12 +270,15 @@ def diff_snapshots(
         vocab_removed=len(vocab_diff.removed),
         topic_pages_a=len(pages_a),
         topic_pages_b=len(pages_b),
+        media_delta_downloaded=media_diff.delta_downloaded,
+        media_delta_failed=media_diff.delta_failed,
     )
     return DiffReport(
         summary=summary,
         items=items_diff,
         topics=topics_diff,
         vocab=vocab_diff,
+        media=media_diff,
     )
 
 
@@ -335,6 +383,45 @@ def _compute_topics_diff(
     return TopicsDiff(per_slug=per_slug)
 
 
+def _compute_media_diff(
+    items_a: dict[str, Item],
+    items_b: dict[str, Item],
+) -> MediaDiff:
+    """Count media variants on each side and return the deltas (#33 Phase A).
+
+    Walks every media entry on every item — not just the ones in both
+    sides, because the question "how many new photos landed?" applies
+    equally to items that exist only on B (a fresh `xbrain extract` +
+    `xbrain media` run).
+    """
+    counts_a = _count_media_variants(items_a)
+    counts_b = _count_media_variants(items_b)
+    return MediaDiff(
+        a=counts_a,
+        b=counts_b,
+        delta_downloaded=counts_b.downloaded - counts_a.downloaded,
+        delta_pending=counts_b.pending - counts_a.pending,
+        delta_failed=counts_b.failed - counts_a.failed,
+        delta_video_pending=counts_b.video_pending - counts_a.video_pending,
+    )
+
+
+def _count_media_variants(items: dict[str, Item]) -> MediaStateCounts:
+    """Tally the four media variants across every item in the store."""
+    counts = MediaStateCounts()
+    for item in items.values():
+        for entry in item.media:
+            if isinstance(entry, MediaPhotoDownloaded):
+                counts.downloaded += 1
+            elif isinstance(entry, MediaPhotoPending):
+                counts.pending += 1
+            elif isinstance(entry, MediaPhotoFailed):
+                counts.failed += 1
+            elif isinstance(entry, MediaVideoPending):
+                counts.video_pending += 1
+    return counts
+
+
 def _compute_vocab_diff(vocab_a: list[Topic], vocab_b: list[Topic]) -> VocabDiff:
     """Slug set-difference between two vocab.yaml files (sorted output)."""
     slugs_a = {t.slug for t in vocab_a}
@@ -422,7 +509,39 @@ def format_text(report: DiffReport) -> str:
         f"{', '.join(report.vocab.removed) if report.vocab.removed else '(none)'}"
     )
     lines.append(f"  unchanged: {report.vocab.unchanged_count} slugs")
+    lines.append("")
+    lines.append("MEDIA")
+    lines.extend(_format_media_block(report.media))
     return "\n".join(lines)
+
+
+def _format_media_block(media: MediaDiff) -> list[str]:
+    """Render the per-variant media state counts + deltas (#33 Phase A).
+
+    The `+N` / `-N` deltas answer the most common operator question after
+    `xbrain media`: "did this run move the needle?" Negative deltas show
+    up legitimately when `--force` re-downloads a previously-downloaded
+    photo whose URL has turned 404.
+    """
+    return [
+        f"  downloaded:    A={media.a.downloaded:>5}  B={media.b.downloaded:>5}  "
+        f"({_format_delta(media.delta_downloaded)})",
+        f"  pending:       A={media.a.pending:>5}  B={media.b.pending:>5}  "
+        f"({_format_delta(media.delta_pending)})",
+        f"  failed:        A={media.a.failed:>5}  B={media.b.failed:>5}  "
+        f"({_format_delta(media.delta_failed)})",
+        f"  video_pending: A={media.a.video_pending:>5}  B={media.b.video_pending:>5}  "
+        f"({_format_delta(media.delta_video_pending)})",
+    ]
+
+
+def _format_delta(value: int) -> str:
+    """Render a delta as `+N`, `-N`, or `±0` for the text report."""
+    if value > 0:
+        return f"+{value}"
+    if value < 0:
+        return str(value)
+    return "±0"
 
 
 def format_json(report: DiffReport) -> str:

--- a/src/xbrain/extract/graphql.py
+++ b/src/xbrain/extract/graphql.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Iterator, Literal
 from urllib.parse import urlparse
 
-from xbrain.models import Author, Item, Link, Media, SourceName, ThreadInfo
+from xbrain.models import Author, Item, Link, Media, MediaEntry, SourceName, ThreadInfo
 
 logger = logging.getLogger(__name__)
 
@@ -118,11 +118,11 @@ def _extract_links(legacy: dict[str, Any]) -> list[Link]:
     return links
 
 
-def _extract_media(legacy: dict[str, Any]) -> list[Media]:
+def _extract_media(legacy: dict[str, Any]) -> list[MediaEntry]:
     entries = legacy.get("extended_entities", {}).get("media") or legacy.get("entities", {}).get(
         "media", []
     )
-    media: list[Media] = []
+    media: list[MediaEntry] = []
     for entry in entries:
         kind: Literal["photo", "video"] = (
             "video" if entry.get("type") in ("video", "animated_gif") else "photo"

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -14,6 +15,10 @@ from xbrain.models import (
     ContentSourceSuccess,
     FailureReason,
     Item,
+    MediaPhotoDownloaded,
+    MediaPhotoFailed,
+    MediaPhotoPending,
+    MediaVideoPending,
 )
 from xbrain.notes_io import DEFAULT_TAIL, note_filename, slugify, title_of, user_tail, wrap
 
@@ -29,6 +34,16 @@ _FAILURE_ES: dict[FailureReason, str] = {
     "empty_content": "sin contenido extraíble",
     "unknown_error": "error desconocido",
 }
+
+
+# Subdirectory under `output_dir` where downloaded photos are mirrored at
+# generate time, so an Obsidian vault is fully self-contained. Photos are
+# canonically stored under `data/media/<id>/<n>.<ext>` (Phase A scope) and
+# copied to `<output_dir>/_media/<id>/<n>.<ext>` whenever `generate` runs
+# with a `media_root` argument. The leading underscore keeps the directory
+# at the top of file listings and matches the convention used by static-
+# site generators (Hugo, Jekyll) for non-content assets.
+_VAULT_MEDIA_SUBDIR = "_media"
 
 
 def _broken_link_line(source: ContentSourceFailure, fetched_at: datetime) -> str:
@@ -53,6 +68,7 @@ def generate(
     until: datetime | None = None,
     output_language: str = "English",
     topic_style: str = "wikilink",
+    media_root: Path | None = None,
 ) -> None:
     """Write _index.md, log.md and one note per noted item.
 
@@ -66,6 +82,15 @@ def generate(
     Obsidian ``#slug`` tags. The toggle does not affect frontmatter ``tags:``,
     the index ``## Topics`` section, or the topic-page post lists — those
     stay wikilinks by design.
+
+    `media_root` (Phase A — issue #33) is the directory under which
+    `xbrain media` downloads photos as `<item-id>/<index>.<ext>`. When
+    provided, photos for each item being rendered are copied to
+    `<output_dir>/_media/<item-id>/<index>.<ext>` and embedded in the note
+    body via Obsidian wikilink embeds. When `None`, photo entries render
+    as if no `xbrain media` run had taken place — pending photos are
+    silent, failed and video-pending photos still produce their warning
+    lines (the URL is in the data; only the file bytes are missing).
     """
     if topic_style not in SUPPORTED_TOPIC_STYLES:
         raise ValueError(
@@ -79,12 +104,20 @@ def generate(
     (output_dir / "log.md").write_text(_render_log(items), encoding="utf-8")
     for item in items:
         if _has_note(item) and _in_range(item, since, until):
+            if media_root is not None:
+                _mirror_item_media(item, media_root, output_dir / _VAULT_MEDIA_SUBDIR)
             _write_note(items_dir, item, strings, topic_style)
 
 
 def _has_note(item: Item) -> bool:
-    """An item gets its own note if it has links or has been enriched."""
-    return bool(item.links) or item.enriched is not None
+    """An item gets its own note if it has links, media, or has been enriched.
+
+    Phase A (#33) extends note-worthiness to media: a tweet whose only
+    payload is a photo (no link, no LLM enrichment yet) was previously
+    invisible in the wiki. Including it surfaces the photo as soon as
+    `xbrain media` populates the variant — the natural read flow.
+    """
+    return bool(item.links) or bool(item.media) or item.enriched is not None
 
 
 def _in_range(item: Item, since: datetime | None, until: datetime | None) -> bool:
@@ -157,6 +190,89 @@ def _enrichment_lines(item: Item, strings: Strings, topic_style: str) -> list[st
     return lines
 
 
+def _render_media_lines(item: Item) -> list[str]:
+    """One line per `Item.media` entry, ready to splice into the Tweet section.
+
+    Variant handling (issue #33):
+    - `MediaPhotoDownloaded` → Obsidian embed `![[_media/<id>/<n>.<ext>]]`.
+      The vault is self-contained: `generate()` mirrors the file from
+      `data/media/` into `<output_dir>/_media/` before rendering, so the
+      embed resolves with no user configuration.
+    - `MediaPhotoFailed`      → one-line ⚠ warning carrying the failure
+      reason and the original URL — visible evidence, not a silent drop.
+    - `MediaPhotoPending`     → silent. Not an error, just "the next
+      `xbrain media` run will pick it up".
+    - `MediaVideoPending`     → placeholder warning carrying the URL.
+      Phase A does not download videos, so the URL is the only evidence
+      we surface.
+
+    The output is intentionally plain markdown; the caller (`_render_note`)
+    wraps it in a blank line on either side for readability.
+    """
+    lines: list[str] = []
+    for entry in item.media:
+        if isinstance(entry, MediaPhotoDownloaded):
+            lines.append(f"![[{_VAULT_MEDIA_SUBDIR}/{entry.local_path}]]")
+        elif isinstance(entry, MediaPhotoFailed):
+            reason = _FAILURE_ES_MEDIA.get(entry.failure_reason, entry.failure_reason)
+            lines.append(f"> ⚠ Foto no disponible ({reason}): <{entry.url}>")
+        elif isinstance(entry, MediaPhotoPending):
+            # Silent: a future `xbrain media` run will advance this entry.
+            continue
+        elif isinstance(entry, MediaVideoPending):
+            lines.append(f"> 🎥 Vídeo (no descargado): <{entry.url}>")
+    return lines
+
+
+# Translations for media failure reasons — symmetric with `_FAILURE_ES`
+# (content-source failures). Kept separate because the vocabularies differ:
+# media has `http_4xx` and `format_error`, content has `js_required` and
+# `paywall`, etc. A wrong translation here doesn't break anything (the slug
+# itself is a fallback), but the operator-facing line should read cleanly.
+_FAILURE_ES_MEDIA: dict[str, str] = {
+    "http_4xx": "URL no encontrada (HTTP 4xx)",
+    "http_5xx": "error del servidor (HTTP 5xx)",
+    "timeout": "tiempo de espera agotado",
+    "format_error": "formato no reconocido",
+    "unknown_error": "error desconocido",
+}
+
+
+def _mirror_item_media(item: Item, media_root: Path, vault_media_dir: Path) -> None:
+    """Copy every downloaded photo on `item` into the vault's `_media/` tree.
+
+    The canonical store is `data/media/<id>/<n>.<ext>` (under `media_root`);
+    the vault mirror is `<output_dir>/_media/<id>/<n>.<ext>`. Mirroring
+    happens at render time, not download time, so the vault stays in sync
+    with whichever subset of items `--since`/`--until` is regenerating.
+
+    Files are copied with `shutil.copy2` (preserves mtime) and silently
+    skipped when the source is missing — that should never happen on a
+    healthy `data/media/` tree, but a manual cleanup of the bytes must not
+    crash the generator. The variant on disk still drives the embed line,
+    so a missing-bytes-but-marked-downloaded record renders as a broken
+    embed Obsidian shows as an empty rectangle; that is loud enough.
+    """
+    vault_media_dir.mkdir(parents=True, exist_ok=True)
+    for entry in item.media:
+        if not isinstance(entry, MediaPhotoDownloaded):
+            continue
+        source = media_root / entry.local_path
+        destination = vault_media_dir / entry.local_path
+        if not source.exists():
+            # Marked downloaded in items.json but the file is gone — log
+            # and move on. The Obsidian embed will render as a broken
+            # image, which is the right user signal.
+            logger.warning(
+                "Photo bytes missing for item %s at %s — embed will render broken.",
+                item.id,
+                source,
+            )
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
 def _content_lines(content: Content, strings: Strings) -> list[str]:
     """Rendered article bodies + broken-link evidence for a fetched item.
 
@@ -177,9 +293,19 @@ def _content_lines(content: Content, strings: Strings) -> list[str]:
 
 
 def _render_note(item: Item, strings: Strings, topic_style: str) -> str:
+    """Render the wiki-side note for one item.
+
+    The Phase A media block (#33) lives between the tweet text and the
+    `## Enlaces` section: photos appear immediately under the tweet body,
+    matching how X itself renders them — natural read order, no jumping.
+    """
     lines = [_frontmatter(item), "", f"# {title_of(item)}", ""]
     lines += _enrichment_lines(item, strings, topic_style)
     lines += ["## Tweet", "", item.text, ""]
+    media_lines = _render_media_lines(item)
+    if media_lines:
+        lines += media_lines
+        lines.append("")
     if item.links:
         lines.append("## Enlaces")
         lines += [f"- <{link.url}>" for link in item.links]

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -6,6 +6,7 @@ import logging
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import assert_never
 
 from xbrain.config import SUPPORTED_TOPIC_STYLES
 from xbrain.i18n import Strings, strings_for
@@ -221,6 +222,8 @@ def _render_media_lines(item: Item) -> list[str]:
             continue
         elif isinstance(entry, MediaVideoPending):
             lines.append(f"> 🎥 Vídeo (no descargado): <{entry.url}>")
+        else:
+            assert_never(entry)
     return lines
 
 

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -39,10 +39,10 @@ _FAILURE_ES: dict[FailureReason, str] = {
 
 # Subdirectory under `output_dir` where downloaded photos are mirrored at
 # generate time, so an Obsidian vault is fully self-contained. Photos are
-# canonically stored under `data/media/<id>/<n>.<ext>` (Phase A scope) and
-# copied to `<output_dir>/_media/<id>/<n>.<ext>` whenever `generate` runs
-# with a `media_root` argument. The leading underscore keeps the directory
-# at the top of file listings and matches the convention used by static-
+# canonically stored under `data/media/<id>/<n>.<ext>` and copied to
+# `<output_dir>/_media/<id>/<n>.<ext>` whenever `generate` runs with a
+# `media_root` argument. The leading underscore keeps the directory at
+# the top of file listings and matches the convention used by static-
 # site generators (Hugo, Jekyll) for non-content assets.
 _VAULT_MEDIA_SUBDIR = "_media"
 
@@ -84,14 +84,15 @@ def generate(
     the index ``## Topics`` section, or the topic-page post lists — those
     stay wikilinks by design.
 
-    `media_root` (Phase A — issue #33) is the directory under which
-    `xbrain media` downloads photos as `<item-id>/<index>.<ext>`. When
-    provided, photos for each item being rendered are copied to
-    `<output_dir>/_media/<item-id>/<index>.<ext>` and embedded in the note
-    body via Obsidian wikilink embeds. When `None`, photo entries render
-    as if no `xbrain media` run had taken place — pending photos are
-    silent, failed and video-pending photos still produce their warning
-    lines (the URL is in the data; only the file bytes are missing).
+    `media_root` is the directory under which `xbrain media` downloads
+    photos as `<item-id>/<index>.<ext>`. When provided, photos for each
+    item being rendered are copied to
+    `<output_dir>/_media/<item-id>/<index>.<ext>` and embedded in the
+    note body via Obsidian wikilink embeds. When `None`, photo entries
+    render as if no `xbrain media` run had taken place — pending photos
+    are silent, failed and video-pending photos still produce their
+    warning lines (the URL is in the data; only the file bytes are
+    missing).
     """
     if topic_style not in SUPPORTED_TOPIC_STYLES:
         raise ValueError(
@@ -113,10 +114,10 @@ def generate(
 def _has_note(item: Item) -> bool:
     """An item gets its own note if it has links, media, or has been enriched.
 
-    Phase A (#33) extends note-worthiness to media: a tweet whose only
-    payload is a photo (no link, no LLM enrichment yet) was previously
-    invisible in the wiki. Including it surfaces the photo as soon as
-    `xbrain media` populates the variant — the natural read flow.
+    A tweet whose only payload is a photo (no link, no LLM enrichment
+    yet) was previously invisible in the wiki. Including it surfaces
+    the photo as soon as `xbrain media` populates the variant — the
+    natural read flow.
     """
     return bool(item.links) or bool(item.media) or item.enriched is not None
 
@@ -194,7 +195,7 @@ def _enrichment_lines(item: Item, strings: Strings, topic_style: str) -> list[st
 def _render_media_lines(item: Item) -> list[str]:
     """One line per `Item.media` entry, ready to splice into the Tweet section.
 
-    Variant handling (issue #33):
+    Variant handling:
     - `MediaPhotoDownloaded` → Obsidian embed `![[_media/<id>/<n>.<ext>]]`.
       The vault is self-contained: `generate()` mirrors the file from
       `data/media/` into `<output_dir>/_media/` before rendering, so the
@@ -204,8 +205,8 @@ def _render_media_lines(item: Item) -> list[str]:
     - `MediaPhotoPending`     → silent. Not an error, just "the next
       `xbrain media` run will pick it up".
     - `MediaVideoPending`     → placeholder warning carrying the URL.
-      Phase A does not download videos, so the URL is the only evidence
-      we surface.
+      Video bytes are not downloaded yet, so the URL is the only
+      evidence we surface.
 
     The output is intentionally plain markdown; the caller (`_render_note`)
     wraps it in a blank line on either side for readability.
@@ -298,9 +299,9 @@ def _content_lines(content: Content, strings: Strings) -> list[str]:
 def _render_note(item: Item, strings: Strings, topic_style: str) -> str:
     """Render the wiki-side note for one item.
 
-    The Phase A media block (#33) lives between the tweet text and the
-    `## Enlaces` section: photos appear immediately under the tweet body,
-    matching how X itself renders them — natural read order, no jumping.
+    The media block lives between the tweet text and the `## Enlaces`
+    section: photos appear immediately under the tweet body, matching
+    how X itself renders them — natural read order, no jumping.
     """
     lines = [_frontmatter(item), "", f"# {title_of(item)}", ""]
     lines += _enrichment_lines(item, strings, topic_style)

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -1,30 +1,18 @@
 """Download X-post photos referenced in `Item.media`.
 
-Phase A scope (issue #33): photos only. Videos are deliberately left in the
-`MediaVideoPending` variant for a later phase — HLS + ffmpeg is significantly
-different complexity and not on the critical path here.
+Photos only — videos remain in `MediaVideoPending`. The orchestrator
+`download_all` walks every photo entry, downloads from the X CDN with a
+cascading size fallback (`name=orig` → `large` → `medium`), validates with
+Pillow, and atomically replaces the entry with `MediaPhotoDownloaded` or
+`MediaPhotoFailed`. Failure categorisation mirrors `xbrain.fetch`: a
+transient bucket (`http_5xx`, `timeout`, `unknown_error`) is auto-retried
+on the next run; permanent failures (`http_4xx`, `format_error`) need
+`--force`.
 
-The orchestrator (`download_all`) walks every photo entry on every item,
-decides whether it is eligible (pending, transient-failure, or `--force`),
-downloads bytes from the X CDN with a cascading size fallback
-(``name=orig`` → ``name=large`` → ``name=medium``), validates the bytes with
-Pillow, and atomically replaces the entry on the item with the appropriate
-variant — `MediaPhotoDownloaded` on success, `MediaPhotoFailed` on a
-categorised failure.
-
-Failure categorisation mirrors `xbrain.fetch` (#19): the transient bucket
-(`http_5xx`, `timeout`, `unknown_error`) is re-attempted on the next run;
-the permanent bucket (`http_4xx`, `format_error`) is only retried with
-`--force`. Bare-except is bucketed under `unknown_error` so a future
-unhandled error path never silently swallows the URL.
-
-Persistence is the caller's responsibility — the orchestrator mutates
-items in place and calls a `save` callback after each photo, so a Ctrl-C
-mid-batch leaves `items.json` coherent. The default callback writes the
-store atomically via `xbrain.store.save_store`.
-
-I/O dependencies (HTTP session, sleep, Pillow) are dependency-injected via
-keyword arguments so tests run offline without monkeypatching.
+Persistence is the caller's responsibility — `download_all` mutates items
+in place and calls an `on_progress` hook after each photo, so a Ctrl-C
+mid-batch leaves `items.json` coherent. I/O dependencies (HTTP session,
+sleep) are keyword-injectable so tests run offline.
 """
 
 from __future__ import annotations
@@ -33,11 +21,11 @@ import io
 import logging
 import sys
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Protocol
+from typing import assert_never
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
 import requests
@@ -57,12 +45,25 @@ logger = logging.getLogger(__name__)
 
 
 # Failure reasons that justify an automatic retry on the next `xbrain media`
-# run. Mirror of `_TRANSIENT_FAILURES` in `fetch.py` (#19) — kept as a separate
-# frozenset because the categories differ from content-fetch failures, but the
-# retry contract is the same.
+# run. Mirror of `_TRANSIENT_FAILURES` in `fetch.py` — kept as a separate
+# frozenset because the categories differ from content-fetch failures, but
+# the retry contract is the same.
 _TRANSIENT_MEDIA_FAILURES: frozenset[MediaFailureReason] = frozenset(
     {"http_5xx", "timeout", "unknown_error"}
 )
+
+# Severity ordering across the cascade — a 5xx beats a 4xx (we want the
+# transient retry signal), a network error beats both. Used by
+# `_download_one` to decide which failure category to record when several
+# sizes in the cascade fail with different reasons. `format_error` is not
+# listed: it's an early-return path inside the 2xx branch, never compared
+# across the cascade.
+_REASON_SEVERITY: dict[MediaFailureReason, int] = {
+    "http_4xx": 1,
+    "unknown_error": 2,
+    "timeout": 3,
+    "http_5xx": 4,
+}
 
 
 # Conservative defaults — pbs.twimg.com tolerates well-behaved scrapers, but
@@ -88,17 +89,11 @@ _SIZE_CASCADE: tuple[str, ...] = ("orig", "large", "medium")
 # extension just records what the CDN sent us.
 _FORMAT_EXTENSIONS: dict[str, str] = {"jpg": ".jpg", "jpeg": ".jpg", "png": ".png", "webp": ".webp"}
 
-
-class SessionProtocol(Protocol):
-    """The subset of `requests.Session` the downloader actually uses.
-
-    Declared as a Protocol so a test can inject a hand-rolled fake without
-    pulling in the full `responses` / `requests-mock` machinery.
-    """
-
-    def get(self, url: str, *, timeout: int) -> requests.Response:
-        """Issue a GET request and return the response."""
-        ...
+# Cap on the length of the `error` string stored on `MediaPhotoFailed`.
+# A hostile or chatty CDN can return a multi-KB HTML body in the response
+# reason field; persisting that bloats items.json and offers no
+# diagnostic value beyond the first few hundred chars.
+_MAX_ERROR_LEN = 500
 
 
 @dataclass
@@ -126,101 +121,6 @@ class MediaReport:
     per_item_failures: dict[str, list[tuple[str, MediaFailureReason]]] = field(default_factory=dict)
 
 
-def _build_session(session: SessionProtocol | None, user_agent: str) -> SessionProtocol:
-    """Return the caller-injected session, or a fresh one with a browser UA."""
-    if session is not None:
-        return session
-    fresh = requests.Session()
-    fresh.headers.update({"User-Agent": user_agent})
-    return fresh
-
-
-def _eligible_items(
-    items: dict[str, Item],
-    target_ids: set[str] | None,
-) -> Iterator[tuple[str, Item]]:
-    """Yield (id, item) pairs that survive the `--items` filter + have media.
-
-    Pulled out of `download_all` so the orchestrator reads as: "for each
-    eligible item, process it." The empty-media skip lives here because a
-    test patching `items_filter` to a value matching an item without media
-    should still produce a clean no-op, not a counter that says
-    `items_processed += 1` for nothing.
-    """
-    for item_id, item in items.items():
-        if target_ids is not None and item_id not in target_ids:
-            continue
-        if not item.media:
-            continue
-        yield item_id, item
-
-
-@dataclass(frozen=True)
-class _DownloadContext:
-    """Inner-loop dependencies bundled so per-item helpers stay short.
-
-    Pulled out of `download_all`'s long parameter list so the per-item
-    loop helper (`_process_item`) reads as a small finite-state machine
-    rather than passing eight kwargs through. Frozen because none of the
-    fields mutate during a run.
-    """
-
-    media_root: Path
-    session: SessionProtocol
-    timeout_seconds: int
-    throttle_seconds: float
-    sleep: Callable[[float], None]
-    on_progress: Callable[[], None] | None
-    force: bool
-
-
-def _process_item(
-    *,
-    item_id: str,
-    item: Item,
-    ctx: _DownloadContext,
-    report: MediaReport,
-    remaining: list[int] | None,
-) -> bool:
-    """Walk an item's media list and attempt every eligible entry.
-
-    Returns True when the `--limit` cap was hit and the caller must
-    abort the outer loop; False when the item finished naturally.
-
-    `remaining` is a single-element mutable list (a "box") so the helper
-    can decrement the global cap in place without returning it. `None`
-    means no limit was passed.
-    """
-    for index in range(len(item.media)):
-        if remaining is not None and remaining[0] <= 0:
-            return True
-        entry = item.media[index]
-        if not _is_eligible(entry, force=ctx.force):
-            if isinstance(entry, MediaPhotoDownloaded):
-                report.photos_skipped_already_downloaded += 1
-            continue
-        # `_is_eligible` already excluded `MediaVideoPending`; narrow for mypy.
-        assert isinstance(entry, (MediaPhotoPending, MediaPhotoFailed, MediaPhotoDownloaded))
-        report.photos_attempted += 1
-        if remaining is not None:
-            remaining[0] -= 1
-        result = _download_one(
-            entry,
-            item_id=item_id,
-            index=index,
-            media_root=ctx.media_root,
-            session=ctx.session,
-            timeout_seconds=ctx.timeout_seconds,
-        )
-        item.media[index] = result
-        _record_outcome(report, item_id=item_id, entry=result, original=entry)
-        if ctx.on_progress is not None:
-            ctx.on_progress()
-        if ctx.throttle_seconds > 0:
-            ctx.sleep(ctx.throttle_seconds)
-    return False
-
-
 def download_all(
     items: dict[str, Item],
     media_root: Path,
@@ -231,7 +131,7 @@ def download_all(
     throttle_seconds: float = _DEFAULT_THROTTLE_SECONDS,
     user_agent: str = _DEFAULT_UA,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
-    session: SessionProtocol | None = None,
+    session: requests.Session | None = None,
     sleep: Callable[[float], None] = time.sleep,
     on_progress: Callable[[], None] | None = None,
 ) -> MediaReport:
@@ -259,34 +159,56 @@ def download_all(
     equivalent). The directory is created on first use.
 
     Raises:
-        RuntimeError: when EVERY photo attempted in the run fails. Mirrors
-            `ApiExecutor.enrich_items` (#24): a total failure (e.g. a CDN
-            outage or a misconfigured network) must surface as non-zero exit,
-            not a silent empty run. The CLI's `_handle_cli_errors` converts
-            this into a clean operator message + exit code 1.
+        RuntimeError: when EVERY photo attempted in the run fails. A total
+            failure (e.g. a CDN outage or a misconfigured network) must
+            surface as non-zero exit, not a silent empty run. The CLI's
+            `_handle_cli_errors` converts this into a clean operator
+            message + exit code 1.
     """
-    ctx = _DownloadContext(
-        media_root=media_root,
-        session=_build_session(session, user_agent),
-        timeout_seconds=timeout_seconds,
-        throttle_seconds=throttle_seconds,
-        sleep=sleep,
-        on_progress=on_progress,
-        force=force,
-    )
+    if session is None:
+        session = requests.Session()
+        session.headers.update({"User-Agent": user_agent})
     _sweep_part_orphans(media_root)
     started = time.monotonic()
     report = MediaReport()
     target_ids: set[str] | None = set(items_filter) if items_filter else None
-    remaining = [limit] if limit is not None else None
+    remaining: int | None = limit
 
-    for item_id, item in _eligible_items(items, target_ids):
+    for item_id, item in items.items():
+        if target_ids is not None and item_id not in target_ids:
+            continue
+        if not item.media:
+            continue
         report.items_processed += 1
-        if _process_item(item_id=item_id, item=item, ctx=ctx, report=report, remaining=remaining):
-            _finalise(report, started)
-            return report
+        for index, entry in enumerate(item.media):
+            if remaining is not None and remaining <= 0:
+                report.elapsed_seconds = time.monotonic() - started
+                return report
+            if not _is_eligible(entry, force=force):
+                if isinstance(entry, MediaPhotoDownloaded):
+                    report.photos_skipped_already_downloaded += 1
+                continue
+            # `_is_eligible` already excluded `MediaVideoPending`; narrow for mypy.
+            assert isinstance(entry, (MediaPhotoPending, MediaPhotoFailed, MediaPhotoDownloaded))
+            report.photos_attempted += 1
+            if remaining is not None:
+                remaining -= 1
+            result = _download_one(
+                entry,
+                item_id=item_id,
+                index=index,
+                media_root=media_root,
+                session=session,
+                timeout_seconds=timeout_seconds,
+            )
+            item.media[index] = result
+            _record_outcome(report, item_id=item_id, entry=result)
+            if on_progress is not None:
+                on_progress()
+            if throttle_seconds > 0:
+                sleep(throttle_seconds)
 
-    _finalise(report, started)
+    report.elapsed_seconds = time.monotonic() - started
     if report.photos_attempted > 0 and report.photos_downloaded == 0:
         # Total-failure short-circuit: no good bytes landed anywhere this
         # run. Tell the operator loudly. The CLI surfaces it via
@@ -311,50 +233,39 @@ def _is_eligible(entry: MediaEntry, *, force: bool) -> bool:
         if force:
             return True
         return entry.failure_reason in _TRANSIENT_MEDIA_FAILURES
-    return False
+    assert_never(entry)
 
 
 def _record_outcome(
     report: MediaReport,
     *,
     item_id: str,
-    entry: MediaEntry,
-    original: MediaEntry,
+    entry: MediaPhotoDownloaded | MediaPhotoFailed,
 ) -> None:
     """Bump the report counters based on the post-transition variant.
 
-    `original` is the pre-transition entry — used to keep a record of bytes
-    downloaded (a re-download of an already-downloaded photo subtracts the
-    old `bytes_size` from the count to avoid double-counting).
+    A successful download contributes to `photos_downloaded` and
+    `bytes_downloaded`; a failed one to the appropriate transient /
+    permanent bucket and to `per_item_failures` (keyed by item id). Every
+    failure also emits a structured `logger.warning` so the total-failure
+    RuntimeError's "see warnings above" message has actual breadcrumbs.
     """
     if isinstance(entry, MediaPhotoDownloaded):
         report.photos_downloaded += 1
         report.bytes_downloaded += entry.bytes_size
-    elif isinstance(entry, MediaPhotoFailed):
-        report.per_item_failures.setdefault(item_id, []).append((entry.url, entry.failure_reason))
-        if entry.failure_reason in _TRANSIENT_MEDIA_FAILURES:
-            report.photos_failed_transient += 1
-        else:
-            report.photos_failed_permanent += 1
-        # Visible breadcrumb for every failed photo — without this the
-        # total-failure RuntimeError says "see warnings above" but logger
-        # was never wired up. One line per failure, structured.
-        logger.warning(
-            "media: download failed item=%s url=%s reason=%s error=%s",
-            item_id,
-            entry.url,
-            entry.failure_reason,
-            entry.error,
-        )
-    # Any other variant (e.g. video pending) is not produced by _download_one,
-    # so we don't need a branch here. `original` is currently unused — kept
-    # in the signature for symmetry / future delta accounting.
-    _ = original
-
-
-def _finalise(report: MediaReport, started: float) -> None:
-    """Stamp the elapsed time on the report at end-of-run."""
-    report.elapsed_seconds = time.monotonic() - started
+        return
+    report.per_item_failures.setdefault(item_id, []).append((entry.url, entry.failure_reason))
+    if entry.failure_reason in _TRANSIENT_MEDIA_FAILURES:
+        report.photos_failed_transient += 1
+    else:
+        report.photos_failed_permanent += 1
+    logger.warning(
+        "media: download failed item=%s url=%s reason=%s error=%s",
+        item_id,
+        entry.url,
+        entry.failure_reason,
+        entry.error,
+    )
 
 
 def _download_one(
@@ -363,7 +274,7 @@ def _download_one(
     item_id: str,
     index: int,
     media_root: Path,
-    session: SessionProtocol,
+    session: requests.Session,
     timeout_seconds: int,
 ) -> MediaPhotoDownloaded | MediaPhotoFailed:
     """Download one photo with size cascade and Pillow validation.
@@ -404,7 +315,6 @@ def _download_one(
                 # Bytes arrived but Pillow couldn't read them. Permanent for
                 # this URL (the CDN sent us something we cannot use).
                 return _failed(
-                    entry=entry,
                     url=url,
                     reason="format_error",
                     error="Pillow could not decode the downloaded bytes.",
@@ -422,7 +332,6 @@ def _download_one(
                 # condition. Without this guard, the OSError escapes
                 # per-item bucketing and aborts the whole batch.
                 return _failed(
-                    entry=entry,
                     url=url,
                     reason="unknown_error",
                     error=f"local write failed: {exc}",
@@ -454,25 +363,11 @@ def _download_one(
 
     reason = cascade_reason or "unknown_error"
     return _failed(
-        entry=entry,
         url=url,
         reason=reason,
         error=_format_error(last_error, cascade_status),
         attempts=attempts,
     )
-
-
-# Severity ordering across the cascade — a 5xx beats a 4xx (we want the
-# transient retry signal), a network error beats both. Used by
-# `_download_one` to decide which failure category to record when several
-# sizes in the cascade fail with different reasons.
-_REASON_SEVERITY: dict[MediaFailureReason, int] = {
-    "http_4xx": 1,
-    "unknown_error": 2,
-    "timeout": 3,
-    "http_5xx": 4,
-    "format_error": 5,  # never used here but completes the table
-}
 
 
 def _worse(
@@ -489,20 +384,12 @@ def _worse(
 
 def _failed(
     *,
-    entry: MediaPhotoPending | MediaPhotoFailed | MediaPhotoDownloaded,
     url: str,
     reason: MediaFailureReason,
     error: str | None,
     attempts: int,
 ) -> MediaPhotoFailed:
-    """Build a `MediaPhotoFailed` variant for a download that did not land.
-
-    `entry` is the pre-transition variant — currently unused, kept in the
-    signature so future callers can carry forward state (e.g. preserving
-    the original `local_path` from a `MediaPhotoDownloaded` being
-    re-downloaded with `--force` that subsequently failed).
-    """
-    _ = entry
+    """Build a `MediaPhotoFailed` variant for a download that did not land."""
     return MediaPhotoFailed(
         url=url,
         failure_reason=reason,
@@ -599,14 +486,24 @@ def _local_path(item_id: str, index: int, extension: str) -> str:
 
 
 def _format_error(exc: Exception | None, status: int | None) -> str | None:
-    """Compose a human-readable error string from the last exception."""
+    """Compose a human-readable error string from the last exception.
+
+    Capped at `_MAX_ERROR_LEN` characters: a misbehaving CDN can return a
+    multi-KB HTML body in `RequestException.__str__`, and persisting that
+    on every `MediaPhotoFailed` bloats `items.json` for zero diagnostic
+    value beyond the first chunk.
+    """
     if exc is None and status is None:
         return None
     if exc is None:
-        return f"HTTP {status}"
-    if status is None:
-        return str(exc)
-    return f"HTTP {status}: {exc}"
+        text = f"HTTP {status}"
+    elif status is None:
+        text = str(exc)
+    else:
+        text = f"HTTP {status}: {exc}"
+    if len(text) > _MAX_ERROR_LEN:
+        return text[: _MAX_ERROR_LEN - 1] + "…"
+    return text
 
 
 def emit_summary_line(report: MediaReport, *, out: "io.IOBase | None" = None) -> None:

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -146,7 +146,8 @@ def download_all(
       is re-downloaded. The previously-downloaded file on disk is overwritten.
 
     Out of scope (every run):
-    - `MediaVideoPending` — Phase A is photos only.
+    - `MediaVideoPending` — photos only; video download is a future
+      iteration.
 
     The function mutates `items` in place; the caller is expected to wrap
     each transition with a store-write (the `on_progress` callback fires
@@ -304,7 +305,7 @@ def _download_one(
             continue
         except requests.RequestException as exc:
             # Connection errors, SSL errors, etc — bucket as unknown_error
-            # (transient) per the #19 contract.
+            # (transient), matching `xbrain.fetch`'s retry contract.
             cascade_reason = _worse(cascade_reason, "unknown_error")
             last_error = exc
             continue

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -200,9 +200,7 @@ def download_all(
                     report.photos_skipped_already_downloaded += 1
                 continue
             # `_is_eligible` already excluded `MediaVideoPending`; narrow for mypy.
-            assert isinstance(
-                entry, (MediaPhotoPending, MediaPhotoFailed, MediaPhotoDownloaded)
-            )
+            assert isinstance(entry, (MediaPhotoPending, MediaPhotoFailed, MediaPhotoDownloaded))
             report.photos_attempted += 1
             if remaining is not None:
                 remaining -= 1

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -33,7 +33,7 @@ import io
 import logging
 import sys
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -126,6 +126,101 @@ class MediaReport:
     per_item_failures: dict[str, list[tuple[str, MediaFailureReason]]] = field(default_factory=dict)
 
 
+def _build_session(session: SessionProtocol | None, user_agent: str) -> SessionProtocol:
+    """Return the caller-injected session, or a fresh one with a browser UA."""
+    if session is not None:
+        return session
+    fresh = requests.Session()
+    fresh.headers.update({"User-Agent": user_agent})
+    return fresh
+
+
+def _eligible_items(
+    items: dict[str, Item],
+    target_ids: set[str] | None,
+) -> Iterator[tuple[str, Item]]:
+    """Yield (id, item) pairs that survive the `--items` filter + have media.
+
+    Pulled out of `download_all` so the orchestrator reads as: "for each
+    eligible item, process it." The empty-media skip lives here because a
+    test patching `items_filter` to a value matching an item without media
+    should still produce a clean no-op, not a counter that says
+    `items_processed += 1` for nothing.
+    """
+    for item_id, item in items.items():
+        if target_ids is not None and item_id not in target_ids:
+            continue
+        if not item.media:
+            continue
+        yield item_id, item
+
+
+@dataclass(frozen=True)
+class _DownloadContext:
+    """Inner-loop dependencies bundled so per-item helpers stay short.
+
+    Pulled out of `download_all`'s long parameter list so the per-item
+    loop helper (`_process_item`) reads as a small finite-state machine
+    rather than passing eight kwargs through. Frozen because none of the
+    fields mutate during a run.
+    """
+
+    media_root: Path
+    session: SessionProtocol
+    timeout_seconds: int
+    throttle_seconds: float
+    sleep: Callable[[float], None]
+    on_progress: Callable[[], None] | None
+    force: bool
+
+
+def _process_item(
+    *,
+    item_id: str,
+    item: Item,
+    ctx: _DownloadContext,
+    report: MediaReport,
+    remaining: list[int] | None,
+) -> bool:
+    """Walk an item's media list and attempt every eligible entry.
+
+    Returns True when the `--limit` cap was hit and the caller must
+    abort the outer loop; False when the item finished naturally.
+
+    `remaining` is a single-element mutable list (a "box") so the helper
+    can decrement the global cap in place without returning it. `None`
+    means no limit was passed.
+    """
+    for index in range(len(item.media)):
+        if remaining is not None and remaining[0] <= 0:
+            return True
+        entry = item.media[index]
+        if not _is_eligible(entry, force=ctx.force):
+            if isinstance(entry, MediaPhotoDownloaded):
+                report.photos_skipped_already_downloaded += 1
+            continue
+        # `_is_eligible` already excluded `MediaVideoPending`; narrow for mypy.
+        assert isinstance(entry, (MediaPhotoPending, MediaPhotoFailed, MediaPhotoDownloaded))
+        report.photos_attempted += 1
+        if remaining is not None:
+            remaining[0] -= 1
+        result = _download_one(
+            entry,
+            item_id=item_id,
+            index=index,
+            media_root=ctx.media_root,
+            session=ctx.session,
+            timeout_seconds=ctx.timeout_seconds,
+        )
+        item.media[index] = result
+        _record_outcome(report, item_id=item_id, entry=result, original=entry)
+        if ctx.on_progress is not None:
+            ctx.on_progress()
+        if ctx.throttle_seconds > 0:
+            ctx.sleep(ctx.throttle_seconds)
+    return False
+
+
 def download_all(
     items: dict[str, Item],
     media_root: Path,
@@ -170,54 +265,25 @@ def download_all(
             not a silent empty run. The CLI's `_handle_cli_errors` converts
             this into a clean operator message + exit code 1.
     """
-    if session is None:
-        session = requests.Session()
-        session.headers.update({"User-Agent": user_agent})
-
-    target_ids: set[str] | None = set(items_filter) if items_filter else None
+    ctx = _DownloadContext(
+        media_root=media_root,
+        session=_build_session(session, user_agent),
+        timeout_seconds=timeout_seconds,
+        throttle_seconds=throttle_seconds,
+        sleep=sleep,
+        on_progress=on_progress,
+        force=force,
+    )
     started = time.monotonic()
     report = MediaReport()
-    remaining = limit if limit is not None else None
+    target_ids: set[str] | None = set(items_filter) if items_filter else None
+    remaining = [limit] if limit is not None else None
 
-    for item_id, item in items.items():
-        if target_ids is not None and item_id not in target_ids:
-            continue
-        if not item.media:
-            continue
+    for item_id, item in _eligible_items(items, target_ids):
         report.items_processed += 1
-        # Walk a snapshot of indices: in-place replacement keeps `item.media`
-        # the same length, so range(len(...)) at start is safe.
-        for index in range(len(item.media)):
-            if remaining is not None and remaining <= 0:
-                # `--limit` cap reached. We stop attempting new downloads but
-                # do NOT mutate already-attempted entries (they keep whichever
-                # variant they had on entry).
-                _finalise(report, started)
-                return report
-            entry = item.media[index]
-            if not _is_eligible(entry, force=force):
-                if isinstance(entry, MediaPhotoDownloaded):
-                    report.photos_skipped_already_downloaded += 1
-                continue
-            # `_is_eligible` already excluded `MediaVideoPending`; narrow for mypy.
-            assert isinstance(entry, (MediaPhotoPending, MediaPhotoFailed, MediaPhotoDownloaded))
-            report.photos_attempted += 1
-            if remaining is not None:
-                remaining -= 1
-            result = _download_one(
-                entry,
-                item_id=item_id,
-                index=index,
-                media_root=media_root,
-                session=session,
-                timeout_seconds=timeout_seconds,
-            )
-            item.media[index] = result
-            _record_outcome(report, item_id=item_id, entry=result, original=entry)
-            if on_progress is not None:
-                on_progress()
-            if throttle_seconds > 0:
-                sleep(throttle_seconds)
+        if _process_item(item_id=item_id, item=item, ctx=ctx, report=report, remaining=remaining):
+            _finalise(report, started)
+            return report
 
     _finalise(report, started)
     if report.photos_attempted > 0 and report.photos_downloaded == 0:

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -1,0 +1,513 @@
+"""Download X-post photos referenced in `Item.media`.
+
+Phase A scope (issue #33): photos only. Videos are deliberately left in the
+`MediaVideoPending` variant for a later phase — HLS + ffmpeg is significantly
+different complexity and not on the critical path here.
+
+The orchestrator (`download_all`) walks every photo entry on every item,
+decides whether it is eligible (pending, transient-failure, or `--force`),
+downloads bytes from the X CDN with a cascading size fallback
+(``name=orig`` → ``name=large`` → ``name=medium``), validates the bytes with
+Pillow, and atomically replaces the entry on the item with the appropriate
+variant — `MediaPhotoDownloaded` on success, `MediaPhotoFailed` on a
+categorised failure.
+
+Failure categorisation mirrors `xbrain.fetch` (#19): the transient bucket
+(`http_5xx`, `timeout`, `unknown_error`) is re-attempted on the next run;
+the permanent bucket (`http_4xx`, `format_error`) is only retried with
+`--force`. Bare-except is bucketed under `unknown_error` so a future
+unhandled error path never silently swallows the URL.
+
+Persistence is the caller's responsibility — the orchestrator mutates
+items in place and calls a `save` callback after each photo, so a Ctrl-C
+mid-batch leaves `items.json` coherent. The default callback writes the
+store atomically via `xbrain.store.save_store`.
+
+I/O dependencies (HTTP session, sleep, Pillow) are dependency-injected via
+keyword arguments so tests run offline without monkeypatching.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Protocol
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+import requests
+from PIL import Image, UnidentifiedImageError
+
+from xbrain.models import (
+    Item,
+    MediaEntry,
+    MediaFailureReason,
+    MediaPhotoDownloaded,
+    MediaPhotoFailed,
+    MediaPhotoPending,
+    MediaVideoPending,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# Failure reasons that justify an automatic retry on the next `xbrain media`
+# run. Mirror of `_TRANSIENT_FAILURES` in `fetch.py` (#19) — kept as a separate
+# frozenset because the categories differ from content-fetch failures, but the
+# retry contract is the same.
+_TRANSIENT_MEDIA_FAILURES: frozenset[MediaFailureReason] = frozenset(
+    {"http_5xx", "timeout", "unknown_error"}
+)
+
+
+# Conservative defaults — pbs.twimg.com tolerates well-behaved scrapers, but
+# bursting from a fresh IP earns a 429. The throttle is a per-request sleep
+# (caller-injectable for tests). The User-Agent is browser-shaped so the CDN
+# does not bounce the request on UA-pattern alone.
+_DEFAULT_UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+)
+_DEFAULT_TIMEOUT_SECONDS = 20
+_DEFAULT_THROTTLE_SECONDS = 0.5
+
+# Size cascade in priority order. pbs.twimg.com URLs accept a `name=`
+# parameter selecting the rendered size; `orig` is the highest fidelity the
+# CDN exposes, `large` is the standard high-DPI variant, `medium` is the
+# safe fallback. We try in order and stop at the first variant that returns
+# valid image bytes.
+_SIZE_CASCADE: tuple[str, ...] = ("orig", "large", "medium")
+
+# Map URL-derived `format=` values to file extensions on disk. Twitter
+# returns `jpg`, `png`, `webp` — we never get to choose the format, so the
+# extension just records what the CDN sent us.
+_FORMAT_EXTENSIONS: dict[str, str] = {"jpg": ".jpg", "jpeg": ".jpg", "png": ".png", "webp": ".webp"}
+
+
+class SessionProtocol(Protocol):
+    """The subset of `requests.Session` the downloader actually uses.
+
+    Declared as a Protocol so a test can inject a hand-rolled fake without
+    pulling in the full `responses` / `requests-mock` machinery.
+    """
+
+    def get(self, url: str, *, timeout: int) -> requests.Response:
+        """Issue a GET request and return the response."""
+        ...
+
+
+@dataclass
+class MediaReport:
+    """Counts emitted by `download_all` for the CLI's SUMMARY line.
+
+    `photos_failed_transient` counts entries that landed in the transient
+    failure bucket on THIS run (i.e. eligible for the next run's auto-retry).
+    `photos_failed_permanent` counts entries that landed in a terminal
+    bucket. `photos_skipped_already_downloaded` is the idempotency proof —
+    a no-op re-run must report every previously-downloaded photo here.
+    """
+
+    items_processed: int = 0
+    photos_attempted: int = 0
+    photos_downloaded: int = 0
+    photos_failed_permanent: int = 0
+    photos_failed_transient: int = 0
+    photos_skipped_already_downloaded: int = 0
+    bytes_downloaded: int = 0
+    elapsed_seconds: float = 0.0
+    # Per-item failures keyed by item id → list of (url, reason) tuples.
+    # Surfaces the failed URLs in tests / debugging without re-walking the
+    # mutated store.
+    per_item_failures: dict[str, list[tuple[str, MediaFailureReason]]] = field(default_factory=dict)
+
+
+def download_all(
+    items: dict[str, Item],
+    media_root: Path,
+    *,
+    force: bool = False,
+    limit: int | None = None,
+    items_filter: list[str] | None = None,
+    throttle_seconds: float = _DEFAULT_THROTTLE_SECONDS,
+    user_agent: str = _DEFAULT_UA,
+    timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
+    session: SessionProtocol | None = None,
+    sleep: Callable[[float], None] = time.sleep,
+    on_progress: Callable[[], None] | None = None,
+) -> MediaReport:
+    """Download every eligible photo across the store; return a structured report.
+
+    Eligibility (without `--force`):
+    - `MediaPhotoPending` — always.
+    - `MediaPhotoFailed` whose `failure_reason` is in `_TRANSIENT_MEDIA_FAILURES`.
+
+    With `--force`:
+    - Every `MediaPhotoPending`, `MediaPhotoFailed`, and `MediaPhotoDownloaded`
+      is re-downloaded. The previously-downloaded file on disk is overwritten.
+
+    Out of scope (every run):
+    - `MediaVideoPending` — Phase A is photos only.
+
+    The function mutates `items` in place; the caller is expected to wrap
+    each transition with a store-write (the `on_progress` callback fires
+    after every photo transition). The progress callback is also where the
+    Ctrl-C-coherent invariant lives: the store is written between photos,
+    never mid-download.
+
+    `media_root` is the directory under which `<item_id>/<index>.<ext>` files
+    are created. The caller is expected to point this at `data/media/` (or
+    equivalent). The directory is created on first use.
+
+    Raises:
+        RuntimeError: when EVERY photo attempted in the run fails. Mirrors
+            `ApiExecutor.enrich_items` (#24): a total failure (e.g. a CDN
+            outage or a misconfigured network) must surface as non-zero exit,
+            not a silent empty run. The CLI's `_handle_cli_errors` converts
+            this into a clean operator message + exit code 1.
+    """
+    if session is None:
+        session = requests.Session()
+        session.headers.update({"User-Agent": user_agent})
+
+    target_ids: set[str] | None = set(items_filter) if items_filter else None
+    started = time.monotonic()
+    report = MediaReport()
+    remaining = limit if limit is not None else None
+
+    for item_id, item in items.items():
+        if target_ids is not None and item_id not in target_ids:
+            continue
+        if not item.media:
+            continue
+        report.items_processed += 1
+        # Walk a snapshot of indices: in-place replacement keeps `item.media`
+        # the same length, so range(len(...)) at start is safe.
+        for index in range(len(item.media)):
+            if remaining is not None and remaining <= 0:
+                # `--limit` cap reached. We stop attempting new downloads but
+                # do NOT mutate already-attempted entries (they keep whichever
+                # variant they had on entry).
+                _finalise(report, started)
+                return report
+            entry = item.media[index]
+            if not _is_eligible(entry, force=force):
+                if isinstance(entry, MediaPhotoDownloaded):
+                    report.photos_skipped_already_downloaded += 1
+                continue
+            # `_is_eligible` already excluded `MediaVideoPending`; narrow for mypy.
+            assert isinstance(
+                entry, (MediaPhotoPending, MediaPhotoFailed, MediaPhotoDownloaded)
+            )
+            report.photos_attempted += 1
+            if remaining is not None:
+                remaining -= 1
+            result = _download_one(
+                entry,
+                item_id=item_id,
+                index=index,
+                media_root=media_root,
+                session=session,
+                timeout_seconds=timeout_seconds,
+            )
+            item.media[index] = result
+            _record_outcome(report, item_id=item_id, entry=result, original=entry)
+            if on_progress is not None:
+                on_progress()
+            if throttle_seconds > 0:
+                sleep(throttle_seconds)
+
+    _finalise(report, started)
+    if report.photos_attempted > 0 and report.photos_downloaded == 0:
+        # Total-failure short-circuit: no good bytes landed anywhere this
+        # run. Tell the operator loudly. The CLI surfaces it via
+        # `_handle_cli_errors`.
+        raise RuntimeError(
+            f"All {report.photos_attempted} photo download attempts failed; "
+            "check network / pbs.twimg.com availability and the per-photo "
+            "warnings above."
+        )
+    return report
+
+
+def _is_eligible(entry: MediaEntry, *, force: bool) -> bool:
+    """Decide whether `download_all` should attempt this entry on THIS run."""
+    if isinstance(entry, MediaVideoPending):
+        return False
+    if isinstance(entry, MediaPhotoPending):
+        return True
+    if isinstance(entry, MediaPhotoDownloaded):
+        return force
+    if isinstance(entry, MediaPhotoFailed):
+        if force:
+            return True
+        return entry.failure_reason in _TRANSIENT_MEDIA_FAILURES
+    return False
+
+
+def _record_outcome(
+    report: MediaReport,
+    *,
+    item_id: str,
+    entry: MediaEntry,
+    original: MediaEntry,
+) -> None:
+    """Bump the report counters based on the post-transition variant.
+
+    `original` is the pre-transition entry — used to keep a record of bytes
+    downloaded (a re-download of an already-downloaded photo subtracts the
+    old `bytes_size` from the count to avoid double-counting).
+    """
+    if isinstance(entry, MediaPhotoDownloaded):
+        report.photos_downloaded += 1
+        report.bytes_downloaded += entry.bytes_size
+    elif isinstance(entry, MediaPhotoFailed):
+        report.per_item_failures.setdefault(item_id, []).append((entry.url, entry.failure_reason))
+        if entry.failure_reason in _TRANSIENT_MEDIA_FAILURES:
+            report.photos_failed_transient += 1
+        else:
+            report.photos_failed_permanent += 1
+    # Any other variant (e.g. video pending) is not produced by _download_one,
+    # so we don't need a branch here. `original` is currently unused — kept
+    # in the signature for symmetry / future delta accounting.
+    _ = original
+
+
+def _finalise(report: MediaReport, started: float) -> None:
+    """Stamp the elapsed time on the report at end-of-run."""
+    report.elapsed_seconds = time.monotonic() - started
+
+
+def _download_one(
+    entry: MediaPhotoPending | MediaPhotoFailed | MediaPhotoDownloaded,
+    *,
+    item_id: str,
+    index: int,
+    media_root: Path,
+    session: SessionProtocol,
+    timeout_seconds: int,
+) -> MediaPhotoDownloaded | MediaPhotoFailed:
+    """Download one photo with size cascade and Pillow validation.
+
+    Returns the post-transition variant — the caller swaps it into
+    `item.media[index]`. Never raises on a recoverable failure: the
+    `failure_reason` field carries the categorisation. The only uncaught
+    exceptions are programmer bugs (e.g. `AttributeError`) and
+    `KeyboardInterrupt` — both must propagate so the developer sees the
+    traceback / Ctrl-C still works.
+    """
+    url = entry.url
+    attempts = (entry.attempts if isinstance(entry, MediaPhotoFailed) else 0) + 1
+    last_error: Exception | None = None
+    # Track the worst-failure-seen across the cascade so a 404 on `orig`
+    # plus a 5xx on `large` reports as a 5xx (transient) not a 4xx.
+    cascade_reason: MediaFailureReason | None = None
+    cascade_status: int | None = None
+
+    for size in _SIZE_CASCADE:
+        candidate_url = _url_with_name(url, size)
+        try:
+            response = session.get(candidate_url, timeout=timeout_seconds)
+        except requests.Timeout as exc:
+            cascade_reason = _worse(cascade_reason, "timeout")
+            last_error = exc
+            continue
+        except requests.RequestException as exc:
+            # Connection errors, SSL errors, etc — bucket as unknown_error
+            # (transient) per the #19 contract.
+            cascade_reason = _worse(cascade_reason, "unknown_error")
+            last_error = exc
+            continue
+        status = response.status_code
+        if 200 <= status < 300:
+            decoded = _decode_image(response.content)
+            if decoded is None:
+                # Bytes arrived but Pillow couldn't read them. Permanent for
+                # this URL (the CDN sent us something we cannot use).
+                return _failed(
+                    entry=entry,
+                    url=url,
+                    reason="format_error",
+                    error="Pillow could not decode the downloaded bytes.",
+                    attempts=attempts,
+                )
+            width, height, fmt = decoded
+            extension = _FORMAT_EXTENSIONS.get(fmt.lower(), ".jpg")
+            local_path = _local_path(item_id, index, extension)
+            _write_bytes(media_root / local_path, response.content)
+            return MediaPhotoDownloaded(
+                url=url,
+                local_path=local_path,
+                width=width,
+                height=height,
+                bytes_size=len(response.content),
+                downloaded_at=datetime.now(timezone.utc),
+            )
+        if 400 <= status < 500:
+            cascade_reason = _worse(cascade_reason, "http_4xx")
+            cascade_status = status
+            last_error = RuntimeError(f"HTTP {status} for {candidate_url}")
+            continue
+        if 500 <= status < 600:
+            cascade_reason = _worse(cascade_reason, "http_5xx")
+            cascade_status = status
+            last_error = RuntimeError(f"HTTP {status} for {candidate_url}")
+            continue
+        # Non-success, non-error status code (e.g. a 3xx that requests didn't
+        # follow). Bucket as unknown_error so the next run retries it.
+        cascade_reason = _worse(cascade_reason, "unknown_error")
+        cascade_status = status
+        last_error = RuntimeError(f"HTTP {status} for {candidate_url}")
+
+    reason = cascade_reason or "unknown_error"
+    return _failed(
+        entry=entry,
+        url=url,
+        reason=reason,
+        error=_format_error(last_error, cascade_status),
+        attempts=attempts,
+    )
+
+
+# Severity ordering across the cascade — a 5xx beats a 4xx (we want the
+# transient retry signal), a network error beats both. Used by
+# `_download_one` to decide which failure category to record when several
+# sizes in the cascade fail with different reasons.
+_REASON_SEVERITY: dict[MediaFailureReason, int] = {
+    "http_4xx": 1,
+    "unknown_error": 2,
+    "timeout": 3,
+    "http_5xx": 4,
+    "format_error": 5,  # never used here but completes the table
+}
+
+
+def _worse(
+    current: MediaFailureReason | None,
+    candidate: MediaFailureReason,
+) -> MediaFailureReason:
+    """Return whichever reason has higher severity (= more retry signal)."""
+    if current is None:
+        return candidate
+    if _REASON_SEVERITY[candidate] > _REASON_SEVERITY[current]:
+        return candidate
+    return current
+
+
+def _failed(
+    *,
+    entry: MediaPhotoPending | MediaPhotoFailed | MediaPhotoDownloaded,
+    url: str,
+    reason: MediaFailureReason,
+    error: str | None,
+    attempts: int,
+) -> MediaPhotoFailed:
+    """Build a `MediaPhotoFailed` variant for a download that did not land.
+
+    `entry` is the pre-transition variant — currently unused, kept in the
+    signature so future callers can carry forward state (e.g. preserving
+    the original `local_path` from a `MediaPhotoDownloaded` being
+    re-downloaded with `--force` that subsequently failed).
+    """
+    _ = entry
+    return MediaPhotoFailed(
+        url=url,
+        failure_reason=reason,
+        error=error,
+        attempts=attempts,
+        last_attempt_at=datetime.now(timezone.utc),
+    )
+
+
+def _decode_image(data: bytes) -> tuple[int, int, str] | None:
+    """Validate bytes with Pillow; return ``(width, height, format)`` or None.
+
+    A successful decode means the CDN sent us something Obsidian will render.
+    A failure returns None so the caller can bucket as `format_error` —
+    Pillow's exception types are too noisy to propagate verbatim.
+    """
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            image.verify()
+        # `verify()` invalidates the image — re-open to read size + format.
+        with Image.open(io.BytesIO(data)) as image:
+            return image.width, image.height, image.format or "jpg"
+    except (UnidentifiedImageError, OSError, ValueError):
+        return None
+
+
+def _write_bytes(path: Path, data: bytes) -> None:
+    """Write `data` to `path` atomically (tmp file + rename).
+
+    Atomic write mirrors `xbrain.store._atomic_write`: a Ctrl-C between
+    `open` and `write_bytes` would leave a zero-byte partial file that the
+    next run would consider downloaded. We avoid that by writing to a
+    sibling tmp file and `os.replace`ing it into place.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".part")
+    try:
+        tmp.write_bytes(data)
+        tmp.replace(path)
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+
+def _url_with_name(url: str, size: str) -> str:
+    """Return the URL with the X CDN ``name=`` query param set to `size`.
+
+    Twitter pbs.twimg.com URLs accept a `name=` parameter that selects the
+    rendered size. We always rewrite it (even if absent) so the cascade
+    works regardless of whether the extractor captured an already-sized
+    URL or the bare path.
+    """
+    parsed = urlparse(url)
+    query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+    query["name"] = size
+    return urlunparse(parsed._replace(query=urlencode(query)))
+
+
+def _local_path(item_id: str, index: int, extension: str) -> str:
+    """Deterministic relative path: ``<item_id>/<index><extension>``.
+
+    Returned as a forward-slash string (the storage convention for an
+    Obsidian embed) rather than a `Path` so it can be persisted on
+    `MediaPhotoDownloaded.local_path` without OS-dependent reformatting.
+    """
+    return f"{item_id}/{index}{extension}"
+
+
+def _format_error(exc: Exception | None, status: int | None) -> str | None:
+    """Compose a human-readable error string from the last exception."""
+    if exc is None and status is None:
+        return None
+    if exc is None:
+        return f"HTTP {status}"
+    if status is None:
+        return str(exc)
+    return f"HTTP {status}: {exc}"
+
+
+def emit_summary_line(report: MediaReport, *, out: "io.IOBase | None" = None) -> None:
+    """Print the SUMMARY line on stderr (mirrors `ApiExecutor.enrich_items`).
+
+    The line is emitted only if at least one photo was attempted or skipped —
+    a fully no-op run (e.g. an `--items` filter that matched nothing) stays
+    silent. `out` is injectable for tests; defaults to `sys.stderr`.
+    """
+    if report.photos_attempted == 0 and report.photos_skipped_already_downloaded == 0:
+        return
+    target = out if out is not None else sys.stderr
+    print(
+        f"SUMMARY: downloaded: {report.photos_downloaded}, "
+        f"failed_permanent: {report.photos_failed_permanent}, "
+        f"failed_transient: {report.photos_failed_transient}, "
+        f"skipped: {report.photos_skipped_already_downloaded}, "
+        f"bytes: {report.bytes_downloaded:_}",
+        file=target,
+    )

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -274,6 +274,7 @@ def download_all(
         on_progress=on_progress,
         force=force,
     )
+    _sweep_part_orphans(media_root)
     started = time.monotonic()
     report = MediaReport()
     target_ids: set[str] | None = set(items_filter) if items_filter else None
@@ -335,6 +336,16 @@ def _record_outcome(
             report.photos_failed_transient += 1
         else:
             report.photos_failed_permanent += 1
+        # Visible breadcrumb for every failed photo — without this the
+        # total-failure RuntimeError says "see warnings above" but logger
+        # was never wired up. One line per failure, structured.
+        logger.warning(
+            "media: download failed item=%s url=%s reason=%s error=%s",
+            item_id,
+            entry.url,
+            entry.failure_reason,
+            entry.error,
+        )
     # Any other variant (e.g. video pending) is not produced by _download_one,
     # so we don't need a branch here. `original` is currently unused — kept
     # in the signature for symmetry / future delta accounting.
@@ -402,7 +413,21 @@ def _download_one(
             width, height, fmt = decoded
             extension = _FORMAT_EXTENSIONS.get(fmt.lower(), ".jpg")
             local_path = _local_path(item_id, index, extension)
-            _write_bytes(media_root / local_path, response.content)
+            try:
+                _write_bytes(media_root / local_path, response.content)
+            except OSError as exc:
+                # Disk full, permission denied, read-only filesystem —
+                # bucket as `unknown_error` (transient) so the next run
+                # picks it up once the operator clears the underlying
+                # condition. Without this guard, the OSError escapes
+                # per-item bucketing and aborts the whole batch.
+                return _failed(
+                    entry=entry,
+                    url=url,
+                    reason="unknown_error",
+                    error=f"local write failed: {exc}",
+                    attempts=attempts,
+                )
             return MediaPhotoDownloaded(
                 url=url,
                 local_path=local_path,
@@ -491,8 +516,12 @@ def _decode_image(data: bytes) -> tuple[int, int, str] | None:
     """Validate bytes with Pillow; return ``(width, height, format)`` or None.
 
     A successful decode means the CDN sent us something Obsidian will render.
-    A failure returns None so the caller can bucket as `format_error` —
-    Pillow's exception types are too noisy to propagate verbatim.
+    A failure returns None so the caller can bucket as `format_error`.
+
+    The exception set is narrow-by-design: Pillow-specific signals only.
+    Catching the parent `OSError` would swallow `FileNotFoundError`,
+    `PermissionError` and other real I/O bugs — we want those to propagate
+    as tracebacks, not be silently bucketed as `format_error`.
     """
     try:
         with Image.open(io.BytesIO(data)) as image:
@@ -500,7 +529,7 @@ def _decode_image(data: bytes) -> tuple[int, int, str] | None:
         # `verify()` invalidates the image — re-open to read size + format.
         with Image.open(io.BytesIO(data)) as image:
             return image.width, image.height, image.format or "jpg"
-    except (UnidentifiedImageError, OSError, ValueError):
+    except (UnidentifiedImageError, Image.DecompressionBombError, SyntaxError):
         return None
 
 
@@ -511,6 +540,10 @@ def _write_bytes(path: Path, data: bytes) -> None:
     `open` and `write_bytes` would leave a zero-byte partial file that the
     next run would consider downloaded. We avoid that by writing to a
     sibling tmp file and `os.replace`ing it into place.
+
+    Orphan `.part` files left behind by a hard interruption (SIGKILL, OOM)
+    that bypassed our `except BaseException` cleanup are swept on the next
+    `download_all` entry — see `_sweep_part_orphans`.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".part")
@@ -520,6 +553,25 @@ def _write_bytes(path: Path, data: bytes) -> None:
     except BaseException:
         tmp.unlink(missing_ok=True)
         raise
+
+
+def _sweep_part_orphans(media_root: Path) -> None:
+    """Remove stale ``*.part`` files left by hard-killed previous runs.
+
+    A SIGKILL or OOM kill between `tmp.write_bytes` and `tmp.replace` would
+    leave a `<n>.<ext>.part` next to the final file location with no entry
+    in `items.json` referencing it. We do not block on the sweep — best
+    effort: any path we cannot unlink is logged and skipped, on the theory
+    that "the operator can clean up later" beats "the next photo refuses
+    to download because the tree has an unwritable file in it".
+    """
+    if not media_root.exists():
+        return
+    for orphan in media_root.rglob("*.part"):
+        try:
+            orphan.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("media: could not remove stale .part file %s: %s", orphan, exc)
 
 
 def _url_with_name(url: str, size: str) -> str:

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -53,11 +53,158 @@ class Link(BaseModel):
     domain: str
 
 
-class Media(BaseModel):
-    """One photo or video attached to an item."""
+# Categorised reasons a photo download can fail — mirrors the design of
+# `FailureReason` for content fetches (#19/#20). The transient subset
+# (`_TRANSIENT_MEDIA_FAILURES` in `xbrain.media`) is retried on the next
+# `xbrain media` run; permanent reasons stay as-is unless `--force` is passed.
+MediaFailureReason = Literal[
+    "http_4xx",       # permanent: dead URL / cdn-removed media
+    "http_5xx",       # transient: server-side, may succeed on retry
+    "timeout",        # transient: network blip / cdn slow path
+    "format_error",   # permanent: bytes downloaded but Pillow rejected them
+    "unknown_error",  # bare-except bucket; transient by default (mirrors fetch.py #20)
+]
 
-    type: Literal["photo", "video"]
+
+class _MediaPhotoBase(BaseModel):
+    """Common fields for the three photo variants.
+
+    `type` is kept as the legacy discriminator that pre-Phase-A records used
+    so a re-dump after migration still carries it. The Phase A discriminator
+    is `kind` (see the variant subclasses) — globally unique across photo +
+    video variants because `state="pending"` would collide between
+    `MediaPhotoPending` and `MediaVideoPending`.
+    """
+
+    type: Literal["photo"] = "photo"
     url: str
+
+
+class MediaPhotoPending(_MediaPhotoBase):
+    """A photo URL captured at extract time, download not attempted yet.
+
+    This is the initial state for every photo entry the extractor or the
+    archive importer creates. `xbrain media` walks the store and tries to
+    advance each pending entry to either `MediaPhotoDownloaded` (bytes on
+    disk) or `MediaPhotoFailed` (categorised failure).
+    """
+
+    kind: Literal["photo_pending"] = "photo_pending"
+
+
+class MediaPhotoDownloaded(_MediaPhotoBase):
+    """A photo successfully downloaded; the bytes exist at `local_path`.
+
+    `local_path` is relative to `data/media/` so it can be moved across
+    machines without rewriting the store. Dimensions and byte size are
+    captured for completeness — they let `xbrain diff` answer "did the
+    download cascade pick a smaller size on a re-run?" without re-reading
+    every file.
+    """
+
+    kind: Literal["photo_downloaded"] = "photo_downloaded"
+    local_path: str
+    width: int
+    height: int
+    bytes_size: int
+    downloaded_at: datetime
+
+
+class MediaPhotoFailed(_MediaPhotoBase):
+    """A photo download attempted and failed (categorised).
+
+    Mirrors `ContentSourceFailure`: `failure_reason` is required so a
+    failure is always demonstrable evidence (no Optional, no silent loss).
+    `attempts` counts how many `xbrain media` runs have tried this URL —
+    each transient retry bumps it.
+    """
+
+    kind: Literal["photo_failed"] = "photo_failed"
+    failure_reason: MediaFailureReason
+    error: str | None = None
+    attempts: int = 0
+    last_attempt_at: datetime
+
+
+class MediaVideoPending(BaseModel):
+    """A video URL captured but not downloaded in Phase A.
+
+    Phase A is photos-only — videos remain in this state until Phase B
+    adds HLS + ffmpeg support. The variant is in the union from day one so
+    the wire shape does not change when Phase B lands.
+    """
+
+    type: Literal["video"] = "video"
+    kind: Literal["video_pending"] = "video_pending"
+    url: str
+
+
+def _normalise_legacy_media(value: Any) -> Any:
+    """Migrate the pre-Phase-A ``{type, url}`` shape to the new tagged union.
+
+    The legacy shape (the original `Media(type=..., url=...)` BaseModel)
+    is mapped one-to-one:
+
+    - ``{"type": "photo", "url": ...}`` → `MediaPhotoPending` payload.
+    - ``{"type": "video", "url": ...}`` → `MediaVideoPending` payload.
+
+    Records that already carry a ``kind`` field are passed through
+    unchanged — they are either fresh (extract-time) or persisted
+    Phase A variants. A record with neither `kind` nor a recognised
+    `type` is passed through unchanged so pydantic raises a clean
+    discriminator error rather than this validator inventing a state.
+    """
+    if not isinstance(value, dict):
+        return value
+    if "kind" in value:
+        return value
+    type_value = value.get("type")
+    if type_value == "photo":
+        return {**value, "kind": "photo_pending"}
+    if type_value == "video":
+        return {**value, "kind": "video_pending"}
+    return value
+
+
+# The persisted media type — a discriminated union over the four variants,
+# wrapped in an outer `BeforeValidator` that promotes the legacy
+# `{type, url}` shape on read. Same layering rationale as `ContentSource`
+# (see the long comment above): the discriminator check must run AFTER
+# the legacy normaliser, otherwise pre-Phase-A records get rejected.
+_MediaTagged = Annotated[
+    Union[MediaPhotoPending, MediaPhotoDownloaded, MediaPhotoFailed, MediaVideoPending],
+    Field(discriminator="kind"),
+]
+MediaEntry = Annotated[
+    _MediaTagged,
+    BeforeValidator(_normalise_legacy_media),
+]
+
+
+# TypeAdapter for tests / ad-hoc validation of a single entry outside an
+# `Item` context (mirrors `ContentSourceAdapter`).
+MediaEntryAdapter: TypeAdapter[
+    Union[MediaPhotoPending, MediaPhotoDownloaded, MediaPhotoFailed, MediaVideoPending]
+] = TypeAdapter(MediaEntry)
+
+
+def Media(*, type: Literal["photo", "video"], url: str) -> MediaPhotoPending | MediaVideoPending:
+    """Backward-compatible factory matching the pre-Phase-A constructor.
+
+    The pre-Phase-A `Media` class was a flat `BaseModel(type, url)`. The
+    extractor (`extract/graphql.py`) and the archive importer
+    (`archive.py`) call `Media(type="photo", url=...)` directly — they
+    are deliberately out of scope for Phase A (issue #33), so this
+    factory keeps their call sites working without modification by
+    returning the appropriate variant.
+
+    Photo URLs become `MediaPhotoPending` (the initial state for
+    `xbrain media` to advance); video URLs become `MediaVideoPending`
+    (terminal in Phase A).
+    """
+    if type == "photo":
+        return MediaPhotoPending(url=url)
+    return MediaVideoPending(url=url)
 
 
 class ThreadInfo(BaseModel):
@@ -250,7 +397,7 @@ class Item(BaseModel):
     text: str
     created_at: datetime
     captured_at: datetime
-    media: list[Media] = Field(default_factory=list)
+    media: list[MediaEntry] = Field(default_factory=list)
     links: list[Link] = Field(default_factory=list)
     quoted_id: str | None = None
     thread: ThreadInfo | None = None

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -54,7 +54,7 @@ class Link(BaseModel):
 
 
 # Categorised reasons a photo download can fail — mirrors the design of
-# `FailureReason` for content fetches (#19/#20). The transient subset
+# `FailureReason` for content fetches. The transient subset
 # (`_TRANSIENT_MEDIA_FAILURES` in `xbrain.media`) is retried on the next
 # `xbrain media` run; permanent reasons stay as-is unless `--force` is passed.
 MediaFailureReason = Literal[
@@ -62,7 +62,7 @@ MediaFailureReason = Literal[
     "http_5xx",  # transient: server-side, may succeed on retry
     "timeout",  # transient: network blip / cdn slow path
     "format_error",  # permanent: bytes downloaded but Pillow rejected them
-    "unknown_error",  # bare-except bucket; transient by default (mirrors fetch.py #20)
+    "unknown_error",  # bare-except bucket; transient by default (mirrors fetch.py)
 ]
 
 
@@ -156,11 +156,12 @@ class MediaPhotoFailed(_MediaPhotoBase):
 
 
 class MediaVideoPending(BaseModel):
-    """A video URL captured but not downloaded in Phase A.
+    """A video URL captured but not downloaded.
 
-    Phase A is photos-only — videos remain in this state until Phase B
-    adds HLS + ffmpeg support. The variant is in the union from day one so
-    the wire shape does not change when Phase B lands.
+    Videos are currently captured but not fetched — they remain in this
+    state until a future iteration adds HLS + ffmpeg support. The variant
+    is in the union from day one so the wire shape does not change when
+    video download lands.
     """
 
     type: Literal["video"] = "video"
@@ -169,7 +170,7 @@ class MediaVideoPending(BaseModel):
 
 
 def _normalise_legacy_media(value: Any) -> Any:
-    """Migrate the pre-Phase-A ``{type, url}`` shape to the new tagged union.
+    """Migrate the legacy ``{type, url}`` shape to the tagged union.
 
     The legacy shape (the original `Media(type=..., url=...)` BaseModel)
     is mapped one-to-one:
@@ -178,8 +179,8 @@ def _normalise_legacy_media(value: Any) -> Any:
     - ``{"type": "video", "url": ...}`` → `MediaVideoPending` payload.
 
     Records that already carry a ``kind`` field are passed through
-    unchanged — they are either fresh (extract-time) or persisted
-    Phase A variants. A record with neither `kind` nor a recognised
+    unchanged — they are either fresh (extract-time) or already in the
+    tagged-union shape. A record with neither `kind` nor a recognised
     `type` is passed through unchanged so pydantic raises a clean
     discriminator error rather than this validator inventing a state.
     """
@@ -199,7 +200,7 @@ def _normalise_legacy_media(value: Any) -> Any:
 # wrapped in an outer `BeforeValidator` that promotes the legacy
 # `{type, url}` shape on read. Same layering rationale as `ContentSource`
 # (see the long comment above): the discriminator check must run AFTER
-# the legacy normaliser, otherwise pre-Phase-A records get rejected.
+# the legacy normaliser, otherwise legacy records get rejected.
 _MediaTagged = Annotated[
     Union[MediaPhotoPending, MediaPhotoDownloaded, MediaPhotoFailed, MediaVideoPending],
     Field(discriminator="kind"),

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -118,7 +118,6 @@ class MediaPhotoDownloaded(_MediaPhotoBase):
     @field_validator("local_path")
     @classmethod
     def _reject_path_traversal(cls, value: str) -> str:
-        _ = cls  # required by @field_validator+@classmethod; placate vulture
         """Reject absolute paths and `..` components.
 
         `local_path` is joined onto `data/media/` at render and download
@@ -128,6 +127,7 @@ class MediaPhotoDownloaded(_MediaPhotoBase):
         the persisted store is on-disk plain JSON the user can edit —
         defence in depth at the type boundary is cheap.
         """
+        _ = cls  # required by @field_validator+@classmethod; placate vulture
         if value.startswith("/") or value.startswith("\\"):
             raise ValueError(f"local_path must be relative, got {value!r}")
         # Normalise separators before scanning components so a Windows-style

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime
 from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, BeforeValidator, Field, TypeAdapter
+from pydantic import BaseModel, BeforeValidator, Field, TypeAdapter, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +69,11 @@ MediaFailureReason = Literal[
 class _MediaPhotoBase(BaseModel):
     """Common fields for the three photo variants.
 
-    `type` is kept as the legacy discriminator that pre-Phase-A records used
-    so a re-dump after migration still carries it. The Phase A discriminator
-    is `kind` (see the variant subclasses) — globally unique across photo +
-    video variants because `state="pending"` would collide between
+    `type` is preserved for wire-compatibility with legacy records that
+    used the flat `{type, url}` shape — a re-dump after migration still
+    carries it. The discriminator is `kind` (see the variant subclasses)
+    — globally unique across photo + video variants because the
+    `state="pending"` shape would otherwise collide between
     `MediaPhotoPending` and `MediaVideoPending`.
     """
 
@@ -100,14 +101,40 @@ class MediaPhotoDownloaded(_MediaPhotoBase):
     captured for completeness — they let `xbrain diff` answer "did the
     download cascade pick a smaller size on a re-run?" without re-reading
     every file.
+
+    Dimensions and byte size are `gt=0`: a zero-pixel or zero-byte
+    "downloaded" photo is semantically illegal — Pillow validation in
+    `xbrain.media._decode_image` rules out the dim=0 case at the seam,
+    and the type constraint pins it at the data layer too.
     """
 
     kind: Literal["photo_downloaded"] = "photo_downloaded"
     local_path: str
-    width: int
-    height: int
-    bytes_size: int
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
+    bytes_size: int = Field(gt=0)
     downloaded_at: datetime
+
+    @field_validator("local_path")
+    @classmethod
+    def _reject_path_traversal(cls, value: str) -> str:
+        """Reject absolute paths and `..` components.
+
+        `local_path` is joined onto `data/media/` at render and download
+        time. A persisted record like ``"/etc/passwd"`` or ``"../../x"``
+        would let a poisoned `items.json` exfiltrate bytes outside the
+        media root. The downloader code never builds such a path, but
+        the persisted store is on-disk plain JSON the user can edit —
+        defence in depth at the type boundary is cheap.
+        """
+        if value.startswith("/") or value.startswith("\\"):
+            raise ValueError(f"local_path must be relative, got {value!r}")
+        # Normalise separators before scanning components so a Windows-style
+        # path persisted on a foreign machine is still caught.
+        for part in value.replace("\\", "/").split("/"):
+            if part == "..":
+                raise ValueError(f"local_path must not contain '..' components: {value!r}")
+        return value
 
 
 class MediaPhotoFailed(_MediaPhotoBase):
@@ -116,13 +143,15 @@ class MediaPhotoFailed(_MediaPhotoBase):
     Mirrors `ContentSourceFailure`: `failure_reason` is required so a
     failure is always demonstrable evidence (no Optional, no silent loss).
     `attempts` counts how many `xbrain media` runs have tried this URL —
-    each transient retry bumps it.
+    each transient retry bumps it. `attempts` is `ge=1`: a "failed but
+    never attempted" record is semantically nonsense, and the downloader
+    increments before producing any `MediaPhotoFailed`.
     """
 
     kind: Literal["photo_failed"] = "photo_failed"
     failure_reason: MediaFailureReason
     error: str | None = None
-    attempts: int = 0
+    attempts: int = Field(ge=1)
     last_attempt_at: datetime
 
 
@@ -188,19 +217,21 @@ MediaEntryAdapter: TypeAdapter[
 ] = TypeAdapter(MediaEntry)
 
 
-def Media(*, type: Literal["photo", "video"], url: str) -> MediaPhotoPending | MediaVideoPending:
-    """Backward-compatible factory matching the pre-Phase-A constructor.
+def Media(  # noqa: N802  -- factory keeps the legacy PascalCase call site
+    *, type: Literal["photo", "video"], url: str
+) -> MediaPhotoPending | MediaVideoPending:
+    """Backward-compatible factory matching the pre-tagged-union constructor.
 
-    The pre-Phase-A `Media` class was a flat `BaseModel(type, url)`. The
+    The previous `Media` class was a flat `BaseModel(type, url)`. The
     extractor (`extract/graphql.py`) and the archive importer
-    (`archive.py`) call `Media(type="photo", url=...)` directly — they
-    are deliberately out of scope for Phase A (issue #33), so this
-    factory keeps their call sites working without modification by
-    returning the appropriate variant.
+    (`archive.py`) still call `Media(type="photo", url=...)` directly —
+    this factory keeps those call sites working by returning the
+    appropriate variant. Photo URLs become `MediaPhotoPending` (the
+    initial state); video URLs become `MediaVideoPending`.
 
-    Photo URLs become `MediaPhotoPending` (the initial state for
-    `xbrain media` to advance); video URLs become `MediaVideoPending`
-    (terminal in Phase A).
+    TODO: when the LLM-description phase migrates `extract/graphql.py`
+    and `archive.py` to construct the variants directly, drop this
+    factory.
     """
     if type == "photo":
         return MediaPhotoPending(url=url)

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -58,10 +58,10 @@ class Link(BaseModel):
 # (`_TRANSIENT_MEDIA_FAILURES` in `xbrain.media`) is retried on the next
 # `xbrain media` run; permanent reasons stay as-is unless `--force` is passed.
 MediaFailureReason = Literal[
-    "http_4xx",       # permanent: dead URL / cdn-removed media
-    "http_5xx",       # transient: server-side, may succeed on retry
-    "timeout",        # transient: network blip / cdn slow path
-    "format_error",   # permanent: bytes downloaded but Pillow rejected them
+    "http_4xx",  # permanent: dead URL / cdn-removed media
+    "http_5xx",  # transient: server-side, may succeed on retry
+    "timeout",  # transient: network blip / cdn slow path
+    "format_error",  # permanent: bytes downloaded but Pillow rejected them
     "unknown_error",  # bare-except bucket; transient by default (mirrors fetch.py #20)
 ]
 

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -118,6 +118,7 @@ class MediaPhotoDownloaded(_MediaPhotoBase):
     @field_validator("local_path")
     @classmethod
     def _reject_path_traversal(cls, value: str) -> str:
+        _ = cls  # required by @field_validator+@classmethod; placate vulture
         """Reject absolute paths and `..` components.
 
         `local_path` is joined onto `data/media/` at render and download

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,9 +92,7 @@ def test_media_command_runs_on_empty_store(tmp_path: Path, monkeypatch):
     assert any("pre-media" in p.name for p in snapshots)
 
 
-def test_media_command_creates_media_dir_and_downloads_pending_photos(
-    tmp_path: Path, monkeypatch
-):
+def test_media_command_creates_media_dir_and_downloads_pending_photos(tmp_path: Path, monkeypatch):
     """End-to-end through the CLI with a fake session.
 
     The test patches `xbrain.media.requests.Session` to inject canned

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,15 +81,22 @@ def test_cli_reports_missing_config_cleanly(tmp_path: Path, monkeypatch):
 
 
 def test_media_command_runs_on_empty_store(tmp_path: Path, monkeypatch):
-    """`xbrain media` with no media is a no-op (creates a snapshot, exits 0)."""
+    """`xbrain media` with no media is a no-op (exit 0, items.json unchanged)."""
     _setup_repo(tmp_path, monkeypatch)
-    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    items_path = tmp_path / "data" / "items.json"
+    save_store({"1": _linked_item("1")}, items_path)
+    before_bytes = items_path.read_bytes()
+
     result = runner.invoke(app, ["media"])
+
     assert result.exit_code == 0
     # The pre-media snapshot must have been created — the destructive-op
     # contract: every command that writes items.json snapshots first.
     snapshots = list((tmp_path / "data" / "snapshots").iterdir())
     assert any("pre-media" in p.name for p in snapshots)
+    # items.json content is byte-identical: no media to advance, no
+    # transitions, no spurious rewrites that would dirty timestamps.
+    assert items_path.read_bytes() == before_bytes
 
 
 def test_media_command_creates_media_dir_and_downloads_pending_photos(tmp_path: Path, monkeypatch):
@@ -140,6 +147,89 @@ def test_media_command_creates_media_dir_and_downloads_pending_photos(tmp_path: 
     assert (tmp_path / "data" / "media" / "42" / "0.png").exists()
 
 
+def test_media_command_resume_after_interrupt_completes_remaining(tmp_path: Path, monkeypatch):
+    """Ctrl-C mid-batch leaves items.json valid; the next run completes the rest.
+
+    Setup: an item with 3 pending photos. Run 1 raises KeyboardInterrupt
+    after the 2nd photo's GET, so:
+      - photo 0 was downloaded and persisted by `on_progress`,
+      - photo 1's session.get raises, propagating out of `download_all`
+        (mid-photo: no transition persisted for it, stays Pending),
+      - photo 2 never starts.
+    Run 2 uses a fresh session that succeeds for every photo and verifies
+    that all three end up Downloaded.
+    """
+    import io as _io
+
+    from PIL import Image
+
+    from xbrain.models import MediaPhotoDownloaded, MediaPhotoPending
+
+    _setup_repo(tmp_path, monkeypatch)
+    item = _linked_item("99")
+    item.media = [
+        MediaPhotoPending(url="https://pbs.twimg.com/media/R0.png"),
+        MediaPhotoPending(url="https://pbs.twimg.com/media/R1.png"),
+        MediaPhotoPending(url="https://pbs.twimg.com/media/R2.png"),
+    ]
+    save_store({"99": item}, tmp_path / "data" / "items.json")
+
+    buffer = _io.BytesIO()
+    Image.new("RGB", (4, 3), color=(50, 60, 70)).save(buffer, format="PNG")
+    png = buffer.getvalue()
+
+    class _InterruptingSession:
+        """Returns 200 for the 1st photo, raises KeyboardInterrupt on the 2nd."""
+
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+            self.call_count = 0
+
+        def get(self, _url, *, timeout):
+            self.call_count += 1
+            if self.call_count == 2:
+                raise KeyboardInterrupt
+            class _Resp:
+                status_code = 200
+                content = png
+            return _Resp()
+
+    monkeypatch.setattr("xbrain.media.requests.Session", _InterruptingSession)
+    result1 = runner.invoke(app, ["media"])
+    # Typer surfaces KeyboardInterrupt as a non-zero exit code.
+    assert result1.exit_code != 0
+
+    from xbrain.store import load_store
+
+    reloaded = load_store(tmp_path / "data" / "items.json")
+    media = reloaded["99"].media
+    assert isinstance(media[0], MediaPhotoDownloaded)
+    # Photo 1 stays Pending because the KeyboardInterrupt fired BEFORE
+    # the transition was recorded (the seam: `on_progress` is what
+    # persists per-photo state; we never reached it).
+    assert isinstance(media[1], MediaPhotoPending)
+    assert isinstance(media[2], MediaPhotoPending)
+
+    # Run 2: fresh session that succeeds for every GET.
+    class _OkSession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
+        def get(self, _url, *, timeout):
+            class _Resp:
+                status_code = 200
+                content = png
+            return _Resp()
+
+    monkeypatch.setattr("xbrain.media.requests.Session", _OkSession)
+    result2 = runner.invoke(app, ["media"])
+    assert result2.exit_code == 0
+
+    final = load_store(tmp_path / "data" / "items.json")
+    for entry in final["99"].media:
+        assert isinstance(entry, MediaPhotoDownloaded)
+
+
 def test_media_command_propagates_total_failure_as_exit_1(tmp_path: Path, monkeypatch):
     """A run where every download fails surfaces as exit-1 (mirrors #24)."""
     from xbrain.models import MediaPhotoPending
@@ -171,6 +261,63 @@ def test_media_command_propagates_total_failure_as_exit_1(tmp_path: Path, monkey
 
     reloaded = load_store(tmp_path / "data" / "items.json")
     assert isinstance(reloaded["99"].media[0], _MPF)
+
+
+def test_media_command_warns_when_items_filter_matches_nothing(tmp_path: Path, monkeypatch):
+    """`--items` with IDs absent from the store prints an AVISO to stderr."""
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["media", "--items", "ghost-id-1,ghost-id-2"])
+    assert result.exit_code == 0
+    # The CLI mixes stdout and stderr in CliRunner output; the AVISO is on stderr
+    # — combined output is fine for the substring check.
+    assert "AVISO" in result.output
+    assert "ghost-id-1" in result.output
+
+
+def test_media_command_verbose_lists_failed_urls(tmp_path: Path, monkeypatch):
+    """`--verbose` prints `<item_id> <reason> <url>` per failure on stderr."""
+    from xbrain.models import MediaPhotoPending
+
+    _setup_repo(tmp_path, monkeypatch)
+    items = {
+        "1": _linked_item("1"),
+        "2": _linked_item("2"),
+    }
+    items["1"].media = [MediaPhotoPending(url="https://pbs.twimg.com/media/V1.png")]
+    items["2"].media = [MediaPhotoPending(url="https://pbs.twimg.com/media/V2.png")]
+    save_store(items, tmp_path / "data" / "items.json")
+
+    import io as _io
+    from PIL import Image
+
+    buffer = _io.BytesIO()
+    Image.new("RGB", (4, 3)).save(buffer, format="PNG")
+    png = buffer.getvalue()
+
+    class _MixedSession:
+        """Photo for item 1 succeeds; photo for item 2 returns 404 three times."""
+
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
+        def get(self, url, *, timeout):
+            if "V1" in url:
+                class _Ok:
+                    status_code = 200
+                    content = png
+                return _Ok()
+            class _Fail:
+                status_code = 404
+                content = b""
+            return _Fail()
+
+    monkeypatch.setattr("xbrain.media.requests.Session", _MixedSession)
+    result = runner.invoke(app, ["media", "--verbose"])
+    assert result.exit_code == 0
+    assert "Failed photos" in result.output
+    assert "http_4xx" in result.output
+    assert "V2" in result.output
 
 
 def test_media_command_respects_items_filter(tmp_path: Path, monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,6 +80,145 @@ def test_cli_reports_missing_config_cleanly(tmp_path: Path, monkeypatch):
     assert "Error:" in result.output
 
 
+def test_media_command_runs_on_empty_store(tmp_path: Path, monkeypatch):
+    """`xbrain media` with no media is a no-op (creates a snapshot, exits 0)."""
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["media"])
+    assert result.exit_code == 0
+    # The pre-media snapshot must have been created (#17 contract for any
+    # destructive op — media downloads write the items.json store).
+    snapshots = list((tmp_path / "data" / "snapshots").iterdir())
+    assert any("pre-media" in p.name for p in snapshots)
+
+
+def test_media_command_creates_media_dir_and_downloads_pending_photos(
+    tmp_path: Path, monkeypatch
+):
+    """End-to-end through the CLI with a fake session.
+
+    The test patches `xbrain.media.requests.Session` to inject canned
+    responses so the CLI hits the real `download_all` orchestrator
+    without any real network call.
+    """
+    import io as _io
+
+    from PIL import Image
+
+    from xbrain.models import MediaPhotoDownloaded, MediaPhotoPending
+
+    _setup_repo(tmp_path, monkeypatch)
+    item = _linked_item("42")
+    item.media = [MediaPhotoPending(url="https://pbs.twimg.com/media/Z.png")]
+    save_store({"42": item}, tmp_path / "data" / "items.json")
+
+    # Build a valid PNG byte payload Pillow can decode.
+    buffer = _io.BytesIO()
+    Image.new("RGB", (8, 6), color=(10, 20, 30)).save(buffer, format="PNG")
+    bytes_data = buffer.getvalue()
+
+    class _FakeSession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
+        def get(self, _url, *, timeout):
+            class _Resp:
+                status_code = 200
+                content = bytes_data
+
+            return _Resp()
+
+    monkeypatch.setattr("xbrain.media.requests.Session", _FakeSession)
+    result = runner.invoke(app, ["media"])
+    assert result.exit_code == 0, result.output
+
+    # The downloaded photo landed in the variant + the file is on disk.
+    from xbrain.store import load_store
+
+    reloaded = load_store(tmp_path / "data" / "items.json")
+    entry = reloaded["42"].media[0]
+    assert isinstance(entry, MediaPhotoDownloaded)
+    assert entry.local_path == "42/0.png"
+    assert (tmp_path / "data" / "media" / "42" / "0.png").exists()
+
+
+def test_media_command_propagates_total_failure_as_exit_1(tmp_path: Path, monkeypatch):
+    """A run where every download fails surfaces as exit-1 (mirrors #24)."""
+    from xbrain.models import MediaPhotoPending
+
+    _setup_repo(tmp_path, monkeypatch)
+    item = _linked_item("99")
+    item.media = [MediaPhotoPending(url="https://pbs.twimg.com/media/X.png")]
+    save_store({"99": item}, tmp_path / "data" / "items.json")
+
+    class _FakeSession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
+        def get(self, _url, *, timeout):
+            class _Resp:
+                status_code = 404
+                content = b""
+
+            return _Resp()
+
+    monkeypatch.setattr("xbrain.media.requests.Session", _FakeSession)
+    result = runner.invoke(app, ["media"])
+    assert result.exit_code == 1
+    # Even on total failure, the failure record is persisted: the CLI's
+    # finally block writes the store before the RuntimeError propagates.
+    from xbrain.store import load_store
+
+    from xbrain.models import MediaPhotoFailed as _MPF
+
+    reloaded = load_store(tmp_path / "data" / "items.json")
+    assert isinstance(reloaded["99"].media[0], _MPF)
+
+
+def test_media_command_respects_items_filter(tmp_path: Path, monkeypatch):
+    """`--items` limits the run to specific item IDs."""
+    import io as _io
+
+    from PIL import Image
+
+    from xbrain.models import MediaPhotoPending
+
+    _setup_repo(tmp_path, monkeypatch)
+    item_a = _linked_item("a")
+    item_b = _linked_item("b")
+    item_a.media = [MediaPhotoPending(url="https://pbs.twimg.com/media/A.png")]
+    item_b.media = [MediaPhotoPending(url="https://pbs.twimg.com/media/B.png")]
+    save_store({"a": item_a, "b": item_b}, tmp_path / "data" / "items.json")
+
+    buffer = _io.BytesIO()
+    Image.new("RGB", (4, 3)).save(buffer, format="PNG")
+    bytes_data = buffer.getvalue()
+
+    class _FakeSession:
+        def __init__(self):
+            self.headers: dict[str, str] = {}
+
+        def get(self, _url, *, timeout):
+            class _Resp:
+                status_code = 200
+                content = bytes_data
+
+            return _Resp()
+
+    monkeypatch.setattr("xbrain.media.requests.Session", _FakeSession)
+    result = runner.invoke(app, ["media", "--items", "b"])
+    assert result.exit_code == 0
+
+    from xbrain.store import load_store
+
+    from xbrain.models import MediaPhotoDownloaded, MediaPhotoPending as _MPP
+
+    reloaded = load_store(tmp_path / "data" / "items.json")
+    # `a` stayed pending; only `b` was downloaded.
+    assert isinstance(reloaded["a"].media[0], _MPP)
+    assert isinstance(reloaded["b"].media[0], MediaPhotoDownloaded)
+
+
 def test_parse_date_returns_utc_aware():
     from xbrain.cli import _parse_date
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,9 +189,11 @@ def test_media_command_resume_after_interrupt_completes_remaining(tmp_path: Path
             self.call_count += 1
             if self.call_count == 2:
                 raise KeyboardInterrupt
+
             class _Resp:
                 status_code = 200
                 content = png
+
             return _Resp()
 
     monkeypatch.setattr("xbrain.media.requests.Session", _InterruptingSession)
@@ -219,6 +221,7 @@ def test_media_command_resume_after_interrupt_completes_remaining(tmp_path: Path
             class _Resp:
                 status_code = 200
                 content = png
+
             return _Resp()
 
     monkeypatch.setattr("xbrain.media.requests.Session", _OkSession)
@@ -303,13 +306,17 @@ def test_media_command_verbose_lists_failed_urls(tmp_path: Path, monkeypatch):
 
         def get(self, url, *, timeout):
             if "V1" in url:
+
                 class _Ok:
                     status_code = 200
                     content = png
+
                 return _Ok()
+
             class _Fail:
                 status_code = 404
                 content = b""
+
             return _Fail()
 
     monkeypatch.setattr("xbrain.media.requests.Session", _MixedSession)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -86,8 +86,8 @@ def test_media_command_runs_on_empty_store(tmp_path: Path, monkeypatch):
     save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
     result = runner.invoke(app, ["media"])
     assert result.exit_code == 0
-    # The pre-media snapshot must have been created (#17 contract for any
-    # destructive op — media downloads write the items.json store).
+    # The pre-media snapshot must have been created — the destructive-op
+    # contract: every command that writes items.json snapshots first.
     snapshots = list((tmp_path / "data" / "snapshots").iterdir())
     assert any("pre-media" in p.name for p in snapshots)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,7 +234,7 @@ def test_media_command_resume_after_interrupt_completes_remaining(tmp_path: Path
 
 
 def test_media_command_propagates_total_failure_as_exit_1(tmp_path: Path, monkeypatch):
-    """A run where every download fails surfaces as exit-1 (mirrors #24)."""
+    """A run where every download fails surfaces as exit-1 at the CLI boundary."""
     from xbrain.models import MediaPhotoPending
 
     _setup_repo(tmp_path, monkeypatch)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -471,9 +471,7 @@ def test_diff_reports_media_state_counts(tmp_path: Path) -> None:
 
     a = tmp_path / "a"
     b = tmp_path / "b"
-    item_a = _item_with_media(
-        "1", [MediaPhotoPending(url="https://pbs.twimg.com/media/A.png")]
-    )
+    item_a = _item_with_media("1", [MediaPhotoPending(url="https://pbs.twimg.com/media/A.png")])
     item_b = _item_with_media(
         "1",
         [
@@ -524,9 +522,7 @@ def test_diff_media_counts_video_pending_separately(tmp_path: Path) -> None:
     _seed(
         b,
         items={
-            "1": _item_with_media(
-                "1", [MediaVideoPending(url="https://video.twimg.com/x.mp4")]
-            )
+            "1": _item_with_media("1", [MediaVideoPending(url="https://video.twimg.com/x.mp4")])
         },
         vocab_slugs=[],
     )

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -512,6 +512,54 @@ def test_diff_media_zero_when_no_media(tmp_path: Path) -> None:
     assert report.media.delta_downloaded == 0
 
 
+def test_diff_media_reports_delta_failed(tmp_path: Path) -> None:
+    """The diff surfaces a `delta_failed` count between snapshots.
+
+    Setup: snapshot A has 1 failed photo, snapshot B has 3 failed photos
+    (e.g. a re-run hit more 4xx URLs). The delta is +2, surfaced both on
+    `report.media.delta_failed` and on `summary.media_delta_failed`.
+    """
+    from xbrain.models import MediaPhotoFailed
+
+    def _failed(url: str) -> MediaPhotoFailed:
+        return MediaPhotoFailed(
+            url=url,
+            failure_reason="http_4xx",
+            attempts=1,
+            last_attempt_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(
+        a,
+        items={
+            "1": _item_with_media("1", [_failed("https://pbs.twimg.com/media/A1.png")]),
+        },
+        vocab_slugs=[],
+    )
+    _seed(
+        b,
+        items={
+            "1": _item_with_media(
+                "1",
+                [
+                    _failed("https://pbs.twimg.com/media/A1.png"),
+                    _failed("https://pbs.twimg.com/media/A2.png"),
+                ],
+            ),
+            "2": _item_with_media("2", [_failed("https://pbs.twimg.com/media/B1.png")]),
+        },
+        vocab_slugs=[],
+    )
+
+    report = diff_snapshots(a, b)
+    assert report.media.a.failed == 1
+    assert report.media.b.failed == 3
+    assert report.media.delta_failed == 2
+    assert report.summary.media_delta_failed == 2
+
+
 def test_diff_media_counts_video_pending_separately(tmp_path: Path) -> None:
     """Video-pending entries don't bleed into the photo counters."""
     from xbrain.models import MediaVideoPending

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -438,9 +438,136 @@ def test_format_json_round_trips_through_model(tmp_path: Path) -> None:
     text = format_json(diff_snapshots(a, a))
     parsed = json.loads(text)
     # Top-level keys match the model
-    assert set(parsed.keys()) == {"summary", "items", "topics", "vocab"}
+    assert set(parsed.keys()) == {"summary", "items", "topics", "vocab", "media"}
     # And the model can re-validate its own JSON
     DiffReport.model_validate_json(text)
+
+
+# ----------------------------------------------------------------------- media diff
+
+
+def _item_with_media(item_id: str, media_entries: list) -> Item:
+    """Construct an Item with the given media entries (no enrichment, no links)."""
+    item = Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="alice", name="Alice"),
+        text=f"Note {item_id}",
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+    )
+    item.media = media_entries
+    return item
+
+
+def test_diff_reports_media_state_counts(tmp_path: Path) -> None:
+    """`MediaDiff` carries the four-variant counts on both sides + deltas.
+
+    Scenario: A has 1 pending photo. B has 1 downloaded photo for the same
+    item. The transition counts as `delta_downloaded=+1, delta_pending=-1`.
+    """
+    from xbrain.models import MediaPhotoDownloaded, MediaPhotoPending
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    item_a = _item_with_media(
+        "1", [MediaPhotoPending(url="https://pbs.twimg.com/media/A.png")]
+    )
+    item_b = _item_with_media(
+        "1",
+        [
+            MediaPhotoDownloaded(
+                url="https://pbs.twimg.com/media/A.png",
+                local_path="1/0.png",
+                width=10,
+                height=8,
+                bytes_size=100,
+                downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+            )
+        ],
+    )
+    _seed(a, items={"1": item_a}, vocab_slugs=[])
+    _seed(b, items={"1": item_b}, vocab_slugs=[])
+
+    report = diff_snapshots(a, b)
+    assert report.media.a.pending == 1
+    assert report.media.a.downloaded == 0
+    assert report.media.b.pending == 0
+    assert report.media.b.downloaded == 1
+    assert report.media.delta_downloaded == 1
+    assert report.media.delta_pending == -1
+    # Surfaces in the summary line too — quick-glance counters.
+    assert report.summary.media_delta_downloaded == 1
+
+
+def test_diff_media_zero_when_no_media(tmp_path: Path) -> None:
+    """A diff between two stores without media reports zero everywhere."""
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={"1": _item("1", primary="misc")}, vocab_slugs=["misc"])
+    _seed(b, items={"1": _item("1", primary="misc")}, vocab_slugs=["misc"])
+
+    report = diff_snapshots(a, b)
+    assert report.media.a.downloaded == 0
+    assert report.media.b.downloaded == 0
+    assert report.media.delta_downloaded == 0
+
+
+def test_diff_media_counts_video_pending_separately(tmp_path: Path) -> None:
+    """Video-pending entries don't bleed into the photo counters."""
+    from xbrain.models import MediaVideoPending
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={"1": _item_with_media("1", [])}, vocab_slugs=[])
+    _seed(
+        b,
+        items={
+            "1": _item_with_media(
+                "1", [MediaVideoPending(url="https://video.twimg.com/x.mp4")]
+            )
+        },
+        vocab_slugs=[],
+    )
+
+    report = diff_snapshots(a, b)
+    assert report.media.b.video_pending == 1
+    assert report.media.b.downloaded == 0
+    assert report.media.delta_video_pending == 1
+
+
+def test_diff_media_text_format_includes_block(tmp_path: Path) -> None:
+    """The text renderer includes a `MEDIA` block with the four counters."""
+    from xbrain.models import MediaPhotoDownloaded
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    _seed(a, items={"1": _item_with_media("1", [])}, vocab_slugs=[])
+    _seed(
+        b,
+        items={
+            "1": _item_with_media(
+                "1",
+                [
+                    MediaPhotoDownloaded(
+                        url="u",
+                        local_path="1/0.png",
+                        width=4,
+                        height=3,
+                        bytes_size=10,
+                        downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+                    )
+                ],
+            )
+        },
+        vocab_slugs=[],
+    )
+
+    text = format_text(diff_snapshots(a, b))
+    assert "MEDIA" in text
+    assert "downloaded:" in text
+    assert "+1" in text  # delta marker
 
 
 # ------------------------------------------------------------------------- CLI
@@ -503,7 +630,7 @@ def test_cli_diff_format_json_parses_back(tmp_path: Path, monkeypatch) -> None:
 
     assert result.exit_code == 0, result.output
     parsed = json.loads(result.stdout)
-    assert set(parsed.keys()) == {"summary", "items", "topics", "vocab"}
+    assert set(parsed.keys()) == {"summary", "items", "topics", "vocab", "media"}
 
 
 def test_cli_diff_unknown_snapshot_exits_1(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -98,6 +98,7 @@ def test_generate_renders_failed_photo_as_warning(tmp_path: Path):
         MediaPhotoFailed(
             url="https://pbs.twimg.com/media/dead.png",
             failure_reason="http_4xx",
+            attempts=1,
             last_attempt_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
         )
     ]
@@ -280,6 +281,7 @@ def test_generate_works_without_media_root_argument(tmp_path: Path):
         MediaPhotoFailed(
             url="https://pbs.twimg.com/media/B.png",
             failure_reason="http_4xx",
+            attempts=1,
             last_attempt_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
         ),
     ]

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -54,6 +54,243 @@ def test_log_lists_every_item(tmp_path: Path):
     assert "Note 2" in log
 
 
+def test_generate_renders_downloaded_photo_as_obsidian_embed(tmp_path: Path):
+    """A `MediaPhotoDownloaded` becomes a `![[_media/<id>/<n>.<ext>]]` embed.
+
+    The bytes are copied from `media_root` into the vault's `_media/`
+    subdirectory at render time, so the resulting vault is self-contained
+    and the embed resolves without user configuration.
+    """
+    from xbrain.models import MediaPhotoDownloaded
+
+    media_root = tmp_path / "media"
+    photo_dir = media_root / "1"
+    photo_dir.mkdir(parents=True)
+    (photo_dir / "0.png").write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+    item = _item("1", with_link=True)
+    item.media = [
+        MediaPhotoDownloaded(
+            url="https://pbs.twimg.com/media/A.png",
+            local_path="1/0.png",
+            width=10,
+            height=8,
+            bytes_size=12,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+    ]
+
+    output_dir = tmp_path / "vault"
+    generate({"1": item}, output_dir, media_root=media_root)
+    note = next((output_dir / "items").glob("*.md"))
+    body = note.read_text(encoding="utf-8")
+    assert "![[_media/1/0.png]]" in body
+    # The file got mirrored into the vault.
+    assert (output_dir / "_media" / "1" / "0.png").exists()
+
+
+def test_generate_renders_failed_photo_as_warning(tmp_path: Path):
+    """A `MediaPhotoFailed` becomes a one-line ⚠ warning carrying URL + reason."""
+    from xbrain.models import MediaPhotoFailed
+
+    item = _item("1", with_link=True)
+    item.media = [
+        MediaPhotoFailed(
+            url="https://pbs.twimg.com/media/dead.png",
+            failure_reason="http_4xx",
+            last_attempt_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+    ]
+
+    generate({"1": item}, tmp_path)
+    note = next((tmp_path / "items").glob("*.md"))
+    body = note.read_text(encoding="utf-8")
+    assert "⚠" in body
+    assert "https://pbs.twimg.com/media/dead.png" in body
+    assert "URL no encontrada" in body or "HTTP 4xx" in body
+
+
+def test_generate_skips_pending_photo_silently(tmp_path: Path):
+    """A `MediaPhotoPending` produces NO output — `xbrain media` is the seam.
+
+    A pending photo is not an error; it just means the next `xbrain media`
+    run will pick it up. Surfacing it in the note as "still pending" would
+    be noise. The note is therefore identical to one without any media.
+    """
+    from xbrain.models import MediaPhotoPending
+
+    item = _item("1", with_link=True)
+    item.media = [MediaPhotoPending(url="https://pbs.twimg.com/media/pending.png")]
+
+    generate({"1": item}, tmp_path)
+    note = next((tmp_path / "items").glob("*.md"))
+    body = note.read_text(encoding="utf-8")
+    assert "pending.png" not in body
+    assert "⚠" not in body
+    assert "🎥" not in body
+
+
+def test_generate_renders_video_pending_as_placeholder(tmp_path: Path):
+    """A `MediaVideoPending` becomes a 🎥 placeholder carrying the URL.
+
+    Phase A does not download videos. The URL is the only evidence we
+    have — surface it so the reader can click through to X.
+    """
+    from xbrain.models import MediaVideoPending
+
+    item = _item("1", with_link=True)
+    item.media = [MediaVideoPending(url="https://video.twimg.com/x.mp4")]
+
+    generate({"1": item}, tmp_path)
+    note = next((tmp_path / "items").glob("*.md"))
+    body = note.read_text(encoding="utf-8")
+    assert "🎥" in body
+    assert "https://video.twimg.com/x.mp4" in body
+
+
+def test_generate_media_only_item_gets_a_note(tmp_path: Path):
+    """Phase A: an item with only media (no link, no enrichment) is note-worthy.
+
+    Pre-#33, `_has_note(item)` only returned True for items with links or
+    enrichment. A photo-only tweet was invisible. This test pins the new
+    behaviour: a photo-only item gets its note rendered.
+    """
+    from xbrain.models import MediaPhotoDownloaded
+
+    media_root = tmp_path / "media"
+    (media_root / "1").mkdir(parents=True)
+    (media_root / "1" / "0.png").write_bytes(b"PNGfake")
+
+    item = _item("1", with_link=False)
+    item.media = [
+        MediaPhotoDownloaded(
+            url="https://pbs.twimg.com/media/A.png",
+            local_path="1/0.png",
+            width=4,
+            height=3,
+            bytes_size=7,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+    ]
+    generate({"1": item}, tmp_path, media_root=media_root)
+    notes = list((tmp_path / "items").glob("*.md"))
+    assert len(notes) == 1
+
+
+def test_generate_media_block_precedes_links_section(tmp_path: Path):
+    """Photos render in the Tweet section, ahead of `## Enlaces`.
+
+    The intended read order: tweet text → photos → links → external content.
+    """
+    from xbrain.models import MediaPhotoDownloaded
+
+    media_root = tmp_path / "media"
+    (media_root / "1").mkdir(parents=True)
+    (media_root / "1" / "0.png").write_bytes(b"PNGfake")
+    item = _item("1", with_link=True)
+    item.media = [
+        MediaPhotoDownloaded(
+            url="u",
+            local_path="1/0.png",
+            width=4,
+            height=3,
+            bytes_size=7,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+    ]
+
+    generate({"1": item}, tmp_path, media_root=media_root)
+    body = next((tmp_path / "items").glob("*.md")).read_text(encoding="utf-8")
+    embed_idx = body.find("![[_media/1/0.png]]")
+    enlaces_idx = body.find("## Enlaces")
+    assert embed_idx != -1
+    assert enlaces_idx != -1
+    assert embed_idx < enlaces_idx
+
+
+def test_generate_renders_multiple_photos_inline(tmp_path: Path):
+    """All photos render — no cap (per spec decision: "ALL photos inline")."""
+    from xbrain.models import MediaPhotoDownloaded
+
+    media_root = tmp_path / "media"
+    (media_root / "1").mkdir(parents=True)
+    for n in range(4):
+        (media_root / "1" / f"{n}.png").write_bytes(b"PNGfake")
+
+    item = _item("1", with_link=True)
+    item.media = [
+        MediaPhotoDownloaded(
+            url=f"u{n}",
+            local_path=f"1/{n}.png",
+            width=4,
+            height=3,
+            bytes_size=7,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+        for n in range(4)
+    ]
+
+    generate({"1": item}, tmp_path, media_root=media_root)
+    body = next((tmp_path / "items").glob("*.md")).read_text(encoding="utf-8")
+    for n in range(4):
+        assert f"![[_media/1/{n}.png]]" in body
+
+
+def test_generate_handles_missing_media_bytes_gracefully(tmp_path: Path):
+    """A `MediaPhotoDownloaded` whose file vanished still renders the embed.
+
+    Missing bytes on disk is a manual-cleanup edge case. We log a warning
+    and still emit the embed — Obsidian shows it as a broken image, which
+    is the right user signal that the bytes are gone.
+    """
+    from xbrain.models import MediaPhotoDownloaded
+
+    media_root = tmp_path / "media"
+    # No file on disk.
+    item = _item("1", with_link=True)
+    item.media = [
+        MediaPhotoDownloaded(
+            url="u",
+            local_path="1/0.png",
+            width=4,
+            height=3,
+            bytes_size=7,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+    ]
+
+    # The generator must not raise — missing bytes is recoverable.
+    generate({"1": item}, tmp_path, media_root=media_root)
+    body = next((tmp_path / "items").glob("*.md")).read_text(encoding="utf-8")
+    assert "![[_media/1/0.png]]" in body
+
+
+def test_generate_works_without_media_root_argument(tmp_path: Path):
+    """`media_root=None` is the legacy code path — pending photos stay silent.
+
+    Backward compat: callers that haven't been updated still work. Failed
+    and video-pending entries still render (URL is in the data), only the
+    mirror-to-vault step is skipped.
+    """
+    from xbrain.models import MediaPhotoFailed, MediaPhotoPending
+
+    item = _item("1", with_link=True)
+    item.media = [
+        MediaPhotoPending(url="https://pbs.twimg.com/media/A.png"),
+        MediaPhotoFailed(
+            url="https://pbs.twimg.com/media/B.png",
+            failure_reason="http_4xx",
+            last_attempt_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        ),
+    ]
+    generate({"1": item}, tmp_path)  # no media_root
+    body = next((tmp_path / "items").glob("*.md")).read_text(encoding="utf-8")
+    # Pending: silent
+    assert "A.png" not in body
+    # Failed: still rendered (URL is in the data, no file needed)
+    assert "B.png" in body
+
+
 def test_slugify_handles_edge_cases():
     slug = slugify("Café del Día")
     assert slug == slug.lower()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -134,7 +134,7 @@ def test_generate_skips_pending_photo_silently(tmp_path: Path):
 def test_generate_renders_video_pending_as_placeholder(tmp_path: Path):
     """A `MediaVideoPending` becomes a 🎥 placeholder carrying the URL.
 
-    Phase A does not download videos. The URL is the only evidence we
+    Video bytes are not downloaded yet. The URL is the only evidence we
     have — surface it so the reader can click through to X.
     """
     from xbrain.models import MediaVideoPending
@@ -150,11 +150,11 @@ def test_generate_renders_video_pending_as_placeholder(tmp_path: Path):
 
 
 def test_generate_media_only_item_gets_a_note(tmp_path: Path):
-    """Phase A: an item with only media (no link, no enrichment) is note-worthy.
+    """An item with only media (no link, no enrichment) is note-worthy.
 
-    Pre-#33, `_has_note(item)` only returned True for items with links or
-    enrichment. A photo-only tweet was invisible. This test pins the new
-    behaviour: a photo-only item gets its note rendered.
+    Previously `_has_note(item)` only returned True for items with links or
+    enrichment, so a photo-only tweet was invisible. This test pins the
+    current behaviour: a photo-only item gets its note rendered.
     """
     from xbrain.models import MediaPhotoDownloaded
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -108,7 +108,10 @@ def test_generate_renders_failed_photo_as_warning(tmp_path: Path):
     body = note.read_text(encoding="utf-8")
     assert "⚠" in body
     assert "https://pbs.twimg.com/media/dead.png" in body
-    assert "URL no encontrada" in body or "HTTP 4xx" in body
+    # The `http_4xx` reason maps to "URL no encontrada (HTTP 4xx)" via
+    # `_FAILURE_ES_MEDIA`. The whole rendered phrase must be present —
+    # asserting one substring or the other is brittle.
+    assert "URL no encontrada (HTTP 4xx)" in body
 
 
 def test_generate_skips_pending_photo_silently(tmp_path: Path):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,615 @@
+"""Tests for `xbrain.media` — the photo download orchestrator.
+
+HTTP is mocked via a hand-rolled `FakeSession` (no `requests-mock` dependency
+on the unit path — keeps the test surface dependency-free and obvious).
+Pillow is exercised against real PNG/JPEG bytes generated inline.
+"""
+
+from __future__ import annotations
+
+import io
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from xbrain.media import (
+    _TRANSIENT_MEDIA_FAILURES,
+    MediaReport,
+    _is_eligible,
+    _local_path,
+    _url_with_name,
+    download_all,
+    emit_summary_line,
+)
+from xbrain.models import (
+    Author,
+    Item,
+    MediaPhotoDownloaded,
+    MediaPhotoFailed,
+    MediaPhotoPending,
+    MediaVideoPending,
+)
+
+# --------------------------------------------------------------------- fakes
+
+
+@dataclass
+class FakeResponse:
+    """A minimal stand-in for `requests.Response` — only `status_code` + `content`."""
+
+    status_code: int
+    content: bytes = b""
+
+
+@dataclass
+class FakeSession:
+    """Sequenced fake `requests.Session.get` returning canned responses.
+
+    `responses` is keyed by URL (after `name=` rewriting); each call pops
+    the first entry off the list, so a test can simulate a cascade
+    (orig 404 → large 200) by queueing two entries on the same URL prefix.
+    `raise_for` maps a URL substring to an exception class that should be
+    raised the first time that URL is hit (then cleared).
+    """
+
+    responses: dict[str, list[FakeResponse]] = field(default_factory=dict)
+    raise_for: dict[str, Exception] = field(default_factory=dict)
+    calls: list[tuple[str, int]] = field(default_factory=list)
+
+    def get(self, url: str, *, timeout: int) -> FakeResponse:
+        self.calls.append((url, timeout))
+        for key, exc in list(self.raise_for.items()):
+            if key in url:
+                del self.raise_for[key]
+                raise exc
+        # Match by base-URL (everything before the `?`) so the cascade's
+        # rewritten `name=` parameter does not get in the way.
+        base = url.split("?", 1)[0]
+        for matcher, queue in self.responses.items():
+            if matcher in base or matcher in url:
+                if not queue:
+                    continue
+                return queue.pop(0)
+        # Default to a 404 so an under-specified test fails noisily.
+        return FakeResponse(status_code=404, content=b"")
+
+
+def _png_bytes(width: int = 4, height: int = 3) -> bytes:
+    """Return a valid PNG with the requested dimensions for Pillow validation."""
+    image = Image.new("RGB", (width, height), color=(123, 45, 67))
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _item_with_media(media_entries: list) -> Item:
+    """Build an Item populated with the given media entries (no real text)."""
+    return Item(
+        id="123",
+        source="bookmark",
+        url="https://x.com/a/status/123",
+        author=Author(handle="a", name="A"),
+        text="t",
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        media=media_entries,
+    )
+
+
+# --------------------------------------------------------------------- pure helpers
+
+
+def test_url_with_name_sets_size_parameter():
+    """`name=` is added when absent and overwritten when present."""
+    rewritten = _url_with_name("https://pbs.twimg.com/media/X.jpg", "orig")
+    assert "name=orig" in rewritten
+    rewritten_existing = _url_with_name("https://pbs.twimg.com/media/X.jpg?name=small", "large")
+    assert "name=large" in rewritten_existing
+    assert "name=small" not in rewritten_existing
+
+
+def test_local_path_is_deterministic_relative_string():
+    """`<id>/<index><ext>` with forward slashes regardless of OS."""
+    assert _local_path("123", 0, ".jpg") == "123/0.jpg"
+    assert _local_path("abc", 2, ".png") == "abc/2.png"
+
+
+def test_is_eligible_pending_always_true():
+    pending = MediaPhotoPending(url="u")
+    assert _is_eligible(pending, force=False) is True
+    assert _is_eligible(pending, force=True) is True
+
+
+def test_is_eligible_video_pending_never_attempted():
+    """Phase A is photos only; videos stay in their pending variant always."""
+    video = MediaVideoPending(url="u")
+    assert _is_eligible(video, force=False) is False
+    assert _is_eligible(video, force=True) is False
+
+
+def test_is_eligible_downloaded_only_with_force():
+    """Idempotency: a downloaded photo is skipped unless `--force` is passed."""
+    downloaded = MediaPhotoDownloaded(
+        url="u",
+        local_path="123/0.jpg",
+        width=4,
+        height=3,
+        bytes_size=100,
+        downloaded_at=datetime.now(timezone.utc),
+    )
+    assert _is_eligible(downloaded, force=False) is False
+    assert _is_eligible(downloaded, force=True) is True
+
+
+def test_is_eligible_failed_distinguishes_transient_from_permanent():
+    """Transient retries on the next run; permanent failures only with `--force`."""
+    transient = MediaPhotoFailed(
+        url="u",
+        failure_reason="http_5xx",
+        last_attempt_at=datetime.now(timezone.utc),
+    )
+    permanent = MediaPhotoFailed(
+        url="u",
+        failure_reason="http_4xx",
+        last_attempt_at=datetime.now(timezone.utc),
+    )
+    assert _is_eligible(transient, force=False) is True
+    assert _is_eligible(permanent, force=False) is False
+    assert _is_eligible(permanent, force=True) is True
+
+
+# --------------------------------------------------------------------- download_all
+
+
+def test_download_all_records_local_path_and_dims_on_success(tmp_path: Path):
+    """A pending photo downloads cleanly and lands as MediaPhotoDownloaded."""
+    bytes_data = _png_bytes(width=10, height=7)
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/A.png")])
+    session = FakeSession(
+        responses={"pbs.twimg.com/media/A.png": [FakeResponse(200, bytes_data)]}
+    )
+    report = download_all(
+        {"123": item},
+        media_root=tmp_path,
+        session=session,
+        throttle_seconds=0,
+    )
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoDownloaded)
+    assert entry.width == 10
+    assert entry.height == 7
+    assert entry.bytes_size == len(bytes_data)
+    assert entry.local_path == "123/0.png"
+    assert (tmp_path / "123" / "0.png").exists()
+    assert report.photos_downloaded == 1
+    assert report.bytes_downloaded == len(bytes_data)
+
+
+def test_download_all_idempotent_for_already_downloaded(tmp_path: Path):
+    """A re-run on a downloaded photo bumps `skipped` not `downloaded`."""
+    downloaded = MediaPhotoDownloaded(
+        url="u",
+        local_path="123/0.jpg",
+        width=4,
+        height=3,
+        bytes_size=100,
+        downloaded_at=datetime.now(timezone.utc),
+    )
+    item = _item_with_media([downloaded])
+    session = FakeSession()
+    report = download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
+    )
+    assert report.photos_attempted == 0
+    assert report.photos_skipped_already_downloaded == 1
+    assert session.calls == []  # no HTTP call
+
+
+def test_download_all_falls_back_to_large_when_orig_404s(tmp_path: Path):
+    """The size cascade tries `orig` then `large` then `medium`."""
+    bytes_data = _png_bytes()
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/B.png")])
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/B.png": [
+                FakeResponse(404, b""),  # orig
+                FakeResponse(200, bytes_data),  # large
+            ]
+        }
+    )
+    report = download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
+    )
+    assert isinstance(item.media[0], MediaPhotoDownloaded)
+    assert report.photos_downloaded == 1
+    # Two HTTP calls (orig then large), each with the corresponding name= param.
+    assert len(session.calls) == 2
+    assert "name=orig" in session.calls[0][0]
+    assert "name=large" in session.calls[1][0]
+
+
+def test_download_all_records_http_4xx_failure_when_cascade_exhausted(tmp_path: Path):
+    """Three 404s in a row → MediaPhotoFailed with `http_4xx` (permanent)."""
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/C.png")])
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/C.png": [
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError):
+        # A single attempted photo + zero downloads triggers the total-failure raise.
+        download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "http_4xx"
+    assert entry.attempts == 1
+
+
+def test_download_all_records_http_5xx_as_transient(tmp_path: Path):
+    """A 5xx falls into the transient bucket — eligible for next-run retry."""
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/D.png")])
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/D.png": [
+                FakeResponse(503, b""),
+                FakeResponse(503, b""),
+                FakeResponse(503, b""),
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError):
+        download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "http_5xx"
+    assert entry.failure_reason in _TRANSIENT_MEDIA_FAILURES
+
+
+def test_download_all_records_timeout_as_transient(tmp_path: Path):
+    """`requests.Timeout` from the session is bucketed under `timeout`."""
+    import requests
+
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/E.png")])
+
+    class _AlwaysTimeout:
+        calls: list[tuple[str, int]] = []
+
+        def get(self, url, *, timeout):
+            self.calls.append((url, timeout))
+            raise requests.Timeout("connect timeout")
+
+    timeout_session = _AlwaysTimeout()
+    with pytest.raises(RuntimeError):
+        download_all(
+            {"123": item}, media_root=tmp_path, session=timeout_session, throttle_seconds=0
+        )
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "timeout"
+
+
+def test_download_all_records_format_error_when_pillow_rejects(tmp_path: Path):
+    """A 200 with non-image bytes → `format_error` (permanent)."""
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/F.png")])
+    session = FakeSession(
+        responses={"pbs.twimg.com/media/F.png": [FakeResponse(200, b"not an image at all")]}
+    )
+    with pytest.raises(RuntimeError):
+        download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "format_error"
+
+
+def test_download_all_buckets_unknown_exception_as_unknown_error(tmp_path: Path):
+    """Connection errors land in the unknown_error bucket (transient).
+
+    Mirrors `fetch.py`'s contract: a bare-except path stays retry-worthy.
+    """
+    import requests
+
+    class _AlwaysConnError:
+        calls: list[tuple[str, int]] = []
+
+        def get(self, url, *, timeout):
+            raise requests.ConnectionError("ECONNREFUSED")
+
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/G.png")])
+    with pytest.raises(RuntimeError):
+        download_all(
+            {"123": item},
+            media_root=tmp_path,
+            session=_AlwaysConnError(),
+            throttle_seconds=0,
+        )
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "unknown_error"
+    assert entry.failure_reason in _TRANSIENT_MEDIA_FAILURES
+
+
+def test_download_all_retries_transient_failures_on_next_run(tmp_path: Path):
+    """A MediaPhotoFailed(http_5xx) is re-attempted automatically next run."""
+    item = _item_with_media(
+        [
+            MediaPhotoFailed(
+                url="https://pbs.twimg.com/media/H.png",
+                failure_reason="http_5xx",
+                attempts=1,
+                last_attempt_at=datetime(2026, 5, 23, tzinfo=timezone.utc),
+            )
+        ]
+    )
+    session = FakeSession(
+        responses={"pbs.twimg.com/media/H.png": [FakeResponse(200, _png_bytes())]}
+    )
+    report = download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
+    )
+    assert isinstance(item.media[0], MediaPhotoDownloaded)
+    assert report.photos_attempted == 1
+    assert report.photos_downloaded == 1
+
+
+def test_download_all_skips_permanent_failures_without_force(tmp_path: Path):
+    """A MediaPhotoFailed(http_4xx) is not retried by default."""
+    item = _item_with_media(
+        [
+            MediaPhotoFailed(
+                url="u",
+                failure_reason="http_4xx",
+                attempts=1,
+                last_attempt_at=datetime(2026, 5, 23, tzinfo=timezone.utc),
+            )
+        ]
+    )
+    session = FakeSession()
+    report = download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
+    )
+    assert report.photos_attempted == 0
+    assert session.calls == []
+
+
+def test_download_all_force_redownloads_already_downloaded(tmp_path: Path):
+    """`--force` re-attempts a MediaPhotoDownloaded."""
+    item = _item_with_media(
+        [
+            MediaPhotoDownloaded(
+                url="https://pbs.twimg.com/media/I.png",
+                local_path="123/0.jpg",
+                width=1,
+                height=1,
+                bytes_size=10,
+                downloaded_at=datetime(2026, 5, 23, tzinfo=timezone.utc),
+            )
+        ]
+    )
+    new_bytes = _png_bytes(width=20, height=15)
+    session = FakeSession(
+        responses={"pbs.twimg.com/media/I.png": [FakeResponse(200, new_bytes)]}
+    )
+    report = download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0, force=True
+    )
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoDownloaded)
+    assert entry.width == 20  # new dimensions, not the stale "1" placeholder
+    assert report.photos_downloaded == 1
+
+
+def test_download_all_respects_limit(tmp_path: Path):
+    """`limit=1` caps the number of photo download attempts."""
+    item = _item_with_media(
+        [
+            MediaPhotoPending(url="https://pbs.twimg.com/media/J1.png"),
+            MediaPhotoPending(url="https://pbs.twimg.com/media/J2.png"),
+        ]
+    )
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/J1.png": [FakeResponse(200, _png_bytes())],
+            "pbs.twimg.com/media/J2.png": [FakeResponse(200, _png_bytes())],
+        }
+    )
+    report = download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0, limit=1
+    )
+    assert report.photos_attempted == 1
+    assert report.photos_downloaded == 1
+    # Second entry stays pending — limit hit before we got to it.
+    assert isinstance(item.media[1], MediaPhotoPending)
+
+
+def test_download_all_throttles_between_requests(tmp_path: Path):
+    """`sleep` is called once per successful download."""
+    sleep_calls: list[float] = []
+    item = _item_with_media(
+        [
+            MediaPhotoPending(url="https://pbs.twimg.com/media/K1.png"),
+            MediaPhotoPending(url="https://pbs.twimg.com/media/K2.png"),
+        ]
+    )
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/K1.png": [FakeResponse(200, _png_bytes())],
+            "pbs.twimg.com/media/K2.png": [FakeResponse(200, _png_bytes())],
+        }
+    )
+    download_all(
+        {"123": item},
+        media_root=tmp_path,
+        session=session,
+        throttle_seconds=0.25,
+        sleep=sleep_calls.append,
+    )
+    assert sleep_calls == [0.25, 0.25]
+
+
+def test_download_all_invokes_progress_callback_per_transition(tmp_path: Path):
+    """The on_progress hook fires after each photo transition — the seam
+    where the CLI persists `items.json` so Ctrl-C leaves a coherent store."""
+    progress_calls: list[int] = []
+    item = _item_with_media(
+        [
+            MediaPhotoPending(url="https://pbs.twimg.com/media/L1.png"),
+            MediaPhotoPending(url="https://pbs.twimg.com/media/L2.png"),
+        ]
+    )
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/L1.png": [FakeResponse(200, _png_bytes())],
+            "pbs.twimg.com/media/L2.png": [FakeResponse(200, _png_bytes())],
+        }
+    )
+    download_all(
+        {"123": item},
+        media_root=tmp_path,
+        session=session,
+        throttle_seconds=0,
+        on_progress=lambda: progress_calls.append(1),
+    )
+    assert len(progress_calls) == 2
+
+
+def test_download_all_never_touches_video_pending(tmp_path: Path):
+    """MediaVideoPending entries are not even iterated past."""
+    video = MediaVideoPending(url="https://video.twimg.com/x.mp4")
+    item = _item_with_media([video])
+    session = FakeSession()
+    report = download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
+    )
+    assert report.photos_attempted == 0
+    assert isinstance(item.media[0], MediaVideoPending)
+    assert session.calls == []
+
+
+def test_download_all_filters_by_items(tmp_path: Path):
+    """`items_filter` restricts the run to the named item ids."""
+    items_dict = {
+        "1": _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/M1.png")]),
+        "2": _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/M2.png")]),
+    }
+    # Patch the second item's id (it shares the constructor id="123" otherwise).
+    items_dict["1"].id = "1"
+    items_dict["2"].id = "2"
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/M1.png": [FakeResponse(200, _png_bytes())],
+            "pbs.twimg.com/media/M2.png": [FakeResponse(200, _png_bytes())],
+        }
+    )
+    report = download_all(
+        items_dict,
+        media_root=tmp_path,
+        session=session,
+        throttle_seconds=0,
+        items_filter=["2"],
+    )
+    assert report.items_processed == 1
+    assert report.photos_downloaded == 1
+    # Item 1 was skipped entirely — its media stays pending.
+    assert isinstance(items_dict["1"].media[0], MediaPhotoPending)
+
+
+def test_download_all_propagates_keyboard_interrupt(tmp_path: Path):
+    """Ctrl-C must NOT be swallowed — the narrow except clauses let it through."""
+
+    class _CtrlC:
+        def get(self, url, *, timeout):
+            raise KeyboardInterrupt
+
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/N.png")])
+    with pytest.raises(KeyboardInterrupt):
+        download_all(
+            {"123": item}, media_root=tmp_path, session=_CtrlC(), throttle_seconds=0
+        )
+
+
+def test_download_all_raises_on_total_failure(tmp_path: Path):
+    """All-failed batches surface as RuntimeError (mirror of #24)."""
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/O.png")])
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/O.png": [
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError, match="All 1 photo download attempts failed"):
+        download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+
+
+def test_download_all_partial_failure_does_not_raise(tmp_path: Path):
+    """A run with some downloads + some failures is partial success, not total failure."""
+    items_dict = {
+        "1": _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/P1.png")]),
+        "2": _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/P2.png")]),
+    }
+    items_dict["1"].id = "1"
+    items_dict["2"].id = "2"
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/P1.png": [FakeResponse(200, _png_bytes())],
+            "pbs.twimg.com/media/P2.png": [
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+            ],
+        }
+    )
+    report = download_all(
+        items_dict, media_root=tmp_path, session=session, throttle_seconds=0
+    )
+    assert report.photos_downloaded == 1
+    assert report.photos_failed_permanent == 1
+
+
+def test_download_all_writes_bytes_atomically(tmp_path: Path):
+    """Local file is created via a tmp+rename so partial writes are impossible."""
+    bytes_data = _png_bytes()
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/Q.png")])
+    session = FakeSession(
+        responses={"pbs.twimg.com/media/Q.png": [FakeResponse(200, bytes_data)]}
+    )
+    download_all(
+        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
+    )
+    # No leftover .part files; only the final file exists.
+    assert sorted(p.name for p in (tmp_path / "123").iterdir()) == ["0.png"]
+
+
+def test_emit_summary_line_silent_when_nothing_done(capsys):
+    """A no-op run (zero attempts, zero skips) stays silent."""
+    emit_summary_line(MediaReport())
+    assert capsys.readouterr().err == ""
+
+
+def test_emit_summary_line_includes_all_counters(capsys):
+    """The SUMMARY line carries every relevant counter for ops visibility."""
+    report = MediaReport(
+        photos_attempted=10,
+        photos_downloaded=8,
+        photos_failed_permanent=1,
+        photos_failed_transient=1,
+        photos_skipped_already_downloaded=5,
+        bytes_downloaded=1024000,
+    )
+    emit_summary_line(report)
+    err = capsys.readouterr().err
+    assert "SUMMARY: " in err
+    assert "downloaded: 8" in err
+    assert "failed_permanent: 1" in err
+    assert "failed_transient: 1" in err
+    assert "skipped: 5" in err
+    assert "1_024_000" in err

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -149,11 +149,13 @@ def test_is_eligible_failed_distinguishes_transient_from_permanent():
     transient = MediaPhotoFailed(
         url="u",
         failure_reason="http_5xx",
+        attempts=1,
         last_attempt_at=datetime.now(timezone.utc),
     )
     permanent = MediaPhotoFailed(
         url="u",
         failure_reason="http_4xx",
+        attempts=1,
         last_attempt_at=datetime.now(timezone.utc),
     )
     assert _is_eligible(transient, force=False) is True

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -124,7 +124,7 @@ def test_is_eligible_pending_always_true():
 
 
 def test_is_eligible_video_pending_never_attempted():
-    """Phase A is photos only; videos stay in their pending variant always."""
+    """Photos only; videos stay in their pending variant always."""
     video = MediaVideoPending(url="u")
     assert _is_eligible(video, force=False) is False
     assert _is_eligible(video, force=True) is False

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -85,6 +85,22 @@ def _png_bytes(width: int = 4, height: int = 3) -> bytes:
     return buffer.getvalue()
 
 
+def _jpeg_bytes(width: int = 4, height: int = 3) -> bytes:
+    """Return a valid JPEG with the requested dimensions for Pillow validation."""
+    image = Image.new("RGB", (width, height), color=(11, 22, 33))
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def _webp_bytes(width: int = 4, height: int = 3) -> bytes:
+    """Return a valid WebP with the requested dimensions for Pillow validation."""
+    image = Image.new("RGB", (width, height), color=(44, 55, 66))
+    buffer = io.BytesIO()
+    image.save(buffer, format="WEBP")
+    return buffer.getvalue()
+
+
 def _item_with_media(media_entries: list) -> Item:
     """Build an Item populated with the given media entries (no real text)."""
     return Item(
@@ -227,8 +243,40 @@ def test_download_all_falls_back_to_large_when_orig_404s(tmp_path: Path):
     assert "name=large" in session.calls[1][0]
 
 
-def test_download_all_records_http_4xx_failure_when_cascade_exhausted(tmp_path: Path):
-    """Three 404s in a row → MediaPhotoFailed with `http_4xx` (permanent)."""
+def test_download_all_records_http_4xx_when_cascade_exhausts(tmp_path: Path):
+    """Three 404s in a row land the photo in the `http_4xx` (permanent) bucket.
+
+    Setup is partial-success (a second item downloads cleanly) so the
+    total-failure RuntimeError does NOT fire — the assertion is on the
+    bucket alone, not on the raise.
+    """
+    items_dict = {
+        "1": _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/C.png")]),
+        "2": _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/C2.png")]),
+    }
+    items_dict["1"].id = "1"
+    items_dict["2"].id = "2"
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/C.png": [
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+                FakeResponse(404, b""),
+            ],
+            "pbs.twimg.com/media/C2.png": [FakeResponse(200, _png_bytes())],
+        }
+    )
+    report = download_all(items_dict, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = items_dict["1"].media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "http_4xx"
+    assert entry.attempts == 1
+    assert report.photos_failed_permanent == 1
+    assert report.photos_downloaded == 1
+
+
+def test_download_all_raises_runtime_error_when_lone_4xx_attempt_fails(tmp_path: Path):
+    """A single 4xx-only batch (no downloads at all) surfaces as RuntimeError."""
     item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/C.png")])
     session = FakeSession(
         responses={
@@ -240,12 +288,7 @@ def test_download_all_records_http_4xx_failure_when_cascade_exhausted(tmp_path: 
         }
     )
     with pytest.raises(RuntimeError):
-        # A single attempted photo + zero downloads triggers the total-failure raise.
         download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
-    entry = item.media[0]
-    assert isinstance(entry, MediaPhotoFailed)
-    assert entry.failure_reason == "http_4xx"
-    assert entry.attempts == 1
 
 
 def test_download_all_records_http_5xx_as_transient(tmp_path: Path):
@@ -567,6 +610,174 @@ def test_download_all_writes_bytes_atomically(tmp_path: Path):
     download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     # No leftover .part files; only the final file exists.
     assert sorted(p.name for p in (tmp_path / "123").iterdir()) == ["0.png"]
+
+
+def test_download_all_falls_back_through_full_cascade_to_medium(tmp_path: Path):
+    """orig 404 + large 404 + medium 200 — the cascade exhausts both higher
+    sizes before landing on `medium`. Three calls in cascade order."""
+    bytes_data = _png_bytes(width=8, height=6)
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/CASC.png")])
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/CASC.png": [
+                FakeResponse(404, b""),  # orig
+                FakeResponse(404, b""),  # large
+                FakeResponse(200, bytes_data),  # medium
+            ]
+        }
+    )
+    report = download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    assert isinstance(item.media[0], MediaPhotoDownloaded)
+    assert report.photos_downloaded == 1
+    assert len(session.calls) == 3
+    assert "name=orig" in session.calls[0][0]
+    assert "name=large" in session.calls[1][0]
+    assert "name=medium" in session.calls[2][0]
+
+
+def test_download_all_records_webp_extension(tmp_path: Path):
+    """A `.webp` URL with WebP bytes is stored with `.webp` on disk."""
+    bytes_data = _webp_bytes(width=6, height=5)
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/W.webp")])
+    session = FakeSession(responses={"pbs.twimg.com/media/W.webp": [FakeResponse(200, bytes_data)]})
+    download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoDownloaded)
+    assert entry.local_path.endswith(".webp")
+    assert (tmp_path / entry.local_path).exists()
+
+
+def test_download_all_records_jpeg_extension(tmp_path: Path):
+    """A JPEG URL with JPEG bytes is stored with `.jpg` on disk."""
+    bytes_data = _jpeg_bytes(width=6, height=5)
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/J.jpg")])
+    session = FakeSession(responses={"pbs.twimg.com/media/J.jpg": [FakeResponse(200, bytes_data)]})
+    download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoDownloaded)
+    assert entry.local_path.endswith(".jpg")
+    assert (tmp_path / entry.local_path).exists()
+
+
+def test_download_all_buckets_3xx_status_as_unknown_error(tmp_path: Path):
+    """A 304 (or any non-2xx non-4xx non-5xx) lands in `unknown_error` (transient).
+
+    Three 304s in a row (full cascade exhausted) trigger the total-failure
+    path; the bucket assertion is what we care about.
+    """
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/R.png")])
+    session = FakeSession(
+        responses={
+            "pbs.twimg.com/media/R.png": [
+                FakeResponse(304, b""),
+                FakeResponse(304, b""),
+                FakeResponse(304, b""),
+            ]
+        }
+    )
+    with pytest.raises(RuntimeError):
+        download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "unknown_error"
+
+
+def test_download_all_atomic_write_rollback_cleans_part_file(tmp_path: Path, monkeypatch):
+    """When `path.replace` raises, the `.part` file is removed and no final
+    file exists. Simulates a disk-full condition between write and rename.
+
+    Setup is partial-success (a second item downloads cleanly under a
+    different media_root path that does not collide with the monkeypatch)
+    so the total-failure RuntimeError does not fire and we can assert on
+    the bucket + filesystem state of the failed item.
+    """
+    bytes_data = _png_bytes(width=10, height=8)
+    fail_url = "https://pbs.twimg.com/media/ZFAIL.png"
+    ok_url = "https://pbs.twimg.com/media/ZOK.png"
+    items_dict = {
+        "1": _item_with_media([MediaPhotoPending(url=fail_url)]),
+        "2": _item_with_media([MediaPhotoPending(url=ok_url)]),
+    }
+    items_dict["1"].id = "1"
+    items_dict["2"].id = "2"
+    session = FakeSession(
+        responses={
+            fail_url.replace("https://", "").split("?")[0]: [FakeResponse(200, bytes_data)],
+            ok_url.replace("https://", "").split("?")[0]: [FakeResponse(200, bytes_data)],
+        }
+    )
+
+    original_replace = Path.replace
+
+    def _conditional_fail(self, target):
+        # Only fail the replace for the path containing item id "1".
+        if "/1/" in str(target) or str(target).endswith("/1/0.png"):
+            raise OSError("simulated disk full")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", _conditional_fail)
+    report = download_all(items_dict, media_root=tmp_path, session=session, throttle_seconds=0)
+
+    # Item 1 bucketed as unknown_error (transient): disk full is retryable.
+    failed_entry = items_dict["1"].media[0]
+    assert isinstance(failed_entry, MediaPhotoFailed)
+    assert failed_entry.failure_reason == "unknown_error"
+    # Item 2 downloaded cleanly.
+    assert isinstance(items_dict["2"].media[0], MediaPhotoDownloaded)
+    # No `.part` orphan or half-written final file under item 1.
+    item_dir = tmp_path / "1"
+    if item_dir.exists():
+        names = sorted(p.name for p in item_dir.iterdir())
+        assert "0.png.part" not in names
+        assert "0.png" not in names
+    assert report.photos_downloaded == 1
+    assert report.photos_failed_transient == 1
+
+
+def test_download_all_sweeps_part_orphans_on_entry(tmp_path: Path):
+    """A stale `*.part` file left by a SIGKILL is removed before any download."""
+    orphan_dir = tmp_path / "orphan-item"
+    orphan_dir.mkdir(parents=True)
+    orphan = orphan_dir / "0.png.part"
+    orphan.write_bytes(b"stale junk from a previous run")
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/S.png")])
+    session = FakeSession(
+        responses={"pbs.twimg.com/media/S.png": [FakeResponse(200, _png_bytes())]}
+    )
+    download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    assert not orphan.exists()
+
+
+def test_download_all_partial_failure_summary_emits_line(capsys):
+    """A run with zero downloads + N failures still emits the SUMMARY line.
+
+    The silence rule only applies to "zero attempts AND zero skips" —
+    a failed-only run is not silent: ops needs to see the failure count.
+    """
+    report = MediaReport(
+        photos_attempted=3,
+        photos_downloaded=0,
+        photos_failed_permanent=2,
+        photos_failed_transient=1,
+    )
+    emit_summary_line(report)
+    err = capsys.readouterr().err
+    assert "SUMMARY: " in err
+    assert "downloaded: 0" in err
+    assert "failed_permanent: 2" in err
+    assert "failed_transient: 1" in err
+
+
+def test_download_all_truncated_image_buckets_as_format_error(tmp_path: Path):
+    """Pillow rejecting partial PNG bytes → `format_error` (permanent)."""
+    truncated = _png_bytes()[:32]
+    item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/T.png")])
+    session = FakeSession(responses={"pbs.twimg.com/media/T.png": [FakeResponse(200, truncated)]})
+    with pytest.raises(RuntimeError):
+        download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
+    entry = item.media[0]
+    assert isinstance(entry, MediaPhotoFailed)
+    assert entry.failure_reason == "format_error"
 
 
 def test_emit_summary_line_silent_when_nothing_done(capsys):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -168,9 +168,7 @@ def test_download_all_records_local_path_and_dims_on_success(tmp_path: Path):
     """A pending photo downloads cleanly and lands as MediaPhotoDownloaded."""
     bytes_data = _png_bytes(width=10, height=7)
     item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/A.png")])
-    session = FakeSession(
-        responses={"pbs.twimg.com/media/A.png": [FakeResponse(200, bytes_data)]}
-    )
+    session = FakeSession(responses={"pbs.twimg.com/media/A.png": [FakeResponse(200, bytes_data)]})
     report = download_all(
         {"123": item},
         media_root=tmp_path,
@@ -200,9 +198,7 @@ def test_download_all_idempotent_for_already_downloaded(tmp_path: Path):
     )
     item = _item_with_media([downloaded])
     session = FakeSession()
-    report = download_all(
-        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
-    )
+    report = download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     assert report.photos_attempted == 0
     assert report.photos_skipped_already_downloaded == 1
     assert session.calls == []  # no HTTP call
@@ -220,9 +216,7 @@ def test_download_all_falls_back_to_large_when_orig_404s(tmp_path: Path):
             ]
         }
     )
-    report = download_all(
-        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
-    )
+    report = download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     assert isinstance(item.media[0], MediaPhotoDownloaded)
     assert report.photos_downloaded == 1
     # Two HTTP calls (orig then large), each with the corresponding name= param.
@@ -350,9 +344,7 @@ def test_download_all_retries_transient_failures_on_next_run(tmp_path: Path):
     session = FakeSession(
         responses={"pbs.twimg.com/media/H.png": [FakeResponse(200, _png_bytes())]}
     )
-    report = download_all(
-        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
-    )
+    report = download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     assert isinstance(item.media[0], MediaPhotoDownloaded)
     assert report.photos_attempted == 1
     assert report.photos_downloaded == 1
@@ -371,9 +363,7 @@ def test_download_all_skips_permanent_failures_without_force(tmp_path: Path):
         ]
     )
     session = FakeSession()
-    report = download_all(
-        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
-    )
+    report = download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     assert report.photos_attempted == 0
     assert session.calls == []
 
@@ -393,9 +383,7 @@ def test_download_all_force_redownloads_already_downloaded(tmp_path: Path):
         ]
     )
     new_bytes = _png_bytes(width=20, height=15)
-    session = FakeSession(
-        responses={"pbs.twimg.com/media/I.png": [FakeResponse(200, new_bytes)]}
-    )
+    session = FakeSession(responses={"pbs.twimg.com/media/I.png": [FakeResponse(200, new_bytes)]})
     report = download_all(
         {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0, force=True
     )
@@ -484,9 +472,7 @@ def test_download_all_never_touches_video_pending(tmp_path: Path):
     video = MediaVideoPending(url="https://video.twimg.com/x.mp4")
     item = _item_with_media([video])
     session = FakeSession()
-    report = download_all(
-        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
-    )
+    report = download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     assert report.photos_attempted == 0
     assert isinstance(item.media[0], MediaVideoPending)
     assert session.calls == []
@@ -529,9 +515,7 @@ def test_download_all_propagates_keyboard_interrupt(tmp_path: Path):
 
     item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/N.png")])
     with pytest.raises(KeyboardInterrupt):
-        download_all(
-            {"123": item}, media_root=tmp_path, session=_CtrlC(), throttle_seconds=0
-        )
+        download_all({"123": item}, media_root=tmp_path, session=_CtrlC(), throttle_seconds=0)
 
 
 def test_download_all_raises_on_total_failure(tmp_path: Path):
@@ -568,9 +552,7 @@ def test_download_all_partial_failure_does_not_raise(tmp_path: Path):
             ],
         }
     )
-    report = download_all(
-        items_dict, media_root=tmp_path, session=session, throttle_seconds=0
-    )
+    report = download_all(items_dict, media_root=tmp_path, session=session, throttle_seconds=0)
     assert report.photos_downloaded == 1
     assert report.photos_failed_permanent == 1
 
@@ -579,12 +561,8 @@ def test_download_all_writes_bytes_atomically(tmp_path: Path):
     """Local file is created via a tmp+rename so partial writes are impossible."""
     bytes_data = _png_bytes()
     item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/Q.png")])
-    session = FakeSession(
-        responses={"pbs.twimg.com/media/Q.png": [FakeResponse(200, bytes_data)]}
-    )
-    download_all(
-        {"123": item}, media_root=tmp_path, session=session, throttle_seconds=0
-    )
+    session = FakeSession(responses={"pbs.twimg.com/media/Q.png": [FakeResponse(200, bytes_data)]})
+    download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     # No leftover .part files; only the final file exists.
     assert sorted(p.name for p in (tmp_path / "123").iterdir()) == ["0.png"]
 

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -564,7 +564,7 @@ def test_download_all_propagates_keyboard_interrupt(tmp_path: Path):
 
 
 def test_download_all_raises_on_total_failure(tmp_path: Path):
-    """All-failed batches surface as RuntimeError (mirror of #24)."""
+    """Total-failure batches surface as RuntimeError so callers see exit-1."""
     item = _item_with_media([MediaPhotoPending(url="https://pbs.twimg.com/media/O.png")])
     session = FakeSession(
         responses={

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -305,6 +305,122 @@ def test_media_discriminator_rejects_unknown_kind():
         )
 
 
+def test_media_photo_downloaded_rejects_absolute_local_path():
+    """An absolute `local_path` would let a poisoned items.json exfiltrate
+    bytes outside `data/media/`. The validator must reject it at construction.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaPhotoDownloaded
+
+    with pytest.raises(ValidationError):
+        MediaPhotoDownloaded(
+            url="https://pbs.twimg.com/media/X.jpg",
+            local_path="/etc/passwd",
+            width=1,
+            height=1,
+            bytes_size=1,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_media_photo_downloaded_rejects_parent_traversal_local_path():
+    """A `local_path` containing `..` would let a poisoned items.json escape
+    the media root via path concatenation. The validator must reject it.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaPhotoDownloaded
+
+    with pytest.raises(ValidationError):
+        MediaPhotoDownloaded(
+            url="https://pbs.twimg.com/media/X.jpg",
+            local_path="../x/y.jpg",
+            width=1,
+            height=1,
+            bytes_size=1,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_media_photo_downloaded_rejects_zero_bytes_size():
+    """A zero-byte download is nonsense — the downloader records bytes_size
+    after writing, so a value of 0 either means a failed write was persisted
+    as success or the record was hand-edited. Reject at the boundary.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaPhotoDownloaded
+
+    with pytest.raises(ValidationError):
+        MediaPhotoDownloaded(
+            url="https://pbs.twimg.com/media/X.jpg",
+            local_path="123/0.jpg",
+            width=1,
+            height=1,
+            bytes_size=0,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_media_photo_downloaded_rejects_zero_width():
+    """A zero-width image cannot have been decoded — reject as data corruption."""
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaPhotoDownloaded
+
+    with pytest.raises(ValidationError):
+        MediaPhotoDownloaded(
+            url="https://pbs.twimg.com/media/X.jpg",
+            local_path="123/0.jpg",
+            width=0,
+            height=1,
+            bytes_size=1,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_media_photo_downloaded_rejects_zero_height():
+    """A zero-height image cannot have been decoded — reject as data corruption."""
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaPhotoDownloaded
+
+    with pytest.raises(ValidationError):
+        MediaPhotoDownloaded(
+            url="https://pbs.twimg.com/media/X.jpg",
+            local_path="123/0.jpg",
+            width=1,
+            height=0,
+            bytes_size=1,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+
+
+def test_media_photo_failed_rejects_zero_attempts():
+    """A `MediaPhotoFailed` with `attempts=0` is semantically nonsense — the
+    downloader increments `attempts` before constructing any failed record,
+    so 0 cannot occur naturally. The validator must reject it.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaPhotoFailed
+
+    with pytest.raises(ValidationError):
+        MediaPhotoFailed(
+            url="https://pbs.twimg.com/media/X.jpg",
+            failure_reason="not_found",
+            attempts=0,
+            last_attempt_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        )
+
+
 def test_media_failed_requires_failure_reason():
     """Symmetric with ContentSourceFailure: a failure without a reason is a
     type error. The validator constructs the variant via pydantic, which

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -235,10 +235,10 @@ def test_content_source_legacy_failure_without_reason_buckets_as_transient():
 
 
 def test_media_legacy_photo_shape_migrates_to_pending():
-    """A pre-Phase-A ``{type: "photo", url}`` record reads as MediaPhotoPending.
+    """A legacy ``{type: "photo", url}`` record reads as MediaPhotoPending.
 
-    The on-disk shape before issue #33 was a flat ``Media(type, url)``. The
-    `_normalise_legacy_media` BeforeValidator promotes it to the new
+    The on-disk shape before the tagged union was a flat ``Media(type, url)``.
+    The `_normalise_legacy_media` BeforeValidator promotes it to the new
     tagged-union shape on read, so existing ``data/items.json`` files keep
     working without a manual migration step.
     """
@@ -254,7 +254,7 @@ def test_media_legacy_photo_shape_migrates_to_pending():
 
 
 def test_media_legacy_video_shape_migrates_to_video_pending():
-    """A pre-Phase-A ``{type: "video", url}`` record reads as MediaVideoPending."""
+    """A legacy ``{type: "video", url}`` record reads as MediaVideoPending."""
     from xbrain.models import MediaEntryAdapter, MediaVideoPending
 
     entry = MediaEntryAdapter.validate_python(
@@ -321,8 +321,8 @@ def test_media_failed_requires_failure_reason():
 
 def test_media_factory_returns_pending_variant_for_photo():
     """The backward-compat `Media(type=..., url=...)` factory must yield a
-    `MediaPhotoPending` so the extractor and archive callsites — which are
-    out of scope for #33 — keep building items the new union accepts.
+    `MediaPhotoPending` so the extractor and archive callsites keep
+    building items the tagged union accepts.
     """
     from xbrain.models import Media, MediaPhotoPending
 
@@ -332,8 +332,8 @@ def test_media_factory_returns_pending_variant_for_photo():
 
 
 def test_media_factory_returns_video_pending_for_video():
-    """The factory routes `type="video"` to `MediaVideoPending` — videos
-    are deliberately not downloaded in Phase A.
+    """The factory routes `type="video"` to `MediaVideoPending` — video
+    bytes are not downloaded yet.
     """
     from xbrain.models import Media, MediaVideoPending
 
@@ -347,7 +347,7 @@ def test_item_with_legacy_media_loads_into_pending_variant():
 
     Exercises the full path: the Item validator hits MediaEntry's
     BeforeValidator on each element of the `media` list. This is the
-    invariant the wire-shape compatibility rests on for #33.
+    invariant the wire-shape compatibility rests on.
     """
     from datetime import datetime, timezone
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -234,6 +234,145 @@ def test_content_source_legacy_failure_without_reason_buckets_as_transient():
     assert src.http_status == 429
 
 
+def test_media_legacy_photo_shape_migrates_to_pending():
+    """A pre-Phase-A ``{type: "photo", url}`` record reads as MediaPhotoPending.
+
+    The on-disk shape before issue #33 was a flat ``Media(type, url)``. The
+    `_normalise_legacy_media` BeforeValidator promotes it to the new
+    tagged-union shape on read, so existing ``data/items.json`` files keep
+    working without a manual migration step.
+    """
+    from xbrain.models import MediaEntryAdapter, MediaPhotoPending
+
+    entry = MediaEntryAdapter.validate_python(
+        {"type": "photo", "url": "https://pbs.twimg.com/media/X.jpg"}
+    )
+    assert isinstance(entry, MediaPhotoPending)
+    assert entry.url == "https://pbs.twimg.com/media/X.jpg"
+    assert entry.kind == "photo_pending"
+    assert entry.type == "photo"
+
+
+def test_media_legacy_video_shape_migrates_to_video_pending():
+    """A pre-Phase-A ``{type: "video", url}`` record reads as MediaVideoPending."""
+    from xbrain.models import MediaEntryAdapter, MediaVideoPending
+
+    entry = MediaEntryAdapter.validate_python(
+        {"type": "video", "url": "https://video.twimg.com/x.mp4"}
+    )
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.url == "https://video.twimg.com/x.mp4"
+    assert entry.kind == "video_pending"
+
+
+def test_media_new_tagged_shape_passes_through():
+    """A record that already carries `kind` is preserved verbatim.
+
+    Round-trip dumps from the new variants must read back as the same
+    variant — a freshly-downloaded photo on the live store must NOT be
+    re-bucketed as pending.
+    """
+    from datetime import datetime, timezone
+
+    from xbrain.models import MediaEntryAdapter, MediaPhotoDownloaded
+
+    payload = {
+        "kind": "photo_downloaded",
+        "type": "photo",
+        "url": "https://pbs.twimg.com/media/X.jpg",
+        "local_path": "123/0.jpg",
+        "width": 1200,
+        "height": 800,
+        "bytes_size": 99000,
+        "downloaded_at": datetime(2026, 5, 24, tzinfo=timezone.utc).isoformat(),
+    }
+    entry = MediaEntryAdapter.validate_python(payload)
+    assert isinstance(entry, MediaPhotoDownloaded)
+    assert entry.local_path == "123/0.jpg"
+    assert entry.width == 1200
+
+
+def test_media_discriminator_rejects_unknown_kind():
+    """Silently inventing a variant would mask data corruption — reject loudly."""
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaEntryAdapter
+
+    with pytest.raises(ValidationError):
+        MediaEntryAdapter.validate_python(
+            {"kind": "photo_in_orbit", "type": "photo", "url": "https://pbs.twimg.com/X.jpg"}
+        )
+
+
+def test_media_failed_requires_failure_reason():
+    """Symmetric with ContentSourceFailure: a failure without a reason is a
+    type error. The validator constructs the variant via pydantic, which
+    flags the missing required field.
+    """
+    import pytest
+    from pydantic import ValidationError
+
+    from xbrain.models import MediaPhotoFailed
+
+    with pytest.raises(ValidationError):
+        MediaPhotoFailed(url="u")  # missing failure_reason and last_attempt_at
+
+
+def test_media_factory_returns_pending_variant_for_photo():
+    """The backward-compat `Media(type=..., url=...)` factory must yield a
+    `MediaPhotoPending` so the extractor and archive callsites — which are
+    out of scope for #33 — keep building items the new union accepts.
+    """
+    from xbrain.models import Media, MediaPhotoPending
+
+    entry = Media(type="photo", url="https://pbs.twimg.com/media/X.jpg")
+    assert isinstance(entry, MediaPhotoPending)
+    assert entry.kind == "photo_pending"
+
+
+def test_media_factory_returns_video_pending_for_video():
+    """The factory routes `type="video"` to `MediaVideoPending` — videos
+    are deliberately not downloaded in Phase A.
+    """
+    from xbrain.models import Media, MediaVideoPending
+
+    entry = Media(type="video", url="https://video.twimg.com/x.mp4")
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.kind == "video_pending"
+
+
+def test_item_with_legacy_media_loads_into_pending_variant():
+    """A persisted Item with the legacy media shape migrates on read.
+
+    Exercises the full path: the Item validator hits MediaEntry's
+    BeforeValidator on each element of the `media` list. This is the
+    invariant the wire-shape compatibility rests on for #33.
+    """
+    from datetime import datetime, timezone
+
+    from xbrain.models import Item, MediaPhotoPending, MediaVideoPending
+
+    payload = {
+        "id": "1",
+        "source": "bookmark",
+        "url": "https://x.com/a/status/1",
+        "author": {"handle": "a", "name": "A"},
+        "text": "t",
+        "created_at": datetime(2026, 5, 1, tzinfo=timezone.utc).isoformat(),
+        "captured_at": datetime(2026, 5, 16, tzinfo=timezone.utc).isoformat(),
+        "media": [
+            {"type": "photo", "url": "https://pbs.twimg.com/media/X.jpg"},
+            {"type": "video", "url": "https://video.twimg.com/x.mp4"},
+        ],
+        "links": [],
+    }
+    item = Item.model_validate(payload)
+    assert len(item.media) == 2
+    assert isinstance(item.media[0], MediaPhotoPending)
+    assert isinstance(item.media[1], MediaVideoPending)
+
+
 def test_topic_page_model_round_trips():
     from datetime import datetime, timezone
 

--- a/tests/test_snapshot_auto.py
+++ b/tests/test_snapshot_auto.py
@@ -124,6 +124,19 @@ def test_topics_without_resynth_creates_no_snapshot(tmp_path: Path, monkeypatch)
     assert snapshot_list(tmp_path / "data") == []
 
 
+def test_media_creates_pre_snapshot(tmp_path: Path, monkeypatch):
+    """`xbrain media` always snapshots before mutating items.json — every run
+    is potentially destructive (it rewrites media variants on items)."""
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+
+    result = runner.invoke(app, ["media"])
+
+    assert result.exit_code == 0, result.stdout
+    snapshots = snapshot_list(tmp_path / "data")
+    assert any(p.name.endswith("-pre-media") for p, _ in snapshots), snapshots
+
+
 def test_fetch_force_creates_pre_snapshot(tmp_path: Path, monkeypatch):
     _setup_repo(tmp_path, monkeypatch)
     # An item with no links → fetch_pending no-ops; the snapshot still fires

--- a/uv.lock
+++ b/uv.lock
@@ -888,6 +888,75 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "playwright"
 version = "1.59.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1262,6 +1331,18 @@ wheels = [
 ]
 
 [[package]]
+name = "requests-mock"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
+]
+
+[[package]]
 name = "requirements-parser"
 version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1509,6 +1590,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
+    { name = "pillow" },
     { name = "playwright" },
     { name = "pydantic" },
     { name = "pyyaml" },
@@ -1531,6 +1613,11 @@ dev = [
     { name = "vulture" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "requests-mock" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.39" },
@@ -1539,6 +1626,7 @@ requires-dist = [
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10" },
+    { name = "pillow", specifier = ">=12.2.0" },
     { name = "playwright", specifier = ">=1.44" },
     { name = "poethepoet", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "pydantic", specifier = ">=2.6" },
@@ -1552,3 +1640,6 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.11" },
 ]
 provides-extras = ["dev"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "requests-mock", specifier = ">=1.12.1" }]

--- a/uv.lock
+++ b/uv.lock
@@ -1594,6 +1594,7 @@ dependencies = [
     { name = "playwright" },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "requests" },
     { name = "trafilatura" },
     { name = "typer" },
 ]
@@ -1634,6 +1635,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "radon", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "trafilatura", specifier = ">=1.9" },
     { name = "typer", specifier = ">=0.12" },


### PR DESCRIPTION
Closes #33.

## Summary

Phase A of the media subsystem: `xbrain media` downloads X-post photos to disk, the data model tracks per-photo state via a tagged union, and `xbrain generate` renders downloaded photos inline in Obsidian notes. Videos remain in a `video_pending` state for a future phase.

- **New command** `xbrain media [--force] [--limit N] [--items a,b,c]` walks every photo URL in `Item.media`, downloads bytes from `pbs.twimg.com` with a size cascade (`name=orig` → `large` → `medium`), validates with Pillow, and atomically writes the file under `data/media/<item-id>/<index>.<ext>`. Auto-snapshots `data/` first (label `pre-media`).
- **Tagged union model** replaces the flat `Media(type, url)`: `MediaPhotoPending` / `MediaPhotoDownloaded` / `MediaPhotoFailed` / `MediaVideoPending`, discriminated by `kind`. Mirrors the `ContentSource` design from #20 — illegal states unrepresentable. A `_normalise_legacy_media` BeforeValidator promotes the pre-Phase-A `{type, url}` shape on read; no manual migration.
- **Failure categorisation** mirrors `xbrain.fetch` (#19): transient bucket (`http_5xx`, `timeout`, `unknown_error`) auto-retried on the next run; permanent bucket (`http_4xx`, `format_error`) only with `--force`. Total-failure raises `RuntimeError` (mirror of #24).
- **Ctrl-C safety**: orchestrator calls a `on_progress` callback after every photo transition; CLI persists `items.json` atomically between photos.
- **Rendering**: `xbrain generate` mirrors photos from `data/media/` into `<output_dir>/_media/` at render time and embeds them inline (`![[_media/<id>/<n>.<ext>]]`) so the vault is fully self-contained.
- **`xbrain diff` extension**: new `MediaDiff` block reports per-variant counts on both sides + the four state-transition deltas (`+N`/`-N`).

## Acceptance criteria

Verified locally (the full-corpus end-to-end run is reserved for the reviewer's machine per the task brief):

- [x] Running `xbrain media` on the corpus completes without unhandled exceptions (covered by `tests/test_media.py` — happy path, all five failure categories, total-failure raise, partial-failure no-raise).
- [x] Every photo URL ends in a defined state after a run (the type system enforces it; `_record_outcome` is exhaustive over the post-transition variants).
- [x] Photos land on disk in a deterministic path (`data/media/<id>/<n>.<ext>`).
- [x] Re-running `xbrain media` is a no-op for already-downloaded photos (`test_download_all_idempotent_for_already_downloaded`).
- [x] `--force` re-downloads everything (`test_download_all_force_redownloads_already_downloaded`).
- [x] `xbrain generate` produces notes with photos visible (`test_generate_renders_downloaded_photo_as_obsidian_embed`, mirror-into-vault verified).
- [x] `xbrain diff` reports new-download counts (`test_diff_reports_media_state_counts`).
- [x] Ctrl-C leaves `items.json` valid (`test_download_all_propagates_keyboard_interrupt` + the CLI's atomic per-photo persistence).
- [x] Existing data loads without manual migration (`test_media_legacy_photo_shape_migrates_to_pending`, `test_item_with_legacy_media_loads_into_pending_variant`).
- [x] A snapshot is created automatically before the run (`test_media_creates_pre_snapshot`).
- [ ] **Reserved for reviewer end-to-end:** ≥95% downloaded after a full-corpus run, manual spot-check of 10 random notes, total disk usage ≤350 MB.

## Deviations from the implementation plan

1. **Embed path**: the plan specified `![[data/media/<id>/<n>.<ext>]]` and "verify in the end-to-end test" that Obsidian could resolve the relative path. That only works when the vault root and `data/` align, which is not the common case (Víctor's vault is `~/Documents/Vault/vault/`, the repo is `~/devel/xbrain/`). Instead, `xbrain generate` mirrors each `MediaPhotoDownloaded` from `data/media/` into `<output_dir>/_media/` at render time and embeds `![[_media/<id>/<n>.<ext>]]`. The canonical store stays at `data/media/`; the vault copy is a render-time artifact. Documented in README and ARCHITECTURE.
2. **`Media` as a factory function**: the constraint forbade modifying `extract/graphql.py` and `archive.py` "except possibly to import the new media types". Rather than rewriting their call sites, `Media(type=..., url=...)` is preserved as a factory function in `models.py` that returns `MediaPhotoPending` or `MediaVideoPending`. Existing call sites work unchanged. I did add minimal type annotation updates (`list[Media]` → `list[MediaEntry]`) in those two files because mypy needs the type alias for the new union; the runtime calls are untouched.
3. **`requests` declared explicitly in `pyproject.toml`**: was previously a transitive dep of trafilatura. Deptry flagged DEP003 for the new direct import in `media.py`; declaring it explicitly is the right hygiene.
4. **`_has_note` extended to include items with media**: a photo-only tweet was previously invisible in the wiki. The plan didn't call this out, but `xbrain generate` needs to render notes for photo-only items now that photos have a render block. Pinned by `test_generate_media_only_item_gets_a_note`.

## Open questions / known limitations

- **Disk budget unverified at scale.** The 350 MB target is a guess based on average photo sizes; the actual number will land after the reviewer's full-corpus run.
- **Concurrency**: the plan suggested a `ThreadPoolExecutor(max_workers=4)` parallelism cap. The current implementation is sequential with a 0.5 s throttle between requests. Concurrency was deferred to keep the Ctrl-C-coherency contract simple — adding workers safely requires a lock around the on_progress writes. If the full-corpus run is too slow, a follow-up PR can add bounded parallelism.
- **Snapshot does not include `data/media/`**: `xbrain snapshot` still only copies the JSON artifacts. A `snapshot restore` of a pre-media snapshot will revert `items.json` but leave the bytes on disk (the variants still pointing at them, but the timestamp drift is observable). Fine for #33; a follow-up could decide whether `data/media/` should be part of the snapshot envelope.

## Test plan

- [ ] `uv run pytest -q` — should report **412 passed** (358 baseline + 54 new).
- [ ] `uv run bash scripts/check.sh` — all critical checks must pass; coverage 90%.
- [ ] `uv run xbrain media --help` — confirm the three flags are present.
- [ ] `uv run xbrain media` on the real corpus (`data/items.json`, ~1884 items) — reviewer's machine. Verify:
  - [ ] ≥95% of photo URLs end in `MediaPhotoDownloaded`.
  - [ ] Total disk usage on `data/media/` ≤ 350 MB.
  - [ ] `xbrain generate` then a manual spot-check of 10 random notes — every photo renders inline in Obsidian.
  - [ ] `xbrain diff <pre-media-snapshot>` reports the new-download counts on the `MEDIA` block.
  - [ ] Re-running `xbrain media` reports every previously-downloaded photo on the SUMMARY's `skipped` count and creates zero new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)