### PR TITLE
fix(generate): link dashboard from _index with an absolute file:// URI (#55)

### DIFF
--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -111,6 +111,9 @@ def generate(
     # Absolute file:// URI so Obsidian opens the dashboard in the external browser
     # on click — a relative `dashboard.html` link is unreliable for non-markdown
     # files (Obsidian hides .html from the explorer and won't render its JS inline).
+    # This pins the link to the machine that ran `generate` (the URI is absolute
+    # and `_index.md` syncs via iCloud), which is the unavoidable cost of opening a
+    # local file from Obsidian; it self-heals on the next `generate` per machine.
     dashboard_href = (output_dir / "dashboard.html").resolve().as_uri()
     (output_dir / "_index.md").write_text(
         _render_index(items, strings, dashboard_href), encoding="utf-8"

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -108,7 +108,13 @@ def generate(
     items = sorted(store.values(), key=lambda i: i.created_at, reverse=True)
     items_dir = output_dir / "items"
     items_dir.mkdir(parents=True, exist_ok=True)
-    (output_dir / "_index.md").write_text(_render_index(items, strings), encoding="utf-8")
+    # Absolute file:// URI so Obsidian opens the dashboard in the external browser
+    # on click — a relative `dashboard.html` link is unreliable for non-markdown
+    # files (Obsidian hides .html from the explorer and won't render its JS inline).
+    dashboard_href = (output_dir / "dashboard.html").resolve().as_uri()
+    (output_dir / "_index.md").write_text(
+        _render_index(items, strings, dashboard_href), encoding="utf-8"
+    )
     (output_dir / "log.md").write_text(_render_log(items), encoding="utf-8")
     for item in items:
         if _has_note(item) and _in_range(item, since, until):
@@ -421,8 +427,13 @@ def _count_topic_frequency(items: list[Item]) -> dict[str, int]:
     return topic_freq
 
 
-def _render_index(items: list[Item], strings: Strings) -> str:
-    """Render the top-level index note: corpus stats and the topic list."""
+def _render_index(items: list[Item], strings: Strings, dashboard_href: str) -> str:
+    """Render the top-level index note: corpus stats and the topic list.
+
+    `dashboard_href` is the absolute ``file://`` URI of ``dashboard.html`` so the
+    index link opens the self-contained dashboard in the external browser (see
+    `generate`); Obsidian neither lists nor renders the raw ``.html`` itself.
+    """
     bookmarks = sum(1 for i in items if i.source == "bookmark")
     own = sum(1 for i in items if i.source == "own_tweet")
     noted = sum(1 for i in items if _has_note(i))
@@ -443,7 +454,7 @@ def _render_index(items: list[Item], strings: Strings) -> str:
         "## Índices",
         "",
         "- [[log|Log cronológico completo]]",
-        "- [📊 Dashboard interactivo](dashboard.html) — métricas, drill-down y enlaces (ábrelo en el navegador)",
+        f"- [📊 Dashboard interactivo]({dashboard_href}) — métricas, drill-down y enlaces (se abre en el navegador)",
         "",
         f"## {strings.topics_label}",
         "",

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -357,7 +357,11 @@ def test_generate_writes_dashboard_with_valid_blob_and_links_it(tmp_path):
 
     dashboard = tmp_path / "dashboard.html"
     assert dashboard.exists()
-    assert "dashboard.html" in (tmp_path / "_index.md").read_text(encoding="utf-8")
+    # The index links the dashboard by absolute file:// URI so Obsidian opens it
+    # in the browser (a relative .html link is unreliable there).
+    index_text = (tmp_path / "_index.md").read_text(encoding="utf-8")
+    assert f"]({dashboard.resolve().as_uri()})" in index_text
+    assert "file://" in index_text and index_text.count("dashboard.html") >= 1
     # The full store→compute→render→file path emits parseable JSON with right KPIs.
     text = dashboard.read_text(encoding="utf-8")
     blob = text.split("const DATA = ", 1)[1].split(";\n", 1)[0]


### PR DESCRIPTION
## Problem
Obsidian hides `.html` files from its explorer and won't render the interactive dashboard's JS inline. The `_index.md` link `[..](dashboard.html)` (relative) does not reliably open it — Víctor couldn't reach the dashboard from the vault.

## Fix
Emit an **absolute `file://` URI** (`(output_dir / "dashboard.html").resolve().as_uri()`) for the index link. Obsidian opens `file://` links in the external browser on click. Threads `dashboard_href` into `_render_index`.

Test asserts `_index.md` links the dashboard by its file:// URI. 672 tests, 93% cov, all gates green.