### PR TITLE
[#40] Capture playable video URL from video_info.variants (part 1)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -211,7 +211,7 @@ Renders every item note, topic page and the index into the vault.
 
 Three extra ops sit outside the main loop:
 
-- **`xbrain import-archive <zip>`** — imports your X data archive (the official ZIP export from `x.com/settings/your_archive`) to backfill historical own-tweets beyond what `extract` can reach via the live browser.
+- **`xbrain import-archive <zip>`** — imports your X data archive (the official ZIP export from `x.com/settings/your_archive`) to backfill historical own-tweets beyond what `extract` can reach via the live browser. It shares the same media parsing as `extract` (via `extract/video.py`), so archived videos capture the playable stream + poster thumbnail + bitrate/duration too.
 - **`xbrain sync`** — convenience: runs `extract → fetch → generate` back-to-back. No enrichment (which is the expensive LLM step you run on your own cadence).
 - **`xbrain status`** — read-only diagnostics: item counts, how many have links / content / enrichment, last extraction time per source.
 
@@ -226,6 +226,8 @@ The numbered stages above are summarised; the sections below cover each one in d
 **Reads.** `data/state.json` (the last-seen item id per source) — so re-running is incremental.
 
 **Writes.** `data/items.json` (new `Item` records, merged with existing ones by `id`); `data/state.json` (updated cursors).
+
+**Media capture.** Photo entries become pending URLs. Video and animated-GIF entries capture the **playable stream** — the highest-bitrate progressive `video/mp4` from `video_info.variants`, falling back to the HLS (`.m3u8`) manifest when no mp4 is offered — plus the poster image as `thumbnail_url` and the chosen `bitrate` + `duration_millis` (so a later download can estimate size without fetching bytes). The video URL is the stream, never the poster. The same media parser (`extract/video.py`) is shared by the archive importer, so `import-archive` captures video identically.
 
 **Why it is shaped like this.** The extractor anchors to **operation names** (`Bookmarks`, `UserTweets`) rather than query identifiers, because X rotates the identifiers constantly and anything that depends on them breaks within weeks. It scrolls slowly with randomized 5-12s pauses — fast scripts get rate-limited or banned.
 
@@ -248,7 +250,7 @@ The numbered stages above are summarised; the sections below cover each one in d
 
 ### media
 
-**What it does.** Downloads X-post photos referenced in `Item.media` and persists the bytes locally so the wiki can render them inline. Photos only; videos remain in `video_pending` for a future iteration. Walks every `MediaPhotoPending` entry, downloads from `pbs.twimg.com` with a cascading size fallback (`name=orig` → `name=large` → `name=medium`), validates the bytes with Pillow, and atomically writes the file under `data/media/<item-id>/<index>.<ext>`.
+**What it does.** Downloads X-post photos referenced in `Item.media` and persists the bytes locally so the wiki can render them inline. Photos only; videos remain in `video_pending` for a future iteration (their playable stream URL + poster thumbnail + bitrate/duration were already captured at extract/import time). Walks every `MediaPhotoPending` entry, downloads from `pbs.twimg.com` with a cascading size fallback (`name=orig` → `name=large` → `name=medium`), validates the bytes with Pillow, and atomically writes the file under `data/media/<item-id>/<index>.<ext>`.
 
 **Reads.** `data/items.json` (the URLs to download).
 
@@ -468,7 +470,7 @@ These are the rules the rest of the architecture rests on. Breaking any of them 
 7. **Operation names, not query ids.** The extractor anchors to X GraphQL operation names because X rotates the ids. Anything that hardcodes an id will break.
 8. **Destructive ops are reversible.** Every command that overwrites a `data/` artifact (`vocab --regenerate`, `topics --resynth`, `fetch --force`) snapshots `data/` first to `data/snapshots/<ts>-pre-<command>/`. `xbrain snapshot restore <name>` is the recovery path. A snapshot failure aborts the destructive op.
 9. **Fetch records are tagged unions.** A `ContentSource` on `items.json` is either a `Success` (with required `text`) or a `Failure` (with required `failure_reason`). Mixed shapes are not representable — pydantic rejects them at construction, and mypy rejects them statically (via the `pydantic.mypy` plugin). Legacy records with `ok: bool` (pre-#20) are normalised on read by a `BeforeValidator` on the union, so existing `data/items.json` files keep working without a manual migration. The static contract is pinned by `tests/type_probes/illegal_states.py`.
-10. **Media variants are mutually exclusive states.** A `MediaEntry` on `items.json` is one of `MediaPhotoPending` / `MediaPhotoDownloaded` / `MediaPhotoFailed` / `MediaPhotoDescribed` / `MediaVideoPending`, discriminated by `kind`. The photo states form a linear pipeline: `Pending → Downloaded → Described` (with `Failed` as the off-ramp from `Pending`). State transitions happen only via `xbrain media` (advances `Pending` and retries `Failed`) and `xbrain describe` (advances `Downloaded` to `Described`). Legacy records with the flat `{type, url}` shape are normalised on read by a `BeforeValidator` on the union — no manual migration needed. (See the `### media` and `### describe` sections above for the per-stage contracts.)
+10. **Media variants are mutually exclusive states.** A `MediaEntry` on `items.json` is one of `MediaPhotoPending` / `MediaPhotoDownloaded` / `MediaPhotoFailed` / `MediaPhotoDescribed` / `MediaVideoPending`, discriminated by `kind`. The photo states form a linear pipeline: `Pending → Downloaded → Described` (with `Failed` as the off-ramp from `Pending`). State transitions happen only via `xbrain media` (advances `Pending` and retries `Failed`) and `xbrain describe` (advances `Downloaded` to `Described`). `MediaVideoPending` carries the **playable** stream URL (highest-bitrate mp4, or the HLS manifest) plus the poster as `thumbnail_url` and the chosen `bitrate` + `duration_millis` — populated at extract/import-archive time by the shared `extract/video.py` helper, never the poster stored as the URL. Legacy records with the flat `{type, url}` shape are normalised on read by a `BeforeValidator` on the union — no manual migration needed. (See the `### media` and `### describe` sections above for the per-stage contracts.)
 
 ---
 
@@ -493,7 +495,8 @@ xbrain/
 │   │   ├── browser.py       ← Playwright session + login
 │   │   ├── extractor.py     ← GraphQL operation interception
 │   │   ├── threads.py       ← TweetDetail thread expansion
-│   │   └── graphql.py       ← response parsers
+│   │   ├── graphql.py       ← response parsers
+│   │   └── video.py         ← video-variant selection (shared w/ archive)
 │   │
 │   ├── fetch.py             ← article fetch (HTTP + Trafilatura + Firecrawl)
 │   ├── fetch_x.py           ← x.com article + status fetch

--- a/src/xbrain/archive.py
+++ b/src/xbrain/archive.py
@@ -11,6 +11,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 from xbrain.extract.graphql import _parse_x_date
+from xbrain.extract.video import build_video_media
 from xbrain.models import Author, Item, Link, Media, MediaEntry
 
 logger = logging.getLogger(__name__)
@@ -69,21 +70,27 @@ def _extract_archive_links(tweet: dict[str, Any]) -> list[Link]:
 def _extract_archive_media(tweet: dict[str, Any]) -> list[MediaEntry]:
     """Parse media from `extended_entities.media`, falling back to `entities.media`.
 
-    Normalises `type` to `"video"` (videos and animated GIFs) or `"photo"`, and
-    picks the canonical URL (`media_url_https`, falling back to `expanded_url`).
-    Entries missing both URLs are dropped.
+    Videos and animated GIFs go through `build_video_media` (shared with the
+    GraphQL path) so the archive captures the playable mp4/HLS stream from
+    `video_info.variants` — plus the poster as `thumbnail_url`, the chosen
+    bitrate, and the duration — rather than storing the poster image as the
+    video URL. Photos keep the canonical URL (`media_url_https`, falling back
+    to `expanded_url`). Entries with no usable URL are dropped.
     """
     media_entries = tweet.get("extended_entities", {}).get("media") or tweet.get(
         "entities", {}
     ).get("media", [])
-    return [
-        Media(
-            type="video" if media_entity.get("type") in ("video", "animated_gif") else "photo",
-            url=media_entity.get("media_url_https") or media_entity["expanded_url"],
-        )
-        for media_entity in media_entries
-        if media_entity.get("media_url_https") or media_entity.get("expanded_url")
-    ]
+    media: list[MediaEntry] = []
+    for media_entity in media_entries:
+        if media_entity.get("type") in ("video", "animated_gif"):
+            video = build_video_media(media_entity)
+            if video is not None:
+                media.append(video)
+            continue
+        url = media_entity.get("media_url_https") or media_entity.get("expanded_url")
+        if url:
+            media.append(Media(type="photo", url=url))
+    return media
 
 
 def _archive_tweet_to_item(entry: dict[str, Any], author: Author) -> Item | None:

--- a/src/xbrain/extract/graphql.py
+++ b/src/xbrain/extract/graphql.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Any, Iterator, Literal
+from typing import Any, Iterator
 from urllib.parse import urlparse
 
-from xbrain.models import Author, Item, Link, Media, MediaEntry, SourceName, ThreadInfo
+from xbrain.models import (
+    Author,
+    Item,
+    Link,
+    Media,
+    MediaEntry,
+    MediaVideoPending,
+    SourceName,
+    ThreadInfo,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,18 +127,55 @@ def _extract_links(legacy: dict[str, Any]) -> list[Link]:
     return links
 
 
+def _select_variant(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Pick the playable variant from `video_info.variants`.
+
+    X serves a video as several `variants`: progressive `video/mp4` files
+    (one per bitrate, each a complete downloadable file) plus an
+    `application/x-mpegURL` HLS manifest. Prefer the highest-bitrate mp4 (a
+    single downloadable file); fall back to the HLS manifest when no mp4 is
+    offered. Returns None when there are no usable variants.
+    """
+    variants = entry.get("video_info", {}).get("variants", [])
+    mp4s = [v for v in variants if v.get("content_type") == "video/mp4" and v.get("url")]
+    if mp4s:
+        return max(mp4s, key=lambda v: v.get("bitrate", 0))
+    return next((v for v in variants if v.get("url")), None)
+
+
+def _video_media(entry: dict[str, Any]) -> MediaVideoPending | None:
+    """Build a `MediaVideoPending` from a video/animated_gif media entry.
+
+    Stores the playable stream URL (never the poster), keeps the poster as
+    `thumbnail_url`, and records the chosen mp4's bitrate plus the clip
+    duration so a later download can estimate size without fetching bytes.
+    """
+    variant = _select_variant(entry)
+    url = (variant or {}).get("url") or entry.get("media_url_https") or entry.get("expanded_url")
+    if not url:
+        return None
+    return MediaVideoPending(
+        url=url,
+        thumbnail_url=entry.get("media_url_https"),
+        bitrate=(variant or {}).get("bitrate"),
+        duration_millis=entry.get("video_info", {}).get("duration_millis"),
+    )
+
+
 def _extract_media(legacy: dict[str, Any]) -> list[MediaEntry]:
     entries = legacy.get("extended_entities", {}).get("media") or legacy.get("entities", {}).get(
         "media", []
     )
     media: list[MediaEntry] = []
     for entry in entries:
-        kind: Literal["photo", "video"] = (
-            "video" if entry.get("type") in ("video", "animated_gif") else "photo"
-        )
+        if entry.get("type") in ("video", "animated_gif"):
+            video = _video_media(entry)
+            if video is not None:
+                media.append(video)
+            continue
         url = entry.get("media_url_https") or entry.get("expanded_url")
         if url:
-            media.append(Media(type=kind, url=url))
+            media.append(Media(type="photo", url=url))
     return media
 
 

--- a/src/xbrain/extract/graphql.py
+++ b/src/xbrain/extract/graphql.py
@@ -7,13 +7,13 @@ from datetime import datetime, timezone
 from typing import Any, Iterator
 from urllib.parse import urlparse
 
+from xbrain.extract.video import build_video_media
 from xbrain.models import (
     Author,
     Item,
     Link,
     Media,
     MediaEntry,
-    MediaVideoPending,
     SourceName,
     ThreadInfo,
 )
@@ -127,41 +127,6 @@ def _extract_links(legacy: dict[str, Any]) -> list[Link]:
     return links
 
 
-def _select_variant(entry: dict[str, Any]) -> dict[str, Any] | None:
-    """Pick the playable variant from `video_info.variants`.
-
-    X serves a video as several `variants`: progressive `video/mp4` files
-    (one per bitrate, each a complete downloadable file) plus an
-    `application/x-mpegURL` HLS manifest. Prefer the highest-bitrate mp4 (a
-    single downloadable file); fall back to the HLS manifest when no mp4 is
-    offered. Returns None when there are no usable variants.
-    """
-    variants = entry.get("video_info", {}).get("variants", [])
-    mp4s = [v for v in variants if v.get("content_type") == "video/mp4" and v.get("url")]
-    if mp4s:
-        return max(mp4s, key=lambda v: v.get("bitrate", 0))
-    return next((v for v in variants if v.get("url")), None)
-
-
-def _video_media(entry: dict[str, Any]) -> MediaVideoPending | None:
-    """Build a `MediaVideoPending` from a video/animated_gif media entry.
-
-    Stores the playable stream URL (never the poster), keeps the poster as
-    `thumbnail_url`, and records the chosen mp4's bitrate plus the clip
-    duration so a later download can estimate size without fetching bytes.
-    """
-    variant = _select_variant(entry)
-    url = (variant or {}).get("url") or entry.get("media_url_https") or entry.get("expanded_url")
-    if not url:
-        return None
-    return MediaVideoPending(
-        url=url,
-        thumbnail_url=entry.get("media_url_https"),
-        bitrate=(variant or {}).get("bitrate"),
-        duration_millis=entry.get("video_info", {}).get("duration_millis"),
-    )
-
-
 def _extract_media(legacy: dict[str, Any]) -> list[MediaEntry]:
     entries = legacy.get("extended_entities", {}).get("media") or legacy.get("entities", {}).get(
         "media", []
@@ -169,7 +134,7 @@ def _extract_media(legacy: dict[str, Any]) -> list[MediaEntry]:
     media: list[MediaEntry] = []
     for entry in entries:
         if entry.get("type") in ("video", "animated_gif"):
-            video = _video_media(entry)
+            video = build_video_media(entry)
             if video is not None:
                 media.append(video)
             continue

--- a/src/xbrain/extract/video.py
+++ b/src/xbrain/extract/video.py
@@ -1,0 +1,58 @@
+"""Build a playable `MediaVideoPending` from an X video/animated_gif entry.
+
+Shared by both extraction paths — the live GraphQL parser
+(`extract/graphql.py`) and the X data-archive importer (`archive.py`) —
+because the archive JSON carries the same
+`extended_entities.media[].video_info.variants` shape as the live response.
+Centralising the variant selection here keeps the two paths from drifting:
+before this module, only the GraphQL path captured the playable stream while
+the archive path silently stored the poster image.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from xbrain.models import MediaVideoPending
+
+
+def select_variant(entry: dict[str, Any]) -> dict[str, Any] | None:
+    """Pick the playable variant from a media entry's `video_info.variants`.
+
+    X serves a video as several `variants`: progressive `video/mp4` files
+    (one per bitrate, each a complete downloadable file) plus an
+    `application/x-mpegURL` HLS manifest. Prefer the highest-bitrate mp4 (a
+    single downloadable file); fall back to the HLS manifest when no mp4 is
+    offered. Returns None when there are no usable variants.
+
+    The bitrate key treats both a missing `bitrate` and an explicit
+    `"bitrate": null` as 0 — X drifts, so a variant carrying `null` must not
+    crash the `max` (None is not orderable against int).
+    """
+    variants = entry.get("video_info", {}).get("variants", [])
+    mp4s = [v for v in variants if v.get("content_type") == "video/mp4" and v.get("url")]
+    if mp4s:
+        return max(mp4s, key=lambda v: v.get("bitrate") or 0)
+    return next((v for v in variants if v.get("url")), None)
+
+
+def build_video_media(entry: dict[str, Any]) -> MediaVideoPending | None:
+    """Build a `MediaVideoPending` from a video/animated_gif media entry.
+
+    Stores the playable stream URL (never the poster), keeps the poster as
+    `thumbnail_url`, and records the chosen mp4's bitrate plus the clip
+    duration so a later download can estimate size without fetching bytes.
+    Falls back to the poster (then `expanded_url`) only when no playable
+    variant exists, so a malformed entry is surfaced rather than dropped.
+    Returns None when there is no usable URL at all.
+    """
+    variant = select_variant(entry)
+    url = (variant or {}).get("url") or entry.get("media_url_https") or entry.get("expanded_url")
+    if not url:
+        return None
+    return MediaVideoPending(
+        url=url,
+        thumbnail_url=entry.get("media_url_https"),
+        bitrate=(variant or {}).get("bitrate"),
+        duration_millis=entry.get("video_info", {}).get("duration_millis"),
+    )

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -211,9 +211,10 @@ def _render_media_lines(item: Item) -> list[str]:
       reason and the original URL — visible evidence, not a silent drop.
     - `MediaPhotoPending`     → silent. Not an error, just "the next
       `xbrain media` run will pick it up".
-    - `MediaVideoPending`     → placeholder warning carrying the URL.
-      Video bytes are not downloaded yet, so the URL is the only
-      evidence we surface.
+    - `MediaVideoPending`     → a clickable "Ver vídeo" link to the playable
+      stream (the mp4/HLS URL from `video_info.variants`, not the poster),
+      flagged as pending local download until the video-download phase
+      lands.
 
     The output is intentionally plain markdown; the caller (`_render_note`)
     wraps it in a blank line on either side for readability.
@@ -229,7 +230,9 @@ def _render_media_lines(item: Item) -> list[str]:
             # Silent: a future `xbrain media` run will advance this entry.
             continue
         elif isinstance(entry, MediaVideoPending):
-            lines.append(f"> 🎥 Vídeo (no descargado): <{entry.url}>")
+            # `entry.url` is the playable stream (mp4 or HLS), not the poster,
+            # so surface it as a clickable link; bytes are not saved yet.
+            lines.append(f"> 🎥 [Ver vídeo]({entry.url}) (pendiente de descarga)")
         else:
             assert_never(entry)
     return lines

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -299,17 +299,29 @@ class MediaPhotoDescribed(_MediaPhotoBase):
 
 
 class MediaVideoPending(BaseModel):
-    """A video URL captured but not downloaded.
+    """A video captured but not downloaded.
 
-    Videos are currently captured but not fetched — they remain in this
-    state until a future iteration adds HLS + ffmpeg support. The variant
-    is in the union from day one so the wire shape does not change when
-    video download lands.
+    `url` is the playable stream extracted from `video_info.variants` — the
+    highest-bitrate progressive mp4 when X offers one, else the HLS (`.m3u8`)
+    manifest. It is NOT the poster image; that is kept separately in
+    `thumbnail_url` so a note can still show a still while the bytes are
+    pending.
+
+    `bitrate` (of the chosen mp4) and `duration_millis` let a download
+    pre-flight estimate total size (bitrate × duration) without fetching a
+    byte. All three are optional: legacy records carry only `url`, and an
+    HLS-only variant has no bitrate. Videos stay in this state until a
+    future iteration adds the download (direct mp4 via httpx; HLS via
+    ffmpeg). The variant is in the union from day one so the wire shape does
+    not change when video download lands.
     """
 
     type: Literal["video"] = "video"
     kind: Literal["video_pending"] = "video_pending"
     url: str
+    thumbnail_url: str | None = None
+    bitrate: int | None = None
+    duration_millis: int | None = None
 
 
 def _normalise_legacy_media(value: Any) -> Any:

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -310,7 +310,10 @@ class MediaVideoPending(BaseModel):
     `bitrate` (of the chosen mp4) and `duration_millis` let a download
     pre-flight estimate total size (bitrate × duration) without fetching a
     byte. All three are optional: legacy records carry only `url`, and an
-    HLS-only variant has no bitrate. Videos stay in this state until a
+    HLS-only variant has no bitrate. Note that a real X mp4 can report
+    `bitrate: 0` (animated GIFs always do), so a downstream size estimator
+    must treat `bitrate in (None, 0)` as "unknown" — fall back to a HEAD
+    request's `Content-Length` — NOT as "0 bytes". Videos stay in this state until a
     future iteration adds the download (direct mp4 via httpx; HLS via
     ffmpeg). The variant is in the union from day one so the wire shape does
     not change when video download lands.

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -99,6 +99,61 @@ def test_parse_archive_extracts_media(tmp_path: Path):
     assert items[0].media[0].url == "https://pbs.twimg.com/media/a.jpg"
 
 
+def test_parse_archive_extracts_video_playable_url_not_poster(tmp_path: Path):
+    """An archive video entry yields the highest-bitrate mp4 as its URL — not
+    the poster image — plus the poster as thumbnail_url, the chosen bitrate, and
+    the clip duration. The X archive carries the same
+    `extended_entities.media[].video_info.variants` shape as the live GraphQL
+    response, so the archive path must capture the playable stream too."""
+    from xbrain.models import MediaVideoPending
+
+    author = Author(handle="vgonpa", name="Victor")
+    tweets = [
+        {
+            "tweet": {
+                "id_str": "888",
+                "created_at": "Wed May 10 14:23:00 +0000 2026",
+                "full_text": "with a video",
+                "extended_entities": {
+                    "media": [
+                        {
+                            "type": "video",
+                            "media_url_https": "https://pbs.twimg.com/poster.jpg",
+                            "video_info": {
+                                "duration_millis": 30000,
+                                "variants": [
+                                    {
+                                        "bitrate": 256000,
+                                        "content_type": "video/mp4",
+                                        "url": "https://video.twimg.com/low.mp4?tag=12",
+                                    },
+                                    {
+                                        "bitrate": 2176000,
+                                        "content_type": "video/mp4",
+                                        "url": "https://video.twimg.com/high.mp4?tag=12",
+                                    },
+                                    {
+                                        "content_type": "application/x-mpegURL",
+                                        "url": "https://video.twimg.com/playlist.m3u8?tag=12",
+                                    },
+                                ],
+                            },
+                        }
+                    ]
+                },
+            }
+        }
+    ]
+    items = parse_archive(_make_archive_from_tweets(tmp_path, tweets), author)
+    assert len(items) == 1
+    entry = items[0].media[0]
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.url == "https://video.twimg.com/high.mp4?tag=12"
+    assert entry.thumbnail_url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.bitrate == 2176000
+    assert entry.duration_millis == 30000
+
+
 def test_parse_archive_skips_malformed_entry(tmp_path: Path):
     author = Author(handle="vgonpa", name="Victor")
     tweets = [

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -152,6 +152,21 @@ def test_generate_renders_video_pending_as_placeholder(tmp_path: Path):
     assert "https://video.twimg.com/x.mp4" in body
 
 
+def test_generate_renders_video_pending_as_clickable_play_link(tmp_path: Path):
+    """The video URL is now the playable mp4 (not the poster), so render it as a
+    labelled clickable link, flagged as pending local download."""
+    from xbrain.models import MediaVideoPending
+
+    item = _item("1", with_link=True)
+    item.media = [MediaVideoPending(url="https://video.twimg.com/high.mp4?tag=12")]
+
+    generate({"1": item}, tmp_path)
+    note = next((tmp_path / "items").glob("*.md"))
+    body = note.read_text(encoding="utf-8")
+    assert "[Ver vídeo](https://video.twimg.com/high.mp4?tag=12)" in body
+    assert "pendiente de descarga" in body
+
+
 def test_generate_media_only_item_gets_a_note(tmp_path: Path):
     """An item with only media (no link, no enrichment) is note-worthy.
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -134,24 +134,6 @@ def test_generate_skips_pending_photo_silently(tmp_path: Path):
     assert "🎥" not in body
 
 
-def test_generate_renders_video_pending_as_placeholder(tmp_path: Path):
-    """A `MediaVideoPending` becomes a 🎥 placeholder carrying the URL.
-
-    Video bytes are not downloaded yet. The URL is the only evidence we
-    have — surface it so the reader can click through to X.
-    """
-    from xbrain.models import MediaVideoPending
-
-    item = _item("1", with_link=True)
-    item.media = [MediaVideoPending(url="https://video.twimg.com/x.mp4")]
-
-    generate({"1": item}, tmp_path)
-    note = next((tmp_path / "items").glob("*.md"))
-    body = note.read_text(encoding="utf-8")
-    assert "🎥" in body
-    assert "https://video.twimg.com/x.mp4" in body
-
-
 def test_generate_renders_video_pending_as_clickable_play_link(tmp_path: Path):
     """The video URL is now the playable mp4 (not the poster), so render it as a
     labelled clickable link, flagged as pending local download."""

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -194,3 +194,109 @@ def test_parse_tweets_unwraps_visibility_envelope():
     assert len(items) == 1
     assert items[0].id == "555"
     assert items[0].text == "limited visibility tweet"
+
+
+# --- media: video variant selection (#40 part 1) ---------------------------
+
+
+def _video_legacy(variants: list[dict], *, duration_millis: int = 30000) -> dict:
+    """A `legacy` block carrying one video media entry whose poster is a
+    fixed pbs.twimg.com image and whose playable URLs live in
+    `video_info.variants` (the real X shape)."""
+    return {
+        "extended_entities": {
+            "media": [
+                {
+                    "type": "video",
+                    "media_url_https": "https://pbs.twimg.com/poster.jpg",
+                    "video_info": {
+                        "duration_millis": duration_millis,
+                        "variants": variants,
+                    },
+                }
+            ]
+        }
+    }
+
+
+def test_extract_media_video_picks_highest_bitrate_mp4():
+    """A video entry stores the highest-bitrate mp4 from video_info.variants,
+    not the poster image (media_url_https)."""
+    from xbrain.extract.graphql import _extract_media
+    from xbrain.models import MediaVideoPending
+
+    legacy = _video_legacy(
+        [
+            {
+                "bitrate": 256000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/low.mp4?tag=12",
+            },
+            {
+                "bitrate": 2176000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/high.mp4?tag=12",
+            },
+            {
+                "bitrate": 832000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/mid.mp4?tag=12",
+            },
+            {
+                "content_type": "application/x-mpegURL",
+                "url": "https://video.twimg.com/playlist.m3u8?tag=12",
+            },
+        ]
+    )
+
+    media = _extract_media(legacy)
+
+    assert len(media) == 1
+    entry = media[0]
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.url == "https://video.twimg.com/high.mp4?tag=12"
+
+
+def test_extract_media_video_hls_only_falls_back_to_manifest():
+    """With no progressive mp4 (HLS-only), store the m3u8 manifest URL rather
+    than the poster, so the real stream is captured for a later ffmpeg pass."""
+    from xbrain.extract.graphql import _extract_media
+    from xbrain.models import MediaVideoPending
+
+    legacy = _video_legacy(
+        [
+            {
+                "content_type": "application/x-mpegURL",
+                "url": "https://video.twimg.com/playlist.m3u8?tag=12",
+            },
+        ]
+    )
+
+    media = _extract_media(legacy)
+
+    assert isinstance(media[0], MediaVideoPending)
+    assert media[0].url == "https://video.twimg.com/playlist.m3u8?tag=12"
+
+
+def test_extract_media_video_captures_poster_and_size_metadata():
+    """The poster is kept as thumbnail_url, and the chosen variant's bitrate
+    plus the clip duration are stored so size can be estimated without a
+    download."""
+    from xbrain.extract.graphql import _extract_media
+
+    legacy = _video_legacy(
+        [
+            {
+                "bitrate": 2176000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/high.mp4?tag=12",
+            },
+        ],
+        duration_millis=30000,
+    )
+
+    entry = _extract_media(legacy)[0]
+
+    assert entry.thumbnail_url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.bitrate == 2176000
+    assert entry.duration_millis == 30000

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -199,20 +199,33 @@ def test_parse_tweets_unwraps_visibility_envelope():
 # --- media: video variant selection (#40 part 1) ---------------------------
 
 
-def _video_legacy(variants: list[dict], *, duration_millis: int = 30000) -> dict:
-    """A `legacy` block carrying one video media entry whose poster is a
-    fixed pbs.twimg.com image and whose playable URLs live in
-    `video_info.variants` (the real X shape)."""
+# Sentinel so a test can omit `duration_millis` entirely (an animated_gif
+# entry has `video_info.variants` but no `duration_millis` key at all).
+_OMIT = object()
+
+
+def _video_legacy(
+    variants: list[dict],
+    *,
+    media_type: str = "video",
+    duration_millis: object = 30000,
+) -> dict:
+    """A `legacy` block carrying one video/animated_gif media entry whose poster
+    is a fixed pbs.twimg.com image and whose playable URLs live in
+    `video_info.variants` (the real X shape).
+
+    `media_type` switches between `"video"` and `"animated_gif"`. Pass
+    `duration_millis=_OMIT` to drop the key entirely (the animated_gif case)."""
+    video_info: dict = {"variants": variants}
+    if duration_millis is not _OMIT:
+        video_info["duration_millis"] = duration_millis
     return {
         "extended_entities": {
             "media": [
                 {
-                    "type": "video",
+                    "type": media_type,
                     "media_url_https": "https://pbs.twimg.com/poster.jpg",
-                    "video_info": {
-                        "duration_millis": duration_millis,
-                        "variants": variants,
-                    },
+                    "video_info": video_info,
                 }
             ]
         }
@@ -300,3 +313,80 @@ def test_extract_media_video_captures_poster_and_size_metadata():
     assert entry.thumbnail_url == "https://pbs.twimg.com/poster.jpg"
     assert entry.bitrate == 2176000
     assert entry.duration_millis == 30000
+
+
+def test_extract_media_video_no_variants_falls_back_to_poster():
+    """A video entry with no usable variants (empty list, no playable stream)
+    falls back to the poster url so the item is not silently dropped; the poster
+    is still kept as thumbnail_url and bitrate is None (nothing was chosen)."""
+    from xbrain.extract.graphql import _extract_media
+    from xbrain.models import MediaVideoPending
+
+    legacy = _video_legacy([])
+
+    entry = _extract_media(legacy)[0]
+
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.thumbnail_url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.bitrate is None
+
+
+def test_extract_media_animated_gif_captures_mp4_without_duration():
+    """An `animated_gif` entry is a single soundless mp4 with `bitrate: 0` and
+    no `duration_millis`. The mp4 is captured, bitrate stays 0 (a real value,
+    not "missing"), and duration_millis is None."""
+    from xbrain.extract.graphql import _extract_media
+    from xbrain.models import MediaVideoPending
+
+    legacy = _video_legacy(
+        [
+            {
+                "bitrate": 0,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/gif.mp4?tag=12",
+            },
+        ],
+        media_type="animated_gif",
+        duration_millis=_OMIT,
+    )
+
+    entry = _extract_media(legacy)[0]
+
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.url == "https://video.twimg.com/gif.mp4?tag=12"
+    assert entry.bitrate == 0
+    assert entry.duration_millis is None
+
+
+def test_extract_media_video_handles_null_and_missing_bitrate():
+    """Variant selection must not crash when a variant has an explicit
+    `"bitrate": null` (None) alongside variants with a missing bitrate key.
+    `max(..., key=lambda v: v.get("bitrate", 0))` raises TypeError (None < int);
+    a hardened key treats both null and missing as 0, and the variant carrying a
+    real bitrate wins."""
+    from xbrain.extract.graphql import _extract_media
+
+    legacy = _video_legacy(
+        [
+            {
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/missing.mp4?tag=12",
+            },
+            {
+                "bitrate": None,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/null.mp4?tag=12",
+            },
+            {
+                "bitrate": 832000,
+                "content_type": "video/mp4",
+                "url": "https://video.twimg.com/real.mp4?tag=12",
+            },
+        ]
+    )
+
+    entry = _extract_media(legacy)[0]
+
+    assert entry.url == "https://video.twimg.com/real.mp4?tag=12"
+    assert entry.bitrate == 832000

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -708,3 +708,35 @@ def test_topic_page_model_round_trips():
     assert restored.slug == "ai-coding"
     assert restored.post_count_at_synth == 42
     assert restored.notes == ["Nota uno.", "Nota dos."]
+
+
+def test_media_video_pending_carries_thumbnail_and_size_metadata():
+    """MediaVideoPending can carry the poster thumbnail plus the bitrate and
+    duration used to estimate download size — without fetching anything."""
+    from xbrain.models import MediaVideoPending
+
+    entry = MediaVideoPending(
+        url="https://video.twimg.com/high.mp4?tag=12",
+        thumbnail_url="https://pbs.twimg.com/poster.jpg",
+        bitrate=2176000,
+        duration_millis=30000,
+    )
+
+    assert entry.thumbnail_url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.bitrate == 2176000
+    assert entry.duration_millis == 30000
+
+
+def test_media_video_pending_metadata_optional_for_legacy_records():
+    """A bare video_pending (url only) still loads — the new fields default to
+    None so existing items.json records need no migration."""
+    from xbrain.models import MediaEntryAdapter, MediaVideoPending
+
+    entry = MediaEntryAdapter.validate_python(
+        {"kind": "video_pending", "type": "video", "url": "https://video.twimg.com/x.mp4"}
+    )
+
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.thumbnail_url is None
+    assert entry.bitrate is None
+    assert entry.duration_millis is None

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,69 @@
+# tests/test_video.py
+"""Unit tests for the shared video-variant helper.
+
+The selection/build behaviour is also exercised end-to-end via
+`test_graphql.py` and `test_archive.py`; these pin the helper directly so a
+regression localises here rather than in a caller.
+"""
+
+from xbrain.extract.video import build_video_media, select_variant
+from xbrain.models import MediaVideoPending
+
+
+def _entry(variants: list[dict], *, duration_millis: object = 30000) -> dict:
+    """A media entry with a fixed poster and the given `video_info.variants`."""
+    video_info: dict = {"variants": variants}
+    if duration_millis is not None:
+        video_info["duration_millis"] = duration_millis
+    return {
+        "type": "video",
+        "media_url_https": "https://pbs.twimg.com/poster.jpg",
+        "video_info": video_info,
+    }
+
+
+_MP4_LOW = {"bitrate": 256000, "content_type": "video/mp4", "url": "https://v/low.mp4"}
+_MP4_HIGH = {"bitrate": 2176000, "content_type": "video/mp4", "url": "https://v/high.mp4"}
+_HLS = {"content_type": "application/x-mpegURL", "url": "https://v/play.m3u8"}
+
+
+def test_select_variant_prefers_highest_bitrate_mp4():
+    assert select_variant(_entry([_MP4_LOW, _MP4_HIGH, _HLS])) is _MP4_HIGH
+
+
+def test_select_variant_falls_back_to_hls_when_no_mp4():
+    assert select_variant(_entry([_HLS])) is _HLS
+
+
+def test_select_variant_returns_none_when_no_usable_variant():
+    assert select_variant(_entry([])) is None
+    assert select_variant(_entry([{"content_type": "video/mp4"}])) is None  # no url
+
+
+def test_select_variant_treats_null_and_missing_bitrate_as_zero():
+    missing = {"content_type": "video/mp4", "url": "https://v/missing.mp4"}
+    null = {"bitrate": None, "content_type": "video/mp4", "url": "https://v/null.mp4"}
+    real = {"bitrate": 832000, "content_type": "video/mp4", "url": "https://v/real.mp4"}
+    # Must not raise (None is not orderable against int) and the real one wins.
+    assert select_variant(_entry([missing, null, real])) is real
+
+
+def test_build_video_media_captures_stream_poster_bitrate_duration():
+    entry = build_video_media(_entry([_MP4_HIGH]))
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.url == "https://v/high.mp4"
+    assert entry.thumbnail_url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.bitrate == 2176000
+    assert entry.duration_millis == 30000
+
+
+def test_build_video_media_falls_back_to_poster_when_no_variant():
+    entry = build_video_media(_entry([]))
+    assert isinstance(entry, MediaVideoPending)
+    assert entry.url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.thumbnail_url == "https://pbs.twimg.com/poster.jpg"
+    assert entry.bitrate is None
+
+
+def test_build_video_media_returns_none_when_no_url_at_all():
+    assert build_video_media({"type": "video", "video_info": {"variants": []}}) is None


### PR DESCRIPTION
## What & why

Part 1 of #40. The extractor stored `media_url_https` (the **poster image**) as a video's URL; the playable mp4 inside `video_info.variants` was never read, so every one of the ~232 video bookmarks linked to a still, not something you can watch.

This captures the real playable stream and the metadata needed to estimate download size later — on **both** ingestion paths (live GraphQL extract and X data-archive import).

## Changes

- **`extract/video.py` (new):** shared `select_variant` / `build_video_media`. Picks the highest-bitrate progressive `video/mp4`; falls back to the HLS (`.m3u8`) manifest, then the poster, then `expanded_url`. Keeps the poster as `thumbnail_url` and records the chosen variant's `bitrate` + the clip `duration_millis`.
- **`extract/graphql.py` + `archive.py`:** both now route video/animated_gif entries through `build_video_media`. This closes a sibling bug where `import-archive` also stored the poster as the video URL.
- **`models.py`:** `MediaVideoPending` gains optional `thumbnail_url`, `bitrate`, `duration_millis`. All optional → existing `items.json` records load with no migration.
- **`generate.py`:** renders a clickable `🎥 [Ver vídeo](…) (pendiente de descarga)` link to the playable stream instead of the misleading poster placeholder.
- **Hardening:** variant selection treats a missing or explicit-`null` `bitrate` as `0` (X's private API drifts; `None` is not orderable against `int`).
- **Docs:** `ARCHITECTURE.md` updated (media-capture note, archive shared-parser bullet, invariant for the video-stream contract, source tree).

## Tests / quality

- New: `tests/test_video.py` (unit), archive video case, no-variants poster fallback, animated_gif, missing/null bitrate (the last two are regression guards that fail without the fix). Stale placeholder render test removed.
- Full gate green: ruff, format, mypy, **radon all A/B**, bandit, detect-secrets, **522 tests, coverage 91%**.
- Reviewed by two verifier agents (bug/correctness + Python quality) and a final fix-delta verifier — all clear.

## Known limitation (follow-up, not in this PR)

`extract` is incremental and `merge_items` never overwrites, so the **~232 already-extracted videos stay poster-era** until a backfill re-captures them. A `xbrain refresh-media` command (updates existing items' video media in place, preserving photo/enrichment state, with an auto-snapshot and a download-size estimate) is the next change. Video **download** (part 2 of #40) follows.

---

Substantially written with an AI agent (Claude), reviewed before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)