### PR TITLE
[cleanup] clear radon C and deptry warnings on develop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,10 +97,14 @@ DEP002 = [
     "pytest-cov",
     "ruff",
 ]
-# DEP001: scripts/import_chrome_session.py imports browser-cookie3 behind a
-# guarded `try/except ImportError` — it is a deliberately optional helper
-# dependency, installed on demand, not a declared runtime requirement.
+# DEP001 + DEP003: scripts/import_chrome_session.py + import_safari_session.py
+# import browser-cookie3 behind a guarded `try/except ImportError` — it is a
+# deliberately optional helper dependency, installed on demand, not a declared
+# runtime requirement. Deptry sees it as both undeclared (DEP001) and, once
+# pulled in via another package's extras on some machines, as transitive
+# (DEP003). Both are intentional for this opt-in helper.
 DEP001 = ["browser_cookie3"]
+DEP003 = ["browser_cookie3"]
 
 [tool.coverage.run]
 source = ["src/xbrain"]

--- a/src/xbrain/archive.py
+++ b/src/xbrain/archive.py
@@ -50,7 +50,44 @@ def _parse_js_array(raw: str, tweets_file: str) -> list:
         raise ValueError(f"{tweets_file}: malformed JSON in archive tweets file: {exc}") from exc
 
 
+def _extract_archive_links(tweet: dict[str, Any]) -> list[Link]:
+    """Parse `entities.urls` from an archive tweet into Link objects.
+
+    Each URL entity in the archive carries an `expanded_url`; we derive the
+    domain from it and drop any entry that lacks an expanded URL.
+    """
+    return [
+        Link(
+            url=url_entity["expanded_url"],
+            domain=urlparse(url_entity["expanded_url"]).netloc,
+        )
+        for url_entity in tweet.get("entities", {}).get("urls", [])
+        if url_entity.get("expanded_url")
+    ]
+
+
+def _extract_archive_media(tweet: dict[str, Any]) -> list[MediaEntry]:
+    """Parse media from `extended_entities.media`, falling back to `entities.media`.
+
+    Normalises `type` to `"video"` (videos and animated GIFs) or `"photo"`, and
+    picks the canonical URL (`media_url_https`, falling back to `expanded_url`).
+    Entries missing both URLs are dropped.
+    """
+    media_entries = tweet.get("extended_entities", {}).get("media") or tweet.get(
+        "entities", {}
+    ).get("media", [])
+    return [
+        Media(
+            type="video" if media_entity.get("type") in ("video", "animated_gif") else "photo",
+            url=media_entity.get("media_url_https") or media_entity["expanded_url"],
+        )
+        for media_entity in media_entries
+        if media_entity.get("media_url_https") or media_entity.get("expanded_url")
+    ]
+
+
 def _archive_tweet_to_item(entry: dict[str, Any], author: Author) -> Item | None:
+    """Map one archive entry into an Item, returning None for malformed rows."""
     tweet = entry.get("tweet")
     if not isinstance(tweet, dict):
         logger.warning("archive entry missing 'tweet' object, skipping")
@@ -60,25 +97,6 @@ def _archive_tweet_to_item(entry: dict[str, Any], author: Author) -> Item | None
         logger.warning("archive tweet missing 'id_str', skipping")
         return None
     rest_id = str(rest_id)
-    links = [
-        Link(
-            url=url_entity["expanded_url"],
-            domain=urlparse(url_entity["expanded_url"]).netloc,
-        )
-        for url_entity in tweet.get("entities", {}).get("urls", [])
-        if url_entity.get("expanded_url")
-    ]
-    media_entries = tweet.get("extended_entities", {}).get("media") or tweet.get(
-        "entities", {}
-    ).get("media", [])
-    media: list[MediaEntry] = [
-        Media(
-            type="video" if media_entity.get("type") in ("video", "animated_gif") else "photo",
-            url=media_entity.get("media_url_https") or media_entity["expanded_url"],
-        )
-        for media_entity in media_entries
-        if media_entity.get("media_url_https") or media_entity.get("expanded_url")
-    ]
     return Item(
         id=rest_id,
         source="own_tweet",
@@ -87,7 +105,7 @@ def _archive_tweet_to_item(entry: dict[str, Any], author: Author) -> Item | None
         text=tweet.get("full_text", ""),
         created_at=_parse_x_date(tweet.get("created_at")),
         captured_at=datetime.now(timezone.utc),
-        media=media,
-        links=links,
+        media=_extract_archive_media(tweet),
+        links=_extract_archive_links(tweet),
         quoted_id=None,
     )

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -353,16 +353,27 @@ def _frontmatter(item: Item) -> str:
     return "\n".join(lines)
 
 
-def _render_index(items: list[Item], strings: Strings) -> str:
-    bookmarks = sum(1 for i in items if i.source == "bookmark")
-    own = sum(1 for i in items if i.source == "own_tweet")
-    noted = sum(1 for i in items if _has_note(i))
-    enriched = sum(1 for i in items if i.enriched)
+def _count_topic_frequency(items: list[Item]) -> dict[str, int]:
+    """Tally how often each topic appears across the enriched items.
+
+    Items without enrichment contribute nothing. The result maps topic slug
+    to the number of enriched items that include it.
+    """
     topic_freq: dict[str, int] = {}
     for item in items:
         if item.enriched:
             for topic in item.enriched.topics:
                 topic_freq[topic] = topic_freq.get(topic, 0) + 1
+    return topic_freq
+
+
+def _render_index(items: list[Item], strings: Strings) -> str:
+    """Render the top-level index note: corpus stats and the topic list."""
+    bookmarks = sum(1 for i in items if i.source == "bookmark")
+    own = sum(1 for i in items if i.source == "own_tweet")
+    noted = sum(1 for i in items if _has_note(i))
+    enriched = sum(1 for i in items if i.enriched)
+    topic_freq = _count_topic_frequency(items)
     lines = [
         "# XBrain",
         "",

--- a/src/xbrain/validate.py
+++ b/src/xbrain/validate.py
@@ -14,46 +14,75 @@ from xbrain.rubrics import load_guardrails
 _ALLOWED_KEYS = {"summary", "primary_topic", "topics"}
 
 
+def _validate_judgment_keys(judgment: dict) -> list[str]:
+    """Reject any key outside the allowed enrichment schema."""
+    extra = set(judgment) - _ALLOWED_KEYS
+    if extra:
+        return [f"unexpected keys (LLM must emit only judgment): {sorted(extra)}"]
+    return []
+
+
+def _validate_summary(judgment: dict, rules: dict) -> list[str]:
+    """Require a non-empty summary when guardrails demand it."""
+    summary = judgment.get("summary")
+    if rules.get("summary_required", True) and not (summary and str(summary).strip()):
+        return ["summary is missing or empty"]
+    return []
+
+
+def _validate_topics_list(judgment: dict, rules: dict, vocab: set[str]) -> list[str]:
+    """Validate the topics list itself: count bounds, duplicates, vocabulary membership.
+
+    Returns an empty list when `topics` is not a list — the caller (`validate_judgment`)
+    is responsible for emitting the type error and aborting further topic-related checks.
+    """
+    topics = judgment.get("topics")
+    if not isinstance(topics, list):
+        return []
+    errors: list[str] = []
+    lo, hi = rules.get("topics_min", 1), rules.get("topics_max", 4)
+    if not (lo <= len(topics) <= hi):
+        errors.append(f"topics has {len(topics)} entries, must be {lo}-{hi}")
+    if len(set(topics)) != len(topics):
+        errors.append("topics has duplicate entries")
+    if rules.get("topics_must_be_in_vocab", True):
+        for slug in topics:
+            if slug not in vocab:
+                errors.append(f"topic '{slug}' is not in the vocabulary")
+    return errors
+
+
+def _validate_primary_topic(
+    judgment: dict, topics: list, rules: dict, vocab: set[str]
+) -> list[str]:
+    """Validate `primary_topic`: presence, vocabulary membership, and inclusion in topics."""
+    primary = judgment.get("primary_topic")
+    if not primary:
+        return ["primary_topic is missing"]
+    errors: list[str] = []
+    if rules.get("topics_must_be_in_vocab", True) and primary not in vocab:
+        errors.append(f"primary_topic '{primary}' is not in the vocabulary")
+    if rules.get("primary_topic_must_be_in_topics", True) and primary not in topics:
+        errors.append(f"primary_topic '{primary}' is not inside topics")
+    return errors
+
+
 def validate_judgment(judgment: dict, vocab_slugs: Iterable[str]) -> list[str]:
     """Return a list of human-readable errors; an empty list means valid."""
     rules = load_guardrails().get("enrichment", {})
     vocab = set(vocab_slugs)
+
     errors: list[str] = []
-
-    extra = set(judgment) - _ALLOWED_KEYS
-    if extra:
-        errors.append(f"unexpected keys (LLM must emit only judgment): {sorted(extra)}")
-
-    summary = judgment.get("summary")
-    if rules.get("summary_required", True) and not (summary and str(summary).strip()):
-        errors.append("summary is missing or empty")
+    errors += _validate_judgment_keys(judgment)
+    errors += _validate_summary(judgment, rules)
 
     topics = judgment.get("topics")
     if not isinstance(topics, list):
         errors.append("topics must be a list")
         return errors
 
-    lo, hi = rules.get("topics_min", 1), rules.get("topics_max", 4)
-    if not (lo <= len(topics) <= hi):
-        errors.append(f"topics has {len(topics)} entries, must be {lo}-{hi}")
-
-    if len(set(topics)) != len(topics):
-        errors.append("topics has duplicate entries")
-
-    if rules.get("topics_must_be_in_vocab", True):
-        for slug in topics:
-            if slug not in vocab:
-                errors.append(f"topic '{slug}' is not in the vocabulary")
-
-    primary = judgment.get("primary_topic")
-    if not primary:
-        errors.append("primary_topic is missing")
-    else:
-        if rules.get("topics_must_be_in_vocab", True) and primary not in vocab:
-            errors.append(f"primary_topic '{primary}' is not in the vocabulary")
-        if rules.get("primary_topic_must_be_in_topics", True) and primary not in topics:
-            errors.append(f"primary_topic '{primary}' is not inside topics")
-
+    errors += _validate_topics_list(judgment, rules, vocab)
+    errors += _validate_primary_topic(judgment, topics, rules, vocab)
     return errors
 
 


### PR DESCRIPTION
## Summary

Pure tech-debt cleanup. Clears the two warnings that survived on `develop`:

- **Radon WARN** — 3 grade-C functions refactored down to A/B
- **Deptry WARN** — 1 DEP003 false positive on the optional `browser_cookie3` helper silenced

Behaviour unchanged. All 506 existing tests pass without modification — these are pure refactors plus a config tweak.

## The four fixes

1. **`validate.validate_judgment` C(16) → A(2)** — split into focused sub-validators (`_validate_judgment_keys`, `_validate_summary`, `_validate_topics_list`, `_validate_primary_topic`). Top-level orchestrator just concatenates errors and keeps the early-return on non-list topics.
2. **`archive._archive_tweet_to_item` C(11) → A(3)** — extracted two substantive parsing helpers: `_extract_archive_links` (entities.urls navigation + domain derivation) and `_extract_archive_media` (extended/legacy media source selection + type normalisation + URL fallback).
3. **`generate._render_index` C(13) → B(10)** — extracted `_count_topic_frequency` (the only non-rendering logic — nested loop + dict mutation). Stat counters and markdown emission stay inline; that's the function's actual job.
4. **`pyproject.toml`** — added `DEP003 = ["browser_cookie3"]` to `[tool.deptry.per_rule_ignores]`. The helper is guarded by `try/except ImportError` in `scripts/import_*_session.py` and was already covered by DEP001; DEP003 surfaces on installs where the package gets pulled in via another extra. Comment updated to explain both. Chose the per-rule ignore over an `[project.optional-dependencies] sessions` group because the helper is install-on-demand and isn't part of the project's dependency surface.

## Proof — `scripts/check.sh` SUMMARY

### Before (`develop`)

```
  ✅ Ruff (linting)       PASS
  ✅ Ruff (format)        PASS
  ✅ Mypy (types)         PASS
  ⚠️  Radon (complexity)   WARN - Has grade C
  ✅ Bandit (security)    PASS
  ✅ Vulture (dead code)  PASS
  ✅ Interrogate (docs)   PASS - 84.0%
  ✅ Detect-secrets       PASS
  ✅ Tests                PASS - 506 tests
  ✅ Coverage             91%
  ⚠️  Deptry (deps)        WARN
```

### After (this branch)

```
  ✅ Ruff (linting)       PASS
  ✅ Ruff (format)        PASS
  ✅ Mypy (types)         PASS
  ✅ Radon (complexity)   PASS - All A/B
  ✅ Bandit (security)    PASS
  ✅ Vulture (dead code)  PASS
  ✅ Interrogate (docs)   PASS - 84.9%
  ✅ Detect-secrets       PASS
  ✅ Tests                PASS - 506 tests
  ✅ Coverage             91%
  ✅ Deptry (deps)        PASS
```

## Test plan

- [x] `uv run pytest` — 506 passed (unchanged count)
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] `uv run mypy --ignore-missing-imports src/` — no issues
- [x] `bash scripts/check.sh` — ALL CRITICAL CHECKS PASSED, zero warnings
- [x] Radon grade C count: 3 → 0
- [x] Deptry findings: 2 → 0