### PR TITLE
[#46] --until <date> is inclusive of the whole final day

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,9 @@ uv run xbrain <command> [options]
 | `login` | Open a browser to log in to X (see [Authentication](#authentication) — prefer the cookie import). |
 
 Every stage accepts `--since` / `--until` (ISO dates) to narrow the date window.
+The window is inclusive at both ends: a date-only `--until 2025-12-31` covers the
+whole of Dec 31 (up to `23:59:59.999999` UTC). Pass an explicit time
+(`--until 2025-12-31T09:00:00`) to cut off mid-day instead.
 Run `uv run xbrain <command> --help` for the full option list.
 
 ---

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -137,13 +137,30 @@ def _config() -> Config:
     return load_config(_repo_root())
 
 
-def _parse_date(value: str | None) -> datetime | None:
+def _parse_date(value: str | None, *, end_of_day: bool = False) -> datetime | None:
+    """Parse an ISO date/datetime into a UTC-aware datetime.
+
+    A *date-only* ``value`` (e.g. ``2025-12-31``) carries no time component,
+    so it parses to that day's midnight. For a ``since`` bound that is the
+    correct day start. For an ``until`` bound (``end_of_day=True``) midnight
+    would exclude the whole final day, so we snap it to the last microsecond
+    (``23:59:59.999999`` UTC) — the ``item.created_at > until`` filters then
+    include every item created on that day. An explicit time
+    (e.g. ``2025-12-31T09:00``) is respected as-is and never snapped.
+    """
     if not value:
         return None
     parsed = datetime.fromisoformat(value)
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=timezone.utc)
+    if end_of_day and _is_date_only(value):
+        parsed = parsed.replace(hour=23, minute=59, second=59, microsecond=999999)
     return parsed
+
+
+def _is_date_only(value: str) -> bool:
+    """True when an ISO string has no time component (e.g. ``2025-12-31``)."""
+    return "T" not in value and ":" not in value
 
 
 _OPERATOR_ERRORS = (
@@ -407,11 +424,17 @@ def login() -> None:
 def extract(
     source: Source = typer.Option(Source.all, help="bookmarks | tweets | all"),
     since: str = typer.Option(None, help="ISO date, e.g. 2025-01-01"),
-    until: str = typer.Option(None, help="ISO date, e.g. 2025-12-31"),
+    until: str = typer.Option(None, help="ISO date; whole day inclusive, e.g. 2025-12-31"),
     headless: bool = typer.Option(False, "--headless/--no-headless", help=_HEADLESS_HELP),
 ) -> None:
     """Extrae bookmarks y/o tweets propios desde X."""
-    _run_extract(_config(), source.value, _parse_date(since), _parse_date(until), headless=headless)
+    _run_extract(
+        _config(),
+        source.value,
+        _parse_date(since),
+        _parse_date(until, end_of_day=True),
+        headless=headless,
+    )
 
 
 @app.command(name="import-archive")
@@ -433,12 +456,14 @@ def import_archive(zip_path: Path) -> None:
 @_handle_cli_errors
 def fetch(
     since: str = typer.Option(None),
-    until: str = typer.Option(None),
+    until: str = typer.Option(None, help="ISO date; whole day inclusive, e.g. 2025-12-31"),
     force: bool = typer.Option(False, help="Volver a descargar lo ya descargado"),
     headless: bool = typer.Option(False, "--headless/--no-headless", help=_HEADLESS_HELP),
 ) -> None:
     """Descarga el contenido de los artículos enlazados."""
-    _run_fetch(_config(), _parse_date(since), _parse_date(until), force, headless=headless)
+    _run_fetch(
+        _config(), _parse_date(since), _parse_date(until, end_of_day=True), force, headless=headless
+    )
 
 
 def _run_media(
@@ -1227,7 +1252,7 @@ def enrich(
         None, "--apply", help="Import a filled worksheet and apply it"
     ),
     since: str = typer.Option(None, help="ISO date, e.g. 2025-01-01"),
-    until: str = typer.Option(None, help="ISO date, e.g. 2025-12-31"),
+    until: str = typer.Option(None, help="ISO date; whole day inclusive, e.g. 2025-12-31"),
 ) -> None:
     """Enriquece los items con resumen + topics."""
     cfg = _config()
@@ -1247,7 +1272,9 @@ def enrich(
     chosen = executor or cfg.enrich_executor
 
     if chosen in ("manual", "claude-code"):
-        pending = items_pending_enrichment(store, _parse_date(since), _parse_date(until))
+        pending = items_pending_enrichment(
+            store, _parse_date(since), _parse_date(until, end_of_day=True)
+        )
         if not pending:
             typer.echo("No hay items pendientes de enriquecer.")
             return
@@ -1268,7 +1295,7 @@ def enrich(
         ApiExecutor(model=cfg.enrich_model, output_language=cfg.output_language),
         vocab_topics,
         _parse_date(since),
-        _parse_date(until),
+        _parse_date(until, end_of_day=True),
     )
     save_store(store, cfg.items_path)
     typer.echo(f"Enriquecidos: {enriched} items")
@@ -1418,10 +1445,10 @@ def topics(
 @_handle_cli_errors
 def generate(
     since: str = typer.Option(None, help="ISO date, e.g. 2025-01-01"),
-    until: str = typer.Option(None, help="ISO date, e.g. 2025-12-31"),
+    until: str = typer.Option(None, help="ISO date; whole day inclusive, e.g. 2025-12-31"),
 ) -> None:
     """Genera las notas markdown en el vault."""
-    _run_generate(_config(), _parse_date(since), _parse_date(until))
+    _run_generate(_config(), _parse_date(since), _parse_date(until, end_of_day=True))
 
 
 @app.command()

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -7,6 +7,7 @@ import functools
 import json
 import logging
 import os
+import re
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -158,9 +159,17 @@ def _parse_date(value: str | None, *, end_of_day: bool = False) -> datetime | No
     return parsed
 
 
+# A bare ISO date (``YYYY-MM-DD``) optionally carrying a tz offset (``+00:00``,
+# ``-0500``, ``Z``) but NO time-of-day. A time-of-day is always introduced by a
+# ``T``/space separator, so ``2025-12-31T09:00:00`` and ``2025-12-31 120000``
+# never match — only whole-day bounds do.
+_DATE_ONLY_RE = re.compile(r"\d{4}-\d{2}-\d{2}(?:[Zz]|[+-]\d{2}:?\d{2})?")
+
+
 def _is_date_only(value: str) -> bool:
-    """True when an ISO string has no time component (e.g. ``2025-12-31``)."""
-    return "T" not in value and ":" not in value
+    """True when an ISO string is a bare date (no time-of-day), so an ``until``
+    bound should cover the whole day. See ``_DATE_ONLY_RE``."""
+    return _DATE_ONLY_RE.fullmatch(value) is not None
 
 
 _OPERATOR_ERRORS = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -628,6 +628,69 @@ def test_parse_date_returns_utc_aware():
     assert _parse_date(None) is None
 
 
+def test_parse_date_since_keeps_midnight():
+    """A date-only `since` stays at the day's start (00:00:00) — no snapping."""
+    from xbrain.cli import _parse_date
+
+    parsed = _parse_date("2025-12-31")
+    assert parsed == datetime(2025, 12, 31, 0, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_date_until_snaps_date_only_to_end_of_day():
+    """A date-only `until` snaps to the last microsecond so the whole day is included."""
+    from xbrain.cli import _parse_date
+
+    parsed = _parse_date("2025-12-31", end_of_day=True)
+    assert parsed == datetime(2025, 12, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
+def test_parse_date_until_respects_explicit_time():
+    """An explicit time on `until` is respected as-is — never snapped to end of day."""
+    from xbrain.cli import _parse_date
+
+    parsed = _parse_date("2025-12-31T09:00:00", end_of_day=True)
+    assert parsed == datetime(2025, 12, 31, 9, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_cli_generate_until_date_only_includes_whole_final_day(tmp_path: Path, monkeypatch):
+    """`--until <date>` (date-only) must include an item created that same day at 15:00."""
+    vault = _setup_repo(tmp_path, monkeypatch)
+    item = _linked_item("1")
+    item.created_at = datetime(2026, 1, 15, 15, 0, 0, tzinfo=timezone.utc)
+    save_store({"1": item}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["generate", "--until", "2026-01-15"])
+    assert result.exit_code == 0
+    notes = list((vault / "x-knowledge" / "items").glob("*.md"))
+    assert len(notes) == 1
+
+
+def test_cli_generate_until_explicit_time_is_respected(tmp_path: Path, monkeypatch):
+    """`--until <date>T09:00:00` excludes an item at 10:00 and includes one at 08:00."""
+    vault = _setup_repo(tmp_path, monkeypatch)
+    after = _linked_item("1")
+    after.created_at = datetime(2026, 1, 15, 10, 0, 0, tzinfo=timezone.utc)
+    before = _linked_item("2")
+    before.created_at = datetime(2026, 1, 15, 8, 0, 0, tzinfo=timezone.utc)
+    save_store({"1": after, "2": before}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["generate", "--until", "2026-01-15T09:00:00"])
+    assert result.exit_code == 0
+    notes = list((vault / "x-knowledge" / "items").glob("*.md"))
+    assert len(notes) == 1
+    assert notes[0].name.endswith("-2.md")
+
+
+def test_cli_generate_since_date_only_includes_midnight_item(tmp_path: Path, monkeypatch):
+    """`--since <date>` (date-only) still includes an item created at that day's midnight."""
+    vault = _setup_repo(tmp_path, monkeypatch)
+    item = _linked_item("1")
+    item.created_at = datetime(2026, 1, 15, 0, 0, 0, tzinfo=timezone.utc)
+    save_store({"1": item}, tmp_path / "data" / "items.json")
+    result = runner.invoke(app, ["generate", "--since", "2026-01-15"])
+    assert result.exit_code == 0
+    notes = list((vault / "x-knowledge" / "items").glob("*.md"))
+    assert len(notes) == 1
+
+
 def test_cli_fetch_with_since_does_not_crash(tmp_path: Path, monkeypatch):
     _setup_repo(tmp_path, monkeypatch)
     old_item = _linked_item("1")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -652,16 +652,44 @@ def test_parse_date_until_respects_explicit_time():
     assert parsed == datetime(2025, 12, 31, 9, 0, 0, 0, tzinfo=timezone.utc)
 
 
+def test_parse_date_until_space_basic_time_is_respected():
+    """A space-separated basic-format time (no colon) is a time — must NOT snap."""
+    from xbrain.cli import _parse_date
+
+    parsed = _parse_date("2025-12-31 120000", end_of_day=True)
+    assert parsed == datetime(2025, 12, 31, 12, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def test_parse_date_until_bare_date_with_offset_snaps():
+    """A bare date carrying only a tz offset (no time-of-day) still snaps to end of day."""
+    from xbrain.cli import _parse_date
+
+    parsed = _parse_date("2025-12-31+00:00", end_of_day=True)
+    assert parsed == datetime(2025, 12, 31, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
 def test_cli_generate_until_date_only_includes_whole_final_day(tmp_path: Path, monkeypatch):
-    """`--until <date>` (date-only) must include an item created that same day at 15:00."""
+    """`--until <date>` (date-only) includes items up to 23:59:59.999999 of that day.
+
+    Pins the microsecond boundary: an item at the last microsecond of the day is
+    INCLUDED, the next-day midnight item is EXCLUDED. Catches a `>`→`>=` flip or any
+    coarsening of the snap value.
+    """
     vault = _setup_repo(tmp_path, monkeypatch)
-    item = _linked_item("1")
-    item.created_at = datetime(2026, 1, 15, 15, 0, 0, tzinfo=timezone.utc)
-    save_store({"1": item}, tmp_path / "data" / "items.json")
+    midday = _linked_item("1")
+    midday.created_at = datetime(2026, 1, 15, 15, 0, 0, tzinfo=timezone.utc)
+    last_us = _linked_item("2")
+    last_us.created_at = datetime(2026, 1, 15, 23, 59, 59, 999999, tzinfo=timezone.utc)
+    next_day = _linked_item("3")
+    next_day.created_at = datetime(2026, 1, 16, 0, 0, 0, tzinfo=timezone.utc)
+    save_store({"1": midday, "2": last_us, "3": next_day}, tmp_path / "data" / "items.json")
     result = runner.invoke(app, ["generate", "--until", "2026-01-15"])
     assert result.exit_code == 0
     notes = list((vault / "x-knowledge" / "items").glob("*.md"))
-    assert len(notes) == 1
+    names = sorted(n.name for n in notes)
+    assert len(names) == 2
+    assert names[0].endswith("-1.md") and names[1].endswith("-2.md")
+    assert not any(n.endswith("-3.md") for n in names)
 
 
 def test_cli_generate_until_explicit_time_is_respected(tmp_path: Path, monkeypatch):
@@ -689,6 +717,26 @@ def test_cli_generate_since_date_only_includes_midnight_item(tmp_path: Path, mon
     assert result.exit_code == 0
     notes = list((vault / "x-knowledge" / "items").glob("*.md"))
     assert len(notes) == 1
+
+
+def test_cli_enrich_until_date_only_includes_whole_final_day(tmp_path, monkeypatch):
+    """Pins the `end_of_day=True` wiring on a SECOND command (`enrich`), not just `generate`.
+
+    An item created on the `--until` day at 15:00 must count as pending — a mutation
+    dropping `end_of_day=True` from the enrich site would exclude it (0 pending).
+    """
+    _setup_repo(tmp_path, monkeypatch)
+    from xbrain.models import Topic
+    from xbrain.rubrics import save_vocab
+
+    item = _linked_item("1")
+    item.created_at = datetime(2026, 1, 15, 15, 0, 0, tzinfo=timezone.utc)
+    save_store({"1": item}, tmp_path / "data" / "items.json")
+    save_vocab([Topic(slug="misc", description="d")], tmp_path / "data" / "vocab.yaml")
+    result = runner.invoke(app, ["enrich", "--executor", "manual", "--until", "2026-01-15"])
+    assert result.exit_code == 0
+    assert "1 items exportados" in result.output
+    assert (tmp_path / "data" / "enrich-worksheet.json").exists()
 
 
 def test_cli_fetch_with_since_does_not_crash(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## The bug (#46)

A date-only `--until 2025-12-31` was parsed to that day's **midnight**, so the four `item.created_at > until` filters (`fetch_x`, `enrich`, `fetch`, `generate`) wrongly **excluded** every item created later that same day.

## The fix (single point, parse-time)

`_parse_date` in `src/xbrain/cli.py` gains a keyword-only `end_of_day: bool`. When set on a **date-only** value it snaps to `23:59:59.999999` UTC, so the whole final day is included. Detection uses an anchored regex (`_DATE_ONLY_RE`) that matches a bare `YYYY-MM-DD` plus an optional tz offset — a time-of-day is always introduced by a `T`/space separator, so:

- `2025-12-31` → snapped (whole day)
- `2025-12-31+00:00` (bare date + offset) → snapped
- `2025-12-31T09:00:00` / `2025-12-31 120000` (explicit time) → respected as-is, never snapped

`--since` is **asymmetric**: it keeps midnight (the correct day start) and is never snapped.

## Coverage

All 5 CLI `until` call sites (`extract`, `fetch`, `enrich` ×2, `generate`) route through `end_of_day=True`; all 4 downstream filters consume the parsed value and none re-parse.

## Tests

- Unit on `_parse_date`: date-only snaps; explicit time / space-basic-time respected; bare-date+offset snaps; `since` keeps midnight.
- Integration: date-only `--until` includes a same-day 15:00 item; microsecond boundary pinned (`23:59:59.999999` included, next-day midnight excluded); explicit-time `--until` cuts off mid-day; `since` still inclusive from midnight; `enrich` wiring pinned on a second command.

Help text and README document the inclusive semantics.

Closes #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)