### PR TITLE
feat(describe): claude-code worksheet track + render photo descriptions in notes (#52)

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -682,10 +682,13 @@ def describe(
     if apply is not None:
         _auto_snapshot(cfg, "describe-apply")
         store = load_store(cfg.items_path)
-        applied = apply_describe_worksheet(store, apply)
+        applied, invalid = apply_describe_worksheet(store, apply)
         save_store(store, cfg.items_path)
         typer.echo(f"Describe worksheet aplicada: {applied} fotos descritas")
+        _report_invalid(invalid)
         return
+    if executor is not None and executor not in ("api", "manual", "claude-code"):
+        raise ValueError(f"Ejecutor desconocido: {executor!r}")
     if executor in ("manual", "claude-code"):
         store = load_store(cfg.items_path)
         n = export_describe_worksheet(

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -15,6 +15,7 @@ import typer
 from xbrain import snapshot
 from xbrain.archive import parse_archive
 from xbrain.config import Config, load_config
+from xbrain.describe import apply_describe_worksheet, export_describe_worksheet
 from xbrain.describe import describe_all as run_describe_all
 from xbrain.describe import emit_summary_line as describe_emit_summary_line
 from xbrain.diff import diff_snapshots, format_json, format_text
@@ -649,6 +650,17 @@ def describe(
         min=1,
         help="Número de imágenes por llamada a la API. 5 es el sweet spot (12-15%% ahorro de tokens).",
     ),
+    executor: str | None = typer.Option(
+        None,
+        "--executor",
+        help="api | manual | claude-code (default: api). manual/claude-code exportan un "
+        "worksheet para describir sin API key (como enrich/topics).",
+    ),
+    apply: Path | None = typer.Option(
+        None,
+        "--apply",
+        help="Importa un worksheet de descripciones relleno y lo aplica (sin API key).",
+    ),
     verbose: bool = typer.Option(
         False,
         "--verbose",
@@ -666,6 +678,32 @@ def describe(
     """
     cfg = _config()
     items_filter = [s.strip() for s in items.split(",") if s.strip()] if items else None
+    worksheet_path = cfg.data_dir / "describe-worksheet.json"
+    if apply is not None:
+        _auto_snapshot(cfg, "describe-apply")
+        store = load_store(cfg.items_path)
+        applied = apply_describe_worksheet(store, apply)
+        save_store(store, cfg.items_path)
+        typer.echo(f"Describe worksheet aplicada: {applied} fotos descritas")
+        return
+    if executor in ("manual", "claude-code"):
+        store = load_store(cfg.items_path)
+        n = export_describe_worksheet(
+            store,
+            cfg.media_dir,
+            worksheet_path,
+            version=cfg.describe_version,
+            output_language=cfg.output_language,
+            force=force,
+            limit=limit,
+            items_filter=items_filter,
+        )
+        typer.echo(
+            f"{n} fotos exportadas a {worksheet_path}\n"
+            "Rellena el array `judgments` (con Claude Code o a mano) y ejecuta:\n"
+            f"  xbrain describe --apply {worksheet_path}"
+        )
+        return
     chosen_model = model or cfg.describe_model
     _run_describe(
         cfg,

--- a/src/xbrain/describe.py
+++ b/src/xbrain/describe.py
@@ -898,33 +898,112 @@ def export_describe_worksheet(
     return len(photos)
 
 
-def apply_describe_worksheet(store: dict[str, Item], path: Path) -> int:
+def _validate_worksheet_judgment(raw: object) -> tuple[str, int, dict] | str:
+    """Validate one worksheet judgment; return ``(item_id, index, judgment)`` or an error string.
+
+    The worksheet is authored by a human or a Claude Code session, NOT by
+    the model-validated API path, so it must police the same wire contract
+    `_validate_judgment_entry` enforces on vision responses: the entry is a
+    JSON object with the four required keys, `index` is an int (bool
+    excluded — `True`/`False` would silently coerce to a wrong media slot),
+    and the flags/description are the right primitive types. Range and
+    id/index matching are the caller's job (unknown addresses are reported
+    as unmatched, not as a shape violation). Returning the error as a `str`
+    (rather than raising) lets the caller isolate one bad judgment without
+    aborting the whole apply or leaking a raw `TypeError` traceback.
+    """
+    if not isinstance(raw, dict):
+        return f"judgment is not a JSON object: {raw!r}"
+    if not {"item_id", "index", "is_decorative", "description"} <= raw.keys():
+        return (
+            f"judgment missing required keys (got {sorted(raw)!r}, "
+            "need item_id/index/is_decorative/description)"
+        )
+    index = raw["index"]
+    if not isinstance(index, int) or isinstance(index, bool):
+        return f"judgment `index` must be int, got {index!r}"
+    if not isinstance(raw["is_decorative"], bool):
+        return f"judgment `is_decorative` must be bool, got {raw['is_decorative']!r}"
+    if not isinstance(raw["description"], str):
+        return f"judgment `description` must be str, got {raw['description']!r}"
+    return (str(raw["item_id"]), index, raw)
+
+
+def _parse_worksheet_judgments(
+    raw_judgments: list,
+) -> tuple[dict[tuple[str, int], dict], list[tuple[str, list[str]]]]:
+    """Validate + dedup worksheet judgments into a ``(item_id, index) -> judgment`` map.
+
+    Split out of `apply_describe_worksheet` so the apply body stays a single
+    store walk (keeps the complexity grade off C). Returns the keyed map plus
+    the `invalid` list of ``(label, [reasons])`` for malformed entries and
+    duplicate ``(item_id, index)`` keys (first-wins, like the API path's
+    duplicate-index rejection).
+    """
+    invalid: list[tuple[str, list[str]]] = []
+    by_key: dict[tuple[str, int], dict] = {}
+    for position, raw in enumerate(raw_judgments):
+        validated = _validate_worksheet_judgment(raw)
+        if isinstance(validated, str):
+            invalid.append((f"judgment[{position}]", [validated]))
+            continue
+        item_id, index, judgment = validated
+        key = (item_id, index)
+        if key in by_key:
+            invalid.append((f"{item_id}#{index}", ["duplicate judgment for this (item_id, index)"]))
+            continue
+        by_key[key] = judgment
+    return by_key, invalid
+
+
+def apply_describe_worksheet(
+    store: dict[str, Item], path: Path
+) -> tuple[int, list[tuple[str, list[str]]]]:
     """Apply a filled describe worksheet, transitioning photos to Described.
 
     Reads `judgments` keyed by ``(item_id, index)`` and swaps each addressed
     `MediaPhotoDownloaded` / `MediaPhotoDescribed` entry for the described
     variant via `_apply_judgment`, using the worksheet's own version/language.
-    Unknown ids/indices and non-photo entries are skipped. Returns the count
-    of photos transitioned. No API key.
+
+    Each judgment is validated in isolation (`_validate_worksheet_judgment`),
+    so one malformed entry is skipped and reported rather than aborting the
+    run or escaping as a raw traceback. Returns ``(applied, invalid)`` where
+    `invalid` is a list of ``(label, [reasons])`` for the CLI's
+    `_report_invalid` — covering malformed judgments, duplicate
+    ``(item_id, index)`` keys, and well-formed judgments that never matched a
+    downloaded photo (unknown id/index, or an index landing on a non-photo
+    entry). No API key.
     """
     if not path.exists():
         raise FileNotFoundError(f"Worksheet not found: {path}")
     data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Worksheet is not a JSON object (got {type(data).__name__})")
+    raw_judgments = data.get("judgments", [])
+    if not isinstance(raw_judgments, list):
+        raise ValueError(
+            f"Worksheet `judgments` must be a list (got {type(raw_judgments).__name__})"
+        )
     version = str(data.get("version", "v1"))
     language = cast(SupportedLanguage, data.get("language", "English"))
-    by_key = {(str(j["item_id"]), int(j["index"])): j for j in data.get("judgments", [])}
+
+    by_key, invalid = _parse_worksheet_judgments(raw_judgments)
+
     now = _utcnow()
     applied = 0
+    matched: set[tuple[str, int]] = set()
     for item in store.values():
         for index, entry in enumerate(item.media):
-            judgment = by_key.get((item.id, index))
-            if judgment is None or not isinstance(
-                entry, (MediaPhotoDownloaded, MediaPhotoDescribed)
-            ):
+            hit = by_key.get((item.id, index))
+            if hit is None or not isinstance(entry, (MediaPhotoDownloaded, MediaPhotoDescribed)):
                 continue
             candidate = _Candidate(item_id=item.id, item=item, index=index, entry=entry)
             item.media[index] = _apply_judgment(
-                candidate, judgment, language=language, version=version, described_at=now
+                candidate, hit, language=language, version=version, described_at=now
             )
+            matched.add((item.id, index))
             applied += 1
-    return applied
+
+    for item_id, index in by_key.keys() - matched:
+        invalid.append((f"{item_id}#{index}", ["no downloaded photo at this (item_id, index)"]))
+    return applied, invalid

--- a/src/xbrain/describe.py
+++ b/src/xbrain/describe.py
@@ -28,7 +28,7 @@ from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, cast
 
 from xbrain.models import (
     Item,
@@ -837,3 +837,94 @@ def emit_summary_line(report: DescribeReport, *, out: "io.IOBase | None" = None)
         f"skipped: {report.photos_skipped_already_described}",
         file=target,
     )
+
+
+def export_describe_worksheet(
+    items: dict[str, Item],
+    media_root: Path,
+    path: Path,
+    *,
+    version: str,
+    output_language: str,
+    force: bool = False,
+    limit: int | None = None,
+    items_filter: list[str] | None = None,
+) -> int:
+    """Export eligible photos to a worksheet for the claude-code / manual track.
+
+    Mirrors `xbrain.worksheet.export_worksheet`: XBrain does NOT run the vision
+    model here — it writes each eligible photo's on-disk `image_path` plus the
+    rubric. A Claude Code session (one agent per post) reads each image and
+    fills `judgments`; `apply_describe_worksheet` reads them back. No API key.
+    Returns the number of photos written to the worksheet.
+    """
+    report = DescribeReport()
+    photos = [
+        {
+            "item_id": candidate.item_id,
+            "index": candidate.index,
+            "local_path": candidate.entry.local_path,
+            "image_path": str((media_root / candidate.entry.local_path).resolve()),
+            "text": candidate.item.text,
+        }
+        for candidate in _iter_eligible_candidates(
+            items,
+            force=force,
+            limit=limit,
+            items_filter=set(items_filter) if items_filter else None,
+            current_version=version,
+            current_language=output_language,
+            report=report,
+        )
+    ]
+    payload = {
+        "generated_at": _utcnow().isoformat(),
+        "executor": "claude-code",
+        "version": version,
+        "language": output_language,
+        "instructions": (
+            "For each entry in `photos`, READ the image at its `image_path` and append "
+            "one object to `judgments` with keys {item_id, index, is_decorative, "
+            "description}. Follow `rubric`. Mark avatars, reaction memes and abstract "
+            "backgrounds as is_decorative=true with an empty description. Then run: "
+            "xbrain describe --apply <this file>."
+        ),
+        "rubric": load_rubric("describe-image", language=output_language),
+        "photos": photos,
+        "judgments": [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    return len(photos)
+
+
+def apply_describe_worksheet(store: dict[str, Item], path: Path) -> int:
+    """Apply a filled describe worksheet, transitioning photos to Described.
+
+    Reads `judgments` keyed by ``(item_id, index)`` and swaps each addressed
+    `MediaPhotoDownloaded` / `MediaPhotoDescribed` entry for the described
+    variant via `_apply_judgment`, using the worksheet's own version/language.
+    Unknown ids/indices and non-photo entries are skipped. Returns the count
+    of photos transitioned. No API key.
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Worksheet not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    version = str(data.get("version", "v1"))
+    language = cast(SupportedLanguage, data.get("language", "English"))
+    by_key = {(str(j["item_id"]), int(j["index"])): j for j in data.get("judgments", [])}
+    now = _utcnow()
+    applied = 0
+    for item in store.values():
+        for index, entry in enumerate(item.media):
+            judgment = by_key.get((item.id, index))
+            if judgment is None or not isinstance(
+                entry, (MediaPhotoDownloaded, MediaPhotoDescribed)
+            ):
+                continue
+            candidate = _Candidate(item_id=item.id, item=item, index=index, entry=entry)
+            item.media[index] = _apply_judgment(
+                candidate, judgment, language=language, version=version, described_at=now
+            )
+            applied += 1
+    return applied

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -264,8 +264,12 @@ def _render_media_lines(item: Item) -> list[str]:
             lines.append(f"![[{_VAULT_MEDIA_SUBDIR}/{entry.local_path}]]")
             # A described (non-decorative) photo carries a vision caption right
             # under the embed — plain note text, so Obsidian search finds it.
+            # One `>` per physical line: Markdown blockquotes scope to a single
+            # line, so a multi-line description must re-prefix every line or the
+            # trailing lines leak into the note body (worst case: a line that
+            # starts with `#`/`-`/`![[` injects unintended structure).
             if isinstance(entry, MediaPhotoDescribed) and entry.description:
-                lines.append(f"> {entry.description}")
+                lines.extend(f"> {line}" for line in entry.description.splitlines())
         elif isinstance(entry, MediaPhotoFailed):
             reason = _FAILURE_ES_MEDIA.get(entry.failure_reason, entry.failure_reason)
             lines.append(f"> ⚠ Foto no disponible ({reason}): <{entry.url}>")

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -262,6 +262,10 @@ def _render_media_lines(item: Item) -> list[str]:
     for entry in item.media:
         if isinstance(entry, (MediaPhotoDownloaded, MediaPhotoDescribed, MediaVideoDownloaded)):
             lines.append(f"![[{_VAULT_MEDIA_SUBDIR}/{entry.local_path}]]")
+            # A described (non-decorative) photo carries a vision caption right
+            # under the embed — plain note text, so Obsidian search finds it.
+            if isinstance(entry, MediaPhotoDescribed) and entry.description:
+                lines.append(f"> {entry.description}")
         elif isinstance(entry, MediaPhotoFailed):
             reason = _FAILURE_ES_MEDIA.get(entry.failure_reason, entry.failure_reason)
             lines.append(f"> ⚠ Foto no disponible ({reason}): <{entry.url}>")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -741,6 +741,83 @@ def test_enrich_rejects_unknown_executor(tmp_path, monkeypatch):
     assert "desconocido" in result.output
 
 
+def _photo_item(item_id: str = "1") -> Item:
+    from xbrain.models import MediaPhotoDownloaded
+
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="alice", name="Alice"),
+        text=f"Note {item_id}",
+        created_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        media=[
+            MediaPhotoDownloaded(
+                url="https://p/0.png",
+                local_path=f"{item_id}/0.png",
+                width=4,
+                height=4,
+                bytes_size=9,
+                downloaded_at=datetime(2026, 5, 10, tzinfo=timezone.utc),
+            )
+        ],
+    )
+
+
+def test_describe_rejects_unknown_executor(tmp_path, monkeypatch):
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _linked_item("1")}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["describe", "--executor", "bogus"])
+    assert result.exit_code == 1
+    assert "bogus" in result.output
+    assert "desconocido" in result.output
+
+
+def test_describe_claude_code_exports_a_worksheet(tmp_path, monkeypatch):
+    import json
+
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _photo_item("1")}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["describe", "--executor", "claude-code"])
+    assert result.exit_code == 0
+    ws = tmp_path / "data" / "describe-worksheet.json"
+    assert ws.exists()
+    payload = json.loads(ws.read_text(encoding="utf-8"))
+    assert len(payload["photos"]) == 1
+    assert payload["judgments"] == []
+
+
+def test_describe_apply_dispatches_and_reports_unmatched(tmp_path, monkeypatch):
+    import json
+
+    from xbrain.models import MediaPhotoDescribed
+    from xbrain.store import load_store
+
+    _setup_repo(tmp_path, monkeypatch)
+    save_store({"1": _photo_item("1")}, tmp_path / "data" / "items.json")
+    ws = tmp_path / "ws.json"
+    ws.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "language": "English",
+                "judgments": [
+                    {"item_id": "1", "index": 0, "is_decorative": False, "description": "A chart."},
+                    {"item_id": "ghost", "index": 0, "is_decorative": False, "description": "x"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = runner.invoke(app, ["describe", "--apply", str(ws)])
+    assert result.exit_code == 0
+    assert "1 fotos descritas" in result.output
+    assert "ghost#0" in result.output  # unmatched judgment surfaced, not dropped silently
+    store = load_store(tmp_path / "data" / "items.json")
+    assert isinstance(store["1"].media[0], MediaPhotoDescribed)
+
+
 def test_enrich_manual_without_vocab_fails(tmp_path, monkeypatch):
     _setup_repo(tmp_path, monkeypatch)
     from xbrain.store import save_store

--- a/tests/test_describe_worksheet.py
+++ b/tests/test_describe_worksheet.py
@@ -72,7 +72,9 @@ def test_apply_transitions_to_described_and_enforces_decorative_empty(tmp_path):
     ]
     ws_path.write_text(json.dumps(ws), encoding="utf-8")
 
-    assert apply_describe_worksheet(store, ws_path) == 2
+    applied, invalid = apply_describe_worksheet(store, ws_path)
+    assert applied == 2
+    assert invalid == []
     d1, d2 = store["1"].media[0], store["2"].media[0]
     assert isinstance(d1, MediaPhotoDescribed) and d1.description == "Un gráfico de barras."
     assert not d1.is_decorative
@@ -95,8 +97,101 @@ def test_apply_skips_unknown_id_and_index(tmp_path):
         ),
         encoding="utf-8",
     )
-    assert apply_describe_worksheet(store, ws_path) == 0
+    applied, invalid = apply_describe_worksheet(store, ws_path)
+    assert applied == 0
     assert isinstance(store["1"].media[0], MediaPhotoDownloaded)  # unchanged
+    # Both judgments are well-formed but address no downloaded photo → reported,
+    # not silently dropped.
+    assert {label for label, _ in invalid} == {"1#9", "nope#0"}
+
+
+def test_apply_reports_malformed_judgments_but_applies_valid(tmp_path):
+    # A hand/agent-authored worksheet mixes one good judgment with malformed
+    # ones. The good one must apply; each bad one is isolated + reported —
+    # never a whole-run abort or a raw TypeError traceback.
+    store = {"1": _item("1", [_photo("1/0.png")]), "2": _item("2", [_photo("2/0.png")])}
+    ws_path = tmp_path / "ws.json"
+    ws_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "language": "Spanish",
+                "judgments": [
+                    {"item_id": "1", "index": 0, "is_decorative": False, "description": "Bien."},
+                    {"item_id": "2", "index": None, "is_decorative": False, "description": "x"},
+                    {"item_id": "2", "is_decorative": False, "description": "sin index"},
+                    {"item_id": "2", "index": True, "is_decorative": False, "description": "bool"},
+                    "no soy un objeto",
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    applied, invalid = apply_describe_worksheet(store, ws_path)
+    assert applied == 1
+    assert isinstance(store["1"].media[0], MediaPhotoDescribed)
+    assert isinstance(store["2"].media[0], MediaPhotoDownloaded)  # untouched
+    # Four malformed judgments, each reported with its position label.
+    assert len(invalid) == 4
+    assert {label for label, _ in invalid} == {
+        "judgment[1]",
+        "judgment[2]",
+        "judgment[3]",
+        "judgment[4]",
+    }
+
+
+def test_apply_reports_duplicate_keys(tmp_path):
+    store = {"1": _item("1", [_photo("1/0.png")])}
+    ws_path = tmp_path / "ws.json"
+    ws_path.write_text(
+        json.dumps(
+            {
+                "judgments": [
+                    {"item_id": "1", "index": 0, "is_decorative": False, "description": "first"},
+                    {"item_id": "1", "index": 0, "is_decorative": False, "description": "second"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    applied, invalid = apply_describe_worksheet(store, ws_path)
+    assert applied == 1  # first-wins; duplicate is rejected, not last-wins
+    assert store["1"].media[0].description == "first"
+    assert [label for label, _ in invalid] == ["1#0"]
+
+
+def test_apply_raises_on_non_object_worksheet(tmp_path):
+    import pytest
+
+    ws_path = tmp_path / "ws.json"
+    ws_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+    with pytest.raises(ValueError, match="not a JSON object"):
+        apply_describe_worksheet({}, ws_path)
+
+
+def test_apply_raises_on_non_list_judgments(tmp_path):
+    import pytest
+
+    ws_path = tmp_path / "ws.json"
+    ws_path.write_text(json.dumps({"judgments": {"item_id": "1"}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a list"):
+        apply_describe_worksheet({}, ws_path)
+
+
+def test_generate_multiline_description_quotes_every_line(tmp_path):
+    # A multi-line vision description must be quoted line-by-line: an unquoted
+    # trailing line starting with `##`/`-` would inject structure into the note.
+    desc = "Primera línea.\n## No es un heading\n- tampoco un bullet"
+    store = {"1": _item("1", [_described("1/0.png", desc)])}
+    generate(store, tmp_path, output_language="Spanish")
+    note = next((tmp_path / "items").glob("*-1.md")).read_text(encoding="utf-8")
+    assert "> Primera línea." in note
+    assert "> ## No es un heading" in note
+    assert "> - tampoco un bullet" in note
+    # No description line escaped the blockquote into raw note body.
+    assert "\n## No es un heading" not in note
+    assert "\n- tampoco un bullet" not in note
 
 
 def _described(local_path, description, *, decorative=False):

--- a/tests/test_describe_worksheet.py
+++ b/tests/test_describe_worksheet.py
@@ -1,0 +1,129 @@
+# tests/test_describe_worksheet.py
+import json
+from datetime import datetime, timezone
+
+from xbrain.describe import apply_describe_worksheet, export_describe_worksheet
+from xbrain.generate import generate
+from xbrain.models import (
+    Author,
+    Item,
+    MediaPhotoDescribed,
+    MediaPhotoDownloaded,
+)
+
+DT = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _photo(local_path="1/0.png"):
+    return MediaPhotoDownloaded(
+        url="https://p/" + local_path,
+        local_path=local_path,
+        width=4,
+        height=4,
+        bytes_size=9,
+        downloaded_at=DT,
+    )
+
+
+def _item(item_id="1", media=None):
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="alice", name="Alice"),
+        text=f"text {item_id}",
+        created_at=DT,
+        captured_at=DT,
+        media=media or [],
+    )
+
+
+def test_export_lists_eligible_photos_with_image_paths(tmp_path):
+    store = {
+        "1": _item("1", [_photo("1/0.png")]),
+        "2": _item("2", [_photo("2/0.png"), _photo("2/1.png")]),
+    }
+    ws_path = tmp_path / "ws.json"
+    n = export_describe_worksheet(
+        store, tmp_path / "media", ws_path, version="v1", output_language="Spanish"
+    )
+    ws = json.loads(ws_path.read_text(encoding="utf-8"))
+    assert n == 3
+    assert {(p["item_id"], p["index"]) for p in ws["photos"]} == {("1", 0), ("2", 0), ("2", 1)}
+    assert ws["photos"][0]["image_path"].endswith("1/0.png")
+    assert ws["rubric"] and ws["judgments"] == []
+
+
+def test_apply_transitions_to_described_and_enforces_decorative_empty(tmp_path):
+    store = {"1": _item("1", [_photo("1/0.png")]), "2": _item("2", [_photo("2/0.png")])}
+    ws_path = tmp_path / "ws.json"
+    export_describe_worksheet(
+        store, tmp_path / "media", ws_path, version="v1", output_language="Spanish"
+    )
+    ws = json.loads(ws_path.read_text(encoding="utf-8"))
+    ws["judgments"] = [
+        {
+            "item_id": "1",
+            "index": 0,
+            "is_decorative": False,
+            "description": "Un gráfico de barras.",
+        },
+        {"item_id": "2", "index": 0, "is_decorative": True, "description": "ignored by contract"},
+    ]
+    ws_path.write_text(json.dumps(ws), encoding="utf-8")
+
+    assert apply_describe_worksheet(store, ws_path) == 2
+    d1, d2 = store["1"].media[0], store["2"].media[0]
+    assert isinstance(d1, MediaPhotoDescribed) and d1.description == "Un gráfico de barras."
+    assert not d1.is_decorative
+    assert isinstance(d2, MediaPhotoDescribed) and d2.is_decorative and d2.description == ""
+
+
+def test_apply_skips_unknown_id_and_index(tmp_path):
+    store = {"1": _item("1", [_photo("1/0.png")])}
+    ws_path = tmp_path / "ws.json"
+    ws_path.write_text(
+        json.dumps(
+            {
+                "version": "v1",
+                "language": "Spanish",
+                "judgments": [
+                    {"item_id": "1", "index": 9, "is_decorative": False, "description": "x"},
+                    {"item_id": "nope", "index": 0, "is_decorative": False, "description": "y"},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert apply_describe_worksheet(store, ws_path) == 0
+    assert isinstance(store["1"].media[0], MediaPhotoDownloaded)  # unchanged
+
+
+def _described(local_path, description, *, decorative=False):
+    return MediaPhotoDescribed(
+        url="https://p/" + local_path,
+        local_path=local_path,
+        width=4,
+        height=4,
+        bytes_size=9,
+        downloaded_at=DT,
+        is_decorative=decorative,
+        description=description,
+        description_lang="Spanish",
+        description_version="v1",
+        described_at=DT,
+    )
+
+
+def test_generate_renders_photo_description_as_caption(tmp_path):
+    store = {
+        "1": _item("1", [_described("1/0.png", "Un diagrama de flujo.")]),
+        "2": _item("2", [_described("2/0.png", "", decorative=True)]),
+    }
+    generate(store, tmp_path, output_language="Spanish")
+
+    note1 = next((tmp_path / "items").glob("*-1.md")).read_text(encoding="utf-8")
+    assert "> Un diagrama de flujo." in note1  # described photo → searchable caption
+
+    note2 = next((tmp_path / "items").glob("*-2.md")).read_text(encoding="utf-8")
+    assert "\n> " not in note2  # decorative photo → no caption line


### PR DESCRIPTION
Implementa **#52** (avanza #33/#34). Hace las fotos **buscables** en el vault: descripción de visión sin API key + renderizada en la nota.

## Qué
- **`xbrain describe --executor claude-code`** exporta `data/describe-worksheet.json` (fotos elegibles: item_id, index, image_path abs, texto + rúbrica). Sin API key.
- **`xbrain describe --apply <file>`** transiciona a `MediaPhotoDescribed` (reusa `_apply_judgment`).
- **`generate`** renderiza la descripción como caption `> {description}` bajo la foto → buscable en Obsidian. Decorativas: sin caption.

## Integración
- Reusa `describe._iter_eligible_candidates` + `_apply_judgment` (cero duplicación). El comando `describe` despacha por `--executor` (api|manual|claude-code) + `--apply`, como enrich.

## Pruebas
- `uv run poe check` verde: **662 tests, 93% coverage**, Radon A/B.
- Tests: export lista fotos+rúbrica, apply transiciona + fuerza decorative-empty, apply salta ids/índices desconocidos, generate renderiza el caption (no en decorativas). Smoke contra store real: 830 fotos elegibles.

## Después
Poblar descripciones: workflow de ~700 agentes (uno por post) → apply → generate.

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)