### PR TITLE
fix(dashboard): count described photos as downloaded + show captions (#54)

### DIFF
--- a/src/xbrain/dashboard.py
+++ b/src/xbrain/dashboard.py
@@ -133,14 +133,12 @@ def collect_thumbnails(
                 logger.debug("Skipping unreadable thumbnail %s", path, exc_info=True)
                 continue
             # Surface the vision caption on the thumbnail so the photo drawer says
-            # what each image actually is. Decorative photos carry `description=""`
-            # by contract; a still-undescribed `MediaPhotoDownloaded` has no
-            # description attribute at all — `getattr` keeps both cases empty.
-            desc = (
-                getattr(entry, "description", "")
-                if not getattr(entry, "is_decorative", False)
-                else ""
-            )
+            # what each image actually is. Only `MediaPhotoDescribed` carries a
+            # caption, and the model validator forces a decorative one to "" —
+            # so a single typed isinstance suffices (a plain `MediaPhotoDownloaded`
+            # yields ""). Typed access, not a `getattr` sniff, per the `_VIDEO_TYPES`
+            # note above.
+            desc = entry.description if isinstance(entry, MediaPhotoDescribed) else ""
             thumbs.append(
                 {
                     "thumb": "data:image/jpeg;base64,"

--- a/src/xbrain/dashboard.py
+++ b/src/xbrain/dashboard.py
@@ -23,6 +23,7 @@ from PIL import Image
 from xbrain.models import (
     ContentSourceSuccess,
     Item,
+    MediaPhotoDescribed,
     MediaPhotoDownloaded,
     MediaPhotoPending,
     MediaVideoDownloaded,
@@ -40,6 +41,13 @@ _THUMB_LIMIT = 18
 # `duration_millis`; discriminating on the union (not a `getattr("type")`
 # sniff) keeps the typed access mypy-checked, matching `generate._render_media_lines`.
 _VIDEO_TYPES = (MediaVideoPending, MediaVideoDownloaded, MediaVideoFailed)
+# A described photo (`MediaPhotoDescribed`) IS a downloaded photo — it carries
+# the same `local_path`/bytes and only adds a vision caption. `xbrain describe`
+# transitions Downloaded -> Described in place, so every downloaded-photo count,
+# thumbnail source, and photo-post filter must accept BOTH variants or the whole
+# corpus of described photos vanishes from the dashboard. Mirrors the isinstance
+# grouping in `generate._render_media_lines`.
+_DOWNLOADED_PHOTO_TYPES = (MediaPhotoDownloaded, MediaPhotoDescribed)
 
 
 def humanize_topic(slug: str) -> str:
@@ -110,7 +118,7 @@ def collect_thumbnails(
         for entry in item.media:
             if len(thumbs) >= limit:
                 return thumbs
-            if not isinstance(entry, MediaPhotoDownloaded):
+            if not isinstance(entry, _DOWNLOADED_PHOTO_TYPES):
                 continue
             path = media_root / entry.local_path
             if not path.exists():
@@ -124,6 +132,15 @@ def collect_thumbnails(
             except Exception:  # noqa: BLE001 - a bad image file must not break the dashboard
                 logger.debug("Skipping unreadable thumbnail %s", path, exc_info=True)
                 continue
+            # Surface the vision caption on the thumbnail so the photo drawer says
+            # what each image actually is. Decorative photos carry `description=""`
+            # by contract; a still-undescribed `MediaPhotoDownloaded` has no
+            # description attribute at all — `getattr` keeps both cases empty.
+            desc = (
+                getattr(entry, "description", "")
+                if not getattr(entry, "is_decorative", False)
+                else ""
+            )
             thumbs.append(
                 {
                     "thumb": "data:image/jpeg;base64,"
@@ -133,6 +150,7 @@ def collect_thumbnails(
                     "handle": item.author.handle,
                     "date": _date(item),
                     "summary": _summary(item),
+                    "desc": desc,
                 }
             )
     return thumbs
@@ -208,7 +226,7 @@ def _media_counts(items: list[Item]) -> dict[str, int]:
     downloaded = pending = videos = 0
     for item in items:
         for entry in item.media:
-            if isinstance(entry, MediaPhotoDownloaded):
+            if isinstance(entry, _DOWNLOADED_PHOTO_TYPES):
                 downloaded += 1
             elif isinstance(entry, MediaPhotoPending):
                 pending += 1
@@ -381,7 +399,7 @@ def compute_dashboard_data(
     media = _media_counts(items)
     bookmark_items = [i for i in items if i.source == "bookmark"]
     own_items = [i for i in items if i.source == "own_tweet"]
-    photo_posts = [i for i in items if any(isinstance(m, MediaPhotoDownloaded) for m in i.media)]
+    photo_posts = [i for i in items if any(isinstance(m, _DOWNLOADED_PHOTO_TYPES) for m in i.media)]
 
     return {
         "meta": _meta(

--- a/src/xbrain/resources/dashboard.template.html
+++ b/src/xbrain/resources/dashboard.template.html
@@ -417,7 +417,7 @@ function openLongform(){const L=DATA.longform_full;
  openDrawer('Long-form','Captured articles',nf(L.saved)+' SAVED · '+L.ext_saved+' external · '+L.x_saved+' X',
   `<p class="ov">Full article text fetched and stored. Showing the ${L.items.length} most recent. Title → article; post → the X post; note → the vault.</p><div class="dwsec">Articles</div><div class="lf">${rows}</div>`);}
 function openPhotos(){const p=DATA.photos;
- const th=p.thumbs.map(t=>`<div class="thumb"><a href="${esc(t.url)}" target="_blank" title="@${esc(t.handle)} · ${esc(t.date)} — ${esc((t.summary||'').slice(0,150))}"><img src="${t.thumb}"><span class="cap">@${esc(t.handle)}</span></a>${t.note?`<a class="nl" href="obsidian://open?path=${encodeURIComponent(t.note)}" title="Open vault note">◆</a>`:''}</div>`).join('');
+ const th=p.thumbs.map(t=>`<div class="thumb"><a href="${esc(t.url)}" target="_blank" title="@${esc(t.handle)} · ${esc(t.date)} — ${esc((t.desc||t.summary||'').slice(0,240))}"><img src="${t.thumb}"><span class="cap">@${esc(t.handle)}</span></a>${t.note?`<a class="nl" href="obsidian://open?path=${encodeURIComponent(t.note)}" title="Open vault note">◆</a>`:''}</div>`).join('');
  openDrawer('Media · Photos','Captured photos',nf(p.downloaded)+' DOWNLOADED · '+p.pending+' PENDING',
   `<div class="dwsec">Sample thumbnails — click → the post · ◆ → the note</div><div class="thumbs">${th}</div>`+sampleSec(p.samples,'Posts with photos'));}
 function openVideos(){const v=DATA.videos;

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -314,6 +314,7 @@ def test_collect_thumbnails_none_missing_corrupt_and_real(tmp_path):
     assert len(thumbs) == 1
     assert thumbs[0]["thumb"].startswith("data:image/jpeg;base64,")
     assert thumbs[0]["handle"] == "alice" and thumbs[0]["note"] == "/v/1.md"
+    assert thumbs[0]["desc"] == ""  # undescribed downloaded photo → present but empty caption
 
 
 def test_described_photos_count_as_downloaded_and_populate_photo_posts():

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -19,6 +19,7 @@ from xbrain.models import (
     Enrichment,
     Item,
     Link,
+    MediaPhotoDescribed,
     MediaPhotoDownloaded,
     MediaPhotoPending,
     MediaVideoDownloaded,
@@ -26,6 +27,25 @@ from xbrain.models import (
 )
 
 DT = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+
+def _described_photo(
+    local_path="1/0.png", *, description="Un gráfico de barras.", decorative=False
+):
+    """A `MediaPhotoDescribed` — the variant `xbrain describe` produces in place."""
+    return MediaPhotoDescribed(
+        url="https://p/" + local_path,
+        local_path=local_path,
+        width=3,
+        height=3,
+        bytes_size=9,
+        downloaded_at=DT,
+        is_decorative=decorative,
+        description="" if decorative else description,
+        description_lang="Spanish",
+        description_version="v1",
+        described_at=DT,
+    )
 
 
 def _item(
@@ -294,6 +314,38 @@ def test_collect_thumbnails_none_missing_corrupt_and_real(tmp_path):
     assert len(thumbs) == 1
     assert thumbs[0]["thumb"].startswith("data:image/jpeg;base64,")
     assert thumbs[0]["handle"] == "alice" and thumbs[0]["note"] == "/v/1.md"
+
+
+def test_described_photos_count_as_downloaded_and_populate_photo_posts():
+    # Regression: `xbrain describe` transitions Downloaded -> Described in place.
+    # The dashboard must keep counting described photos as downloaded photos and
+    # keep their posts in the photo samples, or the whole described corpus vanishes.
+    items = [
+        _item("1", media=[_described_photo("1/0.png")]),
+        _item("2", media=[_described_photo("2/0.png", decorative=True)]),
+        _item("3", media=[MediaPhotoPending(url="https://p")]),
+    ]
+    data = compute_dashboard_data(items, {}, {}, [], "JUN 1, 2026")
+    md = data["meta"]["media"]
+    assert (md["photos_downloaded"], md["photos_pending"]) == (2, 1)  # both described counted
+    assert data["photos"]["downloaded"] == 2
+    # Posts 1 and 2 (described photos) appear as photo posts; post 3 (pending) does not.
+    sample_notes = {s["url"] for s in data["photos"]["samples"]}
+    assert "https://x.com/alice/status/1" in sample_notes
+    assert "https://x.com/alice/status/2" in sample_notes
+
+
+def test_collect_thumbnails_includes_described_and_carries_description(tmp_path):
+    described = _item("1", media=[_described_photo("1/0.png", description="Diagrama de flujo.")])
+    decorative = _item("2", media=[_described_photo("2/0.png", decorative=True)])
+    for sub in ("1", "2"):
+        (tmp_path / sub).mkdir()
+        Image.new("RGB", (3, 3), "blue").save(tmp_path / sub / "0.png")
+    thumbs = collect_thumbnails([described, decorative], tmp_path, {})
+    assert len(thumbs) == 2  # described photos ARE thumbnailed (previously excluded)
+    by_handle = {t["url"]: t for t in thumbs}
+    assert by_handle["https://x.com/alice/status/1"]["desc"] == "Diagrama de flujo."
+    assert by_handle["https://x.com/alice/status/2"]["desc"] == ""  # decorative → no caption
 
 
 def test_generate_writes_dashboard_with_valid_blob_and_links_it(tmp_path):


### PR DESCRIPTION
## Problem

`xbrain describe` (#52) transitions `MediaPhotoDownloaded` → `MediaPhotoDescribed` **in place**. The dashboard (#49) predates that variant and gated every downloaded-photo path on `isinstance(m, MediaPhotoDownloaded)` alone. After describing the corpus, all 830 photos **vanished from the dashboard**: the PHOTOS KPI collapsed (830 → 0) and the photo-drawer thumbnails went empty. Víctor caught it in the live dashboard.

## Fix

- `_DOWNLOADED_PHOTO_TYPES = (MediaPhotoDownloaded, MediaPhotoDescribed)` used in `_media_counts`, `collect_thumbnails`, and the `photo_posts` filter — a described photo **is** a downloaded photo (same bytes/local_path), mirroring the isinstance grouping in `generate._render_media_lines`.
- Surface each photo's vision caption in the thumbnail (`desc`) and render it in the photo-drawer tooltip (falls back to the post summary). Decorative photos carry no caption by contract.

## Proof against the real store

`photos_downloaded: 830` (was 0), 18/18 thumbnails carry their description.

## Tests

Regression tests: described photos count as downloaded, populate photo posts, and appear in thumbnails carrying their description (empty for decorative). 672 tests, 93% cov, all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)