### PR TITLE
[#34] Image descriptions (and video transcripts) through the worksheet enrich/topics tracks

### DIFF
--- a/.claude/skills/enriching-x-knowledge/SKILL.md
+++ b/.claude/skills/enriching-x-knowledge/SKILL.md
@@ -75,11 +75,15 @@ each topic page — also via a worksheet, at no API cost.
    with their current post lists. If it reports 0 topics pending, stop.
 
 2. **Read `data/topic-worksheet.json`.** It has `rubric` and `topics` (each with
-   a `slug`, a `description` and the `summaries` of its posts).
+   a `slug`, a `description`, the `summaries` of its posts, and — when the posts
+   carry them — `image_descriptions` (prose for the topic's content-bearing
+   photos) and `video_transcripts` (bounded transcript excerpts of its videos)).
 
 3. **Produce one judgment per topic**, following the embedded rubric exactly:
    - `overview`: 1-3 paragraphs of plain Spanish prose, faithful to the
-     summaries.
+     summaries. When a topic carries `image_descriptions` or `video_transcripts`,
+     weigh them as visual/transcript evidence alongside the summaries — they carry
+     topic signal a one-line summary may only hint at.
    - `notes`: 0-15 plain-prose strings, one important idea each.
    - Emit only `{slug, overview, notes}`. **Never write a wikilink (`[[...]]`),
      a filename or any identifier** — you have summaries, not posts, and the

--- a/.claude/workflows/resynth-topic-overviews.js
+++ b/.claude/workflows/resynth-topic-overviews.js
@@ -87,12 +87,15 @@ const results = await parallel(
       `Eres un sintetizador experto de una base de conocimiento personal (xbrain de Víctor). Tu única tarea: escribir el OVERVIEW del topic "${slug}", leyendo SOLO los posts de ESE topic.
 
 PASO 1 — Extrae tu topic y la rúbrica ejecutando exactamente:
-  cd /Users/vgonpa/devel/xbrain && .venv/bin/python -c "import json; d=json.load(open('${WORKSHEET}')); t=[x for x in d['topics'] if x['slug']=='${slug}'][0]; print('=== RUBRICA ==='); print(d['rubric']); print('=== DESCRIPTION ==='); print(t['description']); print('=== SUMMARIES ('+str(len(t['summaries']))+') ==='); [print('- '+s) for s in t['summaries']]"
+  cd /Users/vgonpa/devel/xbrain && .venv/bin/python -c "import json; d=json.load(open('${WORKSHEET}')); t=[x for x in d['topics'] if x['slug']=='${slug}'][0]; print('=== RUBRICA ==='); print(d['rubric']); print('=== DESCRIPTION ==='); print(t['description']); print('=== SUMMARIES ('+str(len(t['summaries']))+') ==='); [print('- '+s) for s in t['summaries']]; img=t.get('image_descriptions') or []; print('=== IMAGES ('+str(len(img))+') ==='); [print('- '+s) for s in img]; vid=t.get('video_transcripts') or []; print('=== VIDEO TRANSCRIPTS ('+str(len(vid))+') ==='); [print('- '+s) for s in vid]"
 
-PASO 2 — Lee la RÚBRICA entera y respétala al pie de la letra. Lee la DESCRIPTION y TODOS los SUMMARIES: cada summary es el resumen de un post del topic — ESOS son "los posts" que debes leer y sintetizar. No leas otros ficheros; trabaja solo con lo que imprime ese comando.
+PASO 2 — Lee la RÚBRICA entera y respétala al pie de la letra. Lee la DESCRIPTION y TODOS los SUMMARIES: cada summary es el resumen de un post del topic — ESOS son "los posts" que debes leer y sintetizar. El comando también imprime dos bloques de evidencia visual/audiovisual cuando existen — trátalos como parte de "los posts", con el mismo peso que los summaries:
+  - IMAGES — "Images across the content-bearing photos in this topic": descripciones en prosa de las fotos con contenido (gráficas, capturas, diagramas) de los posts del topic. Aportan señal temática que el summary a veces solo insinúa.
+  - VIDEO TRANSCRIPTS — "Video transcripts across the videos in this topic": extractos (truncados) de las transcripciones de los vídeos del topic.
+No leas otros ficheros; trabaja solo con lo que imprime ese comando.
 
 PASO 3 — Sintetiza para el topic "${slug}":
-  - overview: 1 a 3 párrafos en español. Qué es este topic EN ESTE CORPUS: las ideas recurrentes, el arco temporal, las tensiones o debates. Escrito para alguien que decide si leer los posts. FIEL a los summaries — nunca inventes nombres, números ni hechos que no estén en ellos. Prosa plana: sin wikilinks [[...]], sin nombres de fichero, sin identificadores, sin headings markdown. Si el topic es "misc" o de verdad no tiene núcleo temático, dilo con naturalidad en un párrafo y deja notes corto o vacío — no fabriques temas.
+  - overview: 1 a 3 párrafos en español. Qué es este topic EN ESTE CORPUS: las ideas recurrentes, el arco temporal, las tensiones o debates. Escrito para alguien que decide si leer los posts. Integra la evidencia de IMAGES y VIDEO TRANSCRIPTS junto con los summaries. FIEL a los summaries y a esa evidencia — nunca inventes nombres, números ni hechos que no estén en ellos. Prosa plana: sin wikilinks [[...]], sin nombres de fichero, sin identificadores, sin headings markdown. Si el topic es "misc" o de verdad no tiene núcleo temático, dilo con naturalidad en un párrafo y deja notes corto o vacío — no fabriques temas.
   - notes: lista de 0 a 15 frases cortas en español, una idea/hilo/patrón importante por nota, frase plana sin bullets ni wikilinks.
 
 Devuelve SOLO el objeto {overview, notes}.`,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -297,9 +297,11 @@ Eligibility ignores `Pending` / `Failed` / `VideoPending`: describe only runs on
 
 **Feeds the LLM stages.** Once described, the prose is consumed automatically — through **both** the API and the worksheet (`claude-code` / `manual`) tracks, so the descriptions reach the LLM input regardless of which executor runs the stage ([#34](https://github.com/VGonPa/xbrain/issues/34)):
 - `xbrain enrich`: the `api` executor (`executors/api.py:_user_prompt`) splices an `Images in this post:` section between the post body and the links/article block when the item has content-bearing described photos; the worksheet export (`worksheet.py`, an `image_descriptions` field per item) carries the same non-decorative selection (reusing `executors/api._content_image_descriptions`, the same seam) so the claude-code enrich track sees identical visual signal. Decoratives are filtered.
-- `xbrain topics`: the `api` track (`topic_synth.py:_user_prompt`) appends the flat list of content-bearing image descriptions across every post in a topic, after the per-post summaries; the worksheet export (`topic_synth.py:export_topic_worksheet`, an `image_descriptions` field per topic) carries the same list from the `TopicInput` already computed by `build_topic_inputs`.
+- `xbrain topics`: the `api` track (`topic_synth.py:_user_prompt`) appends the flat list of content-bearing image descriptions across every post in a topic, after the per-post summaries; the worksheet export (`topic_synth.py:export_topic_worksheet`, an `image_descriptions` field per topic) carries the same list from the `TopicInput` already computed by `build_topic_inputs`, and the claude-code consumers surface it — the `resynth-topic-overviews` workflow prints an `Images across …` block in each per-topic extraction and the `enriching-x-knowledge` skill lists the field for a hand-run session.
 
 This is how a tweet that is mostly a screenshot of a paper becomes searchable by what the screenshot was actually about — on either track.
+
+**Propagating onto already-enriched items.** This is *wiring*: the descriptions flow whenever `enrich` / `topics` next run for an item. Items already enriched before the describe pass are skipped by the normal idempotency guard, so a one-time forced re-run (real LLM cost, run deliberately) is what back-fills them: `xbrain vocab --regenerate` (clears enrichments) then `xbrain enrich` re-enriches every item with its image descriptions, and `xbrain topics --resynth` re-synthesizes the overviews with the image (and video-transcript) evidence.
 
 ### refresh-media
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -295,11 +295,11 @@ Eligibility ignores `Pending` / `Failed` / `VideoPending`: describe only runs on
 
 **Snapshot trigger.** `xbrain describe` always snapshots `data/` first (label `pre-describe`), mirroring `media`'s recovery boundary. A botched run — wrong model, runaway prompt — can be undone with `xbrain snapshot restore`.
 
-**Feeds the LLM stages.** Once described, the prose is consumed automatically:
-- `xbrain enrich` (in `executors/api.py:_user_prompt`) splices an `Images in this post:` section between the post body and the links/article block when the item has content-bearing described photos. Decoratives are filtered.
-- `xbrain topics` (in `topic_synth.py:_user_prompt`) appends the flat list of content-bearing image descriptions across every post in a topic, after the per-post summaries.
+**Feeds the LLM stages.** Once described, the prose is consumed automatically — through **both** the API and the worksheet (`claude-code` / `manual`) tracks, so the descriptions reach the LLM input regardless of which executor runs the stage ([#34](https://github.com/VGonPa/xbrain/issues/34)):
+- `xbrain enrich`: the `api` executor (`executors/api.py:_user_prompt`) splices an `Images in this post:` section between the post body and the links/article block when the item has content-bearing described photos; the worksheet export (`worksheet.py`, an `image_descriptions` field per item) carries the same non-decorative selection (reusing `executors/api._content_image_descriptions`, the same seam) so the claude-code enrich track sees identical visual signal. Decoratives are filtered.
+- `xbrain topics`: the `api` track (`topic_synth.py:_user_prompt`) appends the flat list of content-bearing image descriptions across every post in a topic, after the per-post summaries; the worksheet export (`topic_synth.py:export_topic_worksheet`, an `image_descriptions` field per topic) carries the same list from the `TopicInput` already computed by `build_topic_inputs`.
 
-This is how a tweet that is mostly a screenshot of a paper becomes searchable by what the screenshot was actually about.
+This is how a tweet that is mostly a screenshot of a paper becomes searchable by what the screenshot was actually about — on either track.
 
 ### refresh-media
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,12 @@ generates an Obsidian wiki.
   the same non-decorative seam — shared, not duplicated). `topics`: the api track appends
   the flat content-image list; the topic worksheet carries `image_descriptions` per topic
   from the `TopicInput` that `build_topic_inputs` already computes. Decoratives are
-  filtered at the seam so avatars/memes add no topic noise. (The 817 already-described
-  photos only reach already-enriched items on a forced `enrich`/`topics` re-run.)
+  filtered at the seam so avatars/memes add no topic noise. Wiring only: the
+  descriptions flow whenever enrich/topics next run for an item. To propagate them
+  onto ALREADY-enriched items (a one-time LLM cost, run separately): `xbrain vocab
+  --regenerate` (clears enrichments) → `xbrain enrich` re-runs every item with its
+  image descriptions; `xbrain topics --resynth` re-synthesizes overviews with the
+  image + transcript evidence.
 - Agent-driven video surface (fetch is mechanical, ML is external): `list-videos`
   is a **read-only** catalog of video media (`--json` → stable `{id, url, state,
   topic, size_bytes, mp4_url, text}` array; filters `--topic/--status/--max-size/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,16 @@ generates an Obsidian wiki.
   for backfilled videos (mp4 only — HLS `.m3u8` needs ffmpeg and is a deferred
   follow-up; prints a ~GB size-gate, confirm unless `--yes`; destructive →
   auto-snapshot).
+- Vision descriptions — pipeline integration (#34): content-bearing described-photo
+  prose feeds **both** the `enrich` and `topics` LLM inputs, on **both** the API and
+  the worksheet (`claude-code`/`manual`) tracks. `enrich`: the api executor splices an
+  `Images in this post:` block (`executors/api.py:_user_prompt`); the enrich worksheet
+  carries an `image_descriptions` field per item (reusing `_content_image_descriptions`,
+  the same non-decorative seam — shared, not duplicated). `topics`: the api track appends
+  the flat content-image list; the topic worksheet carries `image_descriptions` per topic
+  from the `TopicInput` that `build_topic_inputs` already computes. Decoratives are
+  filtered at the seam so avatars/memes add no topic noise. (The 817 already-described
+  photos only reach already-enriched items on a forced `enrich`/`topics` re-run.)
 - Agent-driven video surface (fetch is mechanical, ML is external): `list-videos`
   is a **read-only** catalog of video media (`--json` → stable `{id, url, state,
   topic, size_bytes, mp4_url, text}` array; filters `--topic/--status/--max-size/

--- a/README.md
+++ b/README.md
@@ -646,6 +646,12 @@ either track. This is how a tweet that is mostly a screenshot of a
 paper becomes searchable by what the screenshot was actually about —
 even when the pipeline runs entirely on the Claude Code subscription.
 
+These descriptions flow whenever `enrich` / `topics` next run for an
+item. To back-fill items that were already enriched *before* the
+describe pass (a one-time LLM cost), force the re-run: `xbrain vocab
+--regenerate` (clears enrichments) then `xbrain enrich`, and `xbrain
+topics --resynth`.
+
 Describing the full corpus costs about $3-5 with the default model
 (Sonnet 4.6, 5 images per call). Bump `[describe].version` in
 `config.toml` to invalidate stored descriptions when you change the

--- a/README.md
+++ b/README.md
@@ -637,11 +637,14 @@ abstract backgrounds) are classified as such and persisted with an
 empty description so they introduce no topic noise downstream.
 
 `xbrain enrich` and `xbrain topics` consume the descriptions
-automatically: an item with content-bearing photos gets an
-`Images in this post:` block in the enrichment prompt; topic-page
-synthesis sees the flat list of content image descriptions across the
-topic's posts. This is how a tweet that is mostly a screenshot of a
-paper becomes searchable by what the screenshot was actually about.
+automatically, on **both** the API and the worksheet (`claude-code` /
+`manual`) tracks: an item with content-bearing photos gets an
+`Images in this post:` block in the API enrichment prompt and an
+`image_descriptions` field in the worksheet; topic-page synthesis sees
+the flat list of content image descriptions across the topic's posts on
+either track. This is how a tweet that is mostly a screenshot of a
+paper becomes searchable by what the screenshot was actually about —
+even when the pipeline runs entirely on the Claude Code subscription.
 
 Describing the full corpus costs about $3-5 with the default model
 (Sonnet 4.6, 5 images per call). Bump `[describe].version` in

--- a/src/xbrain/topic_synth.py
+++ b/src/xbrain/topic_synth.py
@@ -195,7 +195,10 @@ def export_topic_worksheet(inputs: list[TopicInput], path: Path, output_language
             f"For each entry in `topics`, append one object to `judgments` with "
             f"keys {{slug, overview, notes}}. `overview` is plain prose in "
             f"{output_language}; `notes` is a list of plain-prose strings in "
-            f"{output_language}. No wikilinks, no filenames. Then run: "
+            f"{output_language}. A topic may also carry `image_descriptions` "
+            f"(content-bearing photos) and `video_transcripts` (bounded excerpts) "
+            f"— weigh them as visual/transcript evidence alongside the summaries. "
+            f"No wikilinks, no filenames. Then run: "
             f"xbrain topics --apply <this file>."
         ),
         "rubric": load_rubric("topic-page", language=output_language),
@@ -210,6 +213,12 @@ def export_topic_worksheet(inputs: list[TopicInput], path: Path, output_language
                 # into `TopicInput.image_descriptions`; empty list when the topic has
                 # none. No truncation — the api path doesn't bound these either.
                 "image_descriptions": t.image_descriptions,
+                # Bounded video-transcript excerpts (#56 transcript-to-topics half):
+                # mirrors the `api` track's topic block ("Video transcripts across
+                # the N videos in this topic"). Already collected + per-video bounded
+                # (`TOPIC_TRANSCRIPT_CHAR_LIMIT`) by `build_topic_inputs` into
+                # `TopicInput.video_transcripts`; empty list when the topic has none.
+                "video_transcripts": t.video_transcripts,
             }
             for t in inputs
         ],

--- a/src/xbrain/topic_synth.py
+++ b/src/xbrain/topic_synth.py
@@ -200,7 +200,18 @@ def export_topic_worksheet(inputs: list[TopicInput], path: Path, output_language
         ),
         "rubric": load_rubric("topic-page", language=output_language),
         "topics": [
-            {"slug": t.slug, "description": t.description, "summaries": t.summaries} for t in inputs
+            {
+                "slug": t.slug,
+                "description": t.description,
+                "summaries": t.summaries,
+                # Content-bearing photo descriptions (#34): mirrors the `api` track's
+                # topic block ("Images across the N content-bearing photos in this
+                # topic"). Already collected + decorative-filtered by `build_topic_inputs`
+                # into `TopicInput.image_descriptions`; empty list when the topic has
+                # none. No truncation — the api path doesn't bound these either.
+                "image_descriptions": t.image_descriptions,
+            }
+            for t in inputs
         ],
         "judgments": [],
     }

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -78,7 +78,9 @@ def export_worksheet(
         "instructions": (
             "For each entry in `items`, append one object to `judgments` with "
             "keys {item_id, summary, primary_topic, topics}. Use only slugs from "
-            "`vocab`. Then run: xbrain enrich --apply <this file>."
+            "`vocab`. An item may also carry `links`, `article`, `video_transcript` "
+            "and `image_descriptions` (content-bearing photos) — weigh them all as "
+            "topic signal, not just `text`. Then run: xbrain enrich --apply <this file>."
         ),
         "rubrics": {
             "summary": load_rubric("summary", language=output_language),

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -12,6 +12,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
+from xbrain.executors.api import _content_image_descriptions
 from xbrain.models import ContentSourceSuccess, Item, Topic
 from xbrain.rubrics import (
     ARTICLE_CHAR_LIMIT,
@@ -93,6 +94,12 @@ def export_worksheet(
                 "links": [{"url": ln.url, "domain": ln.domain} for ln in it.links],
                 "article": _article_text(it),
                 "video_transcript": _video_transcript(it),
+                # Content-bearing photo descriptions (#34): the same non-decorative
+                # selection the `api` executor injects as its `Images in this post:`
+                # section (`_content_image_descriptions`), so the manual/claude-code
+                # enrich track sees the identical visual signal. Empty list when the
+                # item has no described photos or only decorative ones.
+                "image_descriptions": _content_image_descriptions(it),
             }
             for it in items
         ],

--- a/tests/test_topic_synth.py
+++ b/tests/test_topic_synth.py
@@ -174,6 +174,46 @@ def test_export_topic_worksheet_omits_image_descriptions_when_none(tmp_path):
     assert payload["topics"][0]["image_descriptions"] == []
 
 
+def test_export_topic_worksheet_includes_video_transcripts(tmp_path):
+    """The topic worksheet carries `video_transcripts` so the claude-code topics
+    track synthesizes overviews from the same transcript evidence as the api track
+    — closes #56's transcript-to-topics half. The excerpts ride the `TopicInput`
+    already computed (and bounded) by `build_topic_inputs`."""
+    import json
+
+    from xbrain.topic_synth import export_topic_worksheet
+
+    inputs = [
+        TopicInput(
+            slug="ai-coding",
+            description="LLMs writing software",
+            summaries=["s1"],
+            video_transcripts=["A talk on retrieval-augmented agents.", "A live coding demo."],
+        )
+    ]
+    path = tmp_path / "topic-worksheet.json"
+    export_topic_worksheet(inputs, path, output_language="English")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["topics"][0]["video_transcripts"] == [
+        "A talk on retrieval-augmented agents.",
+        "A live coding demo.",
+    ]
+
+
+def test_export_topic_worksheet_omits_video_transcripts_when_none(tmp_path):
+    """A topic with no with-speech videos exports an empty `video_transcripts`
+    list — regression guard so the key is always present and clean."""
+    import json
+
+    from xbrain.topic_synth import export_topic_worksheet
+
+    inputs = [TopicInput(slug="x", description="d", summaries=["s1"])]
+    path = tmp_path / "topic-worksheet.json"
+    export_topic_worksheet(inputs, path, output_language="English")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["topics"][0]["video_transcripts"] == []
+
+
 def test_import_topic_worksheet_rejects_non_list_judgments(tmp_path):
     import json
 

--- a/tests/test_topic_synth.py
+++ b/tests/test_topic_synth.py
@@ -134,6 +134,46 @@ def test_export_and_import_topic_worksheet_round_trip(tmp_path):
     assert import_topic_worksheet(path) == []
 
 
+def test_export_topic_worksheet_includes_image_descriptions(tmp_path):
+    """The topic worksheet carries `image_descriptions` so the claude-code topics
+    track synthesizes overviews from the same visual evidence as the api track —
+    closing the #34 gap. The descriptions ride the `TopicInput` already computed
+    by `build_topic_inputs`."""
+    import json
+
+    from xbrain.topic_synth import export_topic_worksheet
+
+    inputs = [
+        TopicInput(
+            slug="ai-coding",
+            description="LLMs writing software",
+            summaries=["s1"],
+            image_descriptions=["A flowchart of a feedback loop.", "Code in a terminal."],
+        )
+    ]
+    path = tmp_path / "topic-worksheet.json"
+    export_topic_worksheet(inputs, path, output_language="English")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["topics"][0]["image_descriptions"] == [
+        "A flowchart of a feedback loop.",
+        "Code in a terminal.",
+    ]
+
+
+def test_export_topic_worksheet_omits_image_descriptions_when_none(tmp_path):
+    """A topic with no content-bearing photos exports an empty `image_descriptions`
+    list — regression guard so the key is always present and clean."""
+    import json
+
+    from xbrain.topic_synth import export_topic_worksheet
+
+    inputs = [TopicInput(slug="x", description="d", summaries=["s1"])]
+    path = tmp_path / "topic-worksheet.json"
+    export_topic_worksheet(inputs, path, output_language="English")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["topics"][0]["image_descriptions"] == []
+
+
 def test_import_topic_worksheet_rejects_non_list_judgments(tmp_path):
     import json
 

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -142,7 +142,15 @@ def test_export_worksheet_includes_image_descriptions(tmp_path):
 
 def test_export_worksheet_omits_decorative_image_descriptions(tmp_path):
     """A decorative-only item carries no image descriptions — avatars / reaction
-    memes are filtered at the same seam the api path uses, so no topic noise."""
+    memes are filtered at the same seam the api path uses, so no topic noise.
+
+    Note: this exercises the filter's decorative exclusion only *indirectly*. The
+    model invariant `is_decorative => description == ""` (enforced by
+    `MediaPhotoDescribed`) makes a decorative-photo-with-nonempty-description
+    unconstructable, so the filter's `not is_decorative` clause and its
+    empty-description backstop can't be told apart by a test — either one alone
+    excludes this photo. Both clauses are kept for defence in depth.
+    """
     path = tmp_path / "ws.json"
     export_worksheet(
         [_photo_item("1", _described_photo(description="ignored", decorative=True))],

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -86,6 +86,87 @@ def test_import_worksheet_rejects_non_list_judgments(tmp_path):
     assert "must be a list" in str(exc_info.value)
 
 
+def _described_photo(*, description: str, decorative: bool = False):
+    """Build a `MediaPhotoDescribed` for the worksheet image tests (#34).
+
+    Mirrors the api-executor test helper: `MediaPhotoDescribed` enforces
+    `is_decorative => description == ""` at the model layer, so the
+    `description` argument is dropped in the decorative branch.
+    """
+    from xbrain.models import MediaPhotoDescribed
+
+    return MediaPhotoDescribed(
+        url="https://pbs.twimg.com/media/X.jpg",
+        local_path="1/0.jpg",
+        width=4,
+        height=3,
+        bytes_size=512,
+        downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        is_decorative=decorative,
+        description="" if decorative else description,
+        description_lang="English",
+        description_version="v1",
+        described_at=datetime(2026, 5, 24, 12, tzinfo=timezone.utc),
+    )
+
+
+def _photo_item(item_id: str, *photos) -> Item:
+    """An item carrying described photos (#34)."""
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="a", name="A"),
+        text="post text",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        media=list(photos),
+    )
+
+
+def test_export_worksheet_includes_image_descriptions(tmp_path):
+    """A content-bearing described photo surfaces under `image_descriptions` so
+    the manual/claude-code enrich track sees the same visual signal the api
+    track injects as `Images in this post:` — closing the #34 gap."""
+    path = tmp_path / "ws.json"
+    export_worksheet(
+        [_photo_item("1", _described_photo(description="A chart of MMLU scores."))],
+        VOCAB,
+        path,
+        "manual",
+        "English",
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["image_descriptions"] == ["A chart of MMLU scores."]
+
+
+def test_export_worksheet_omits_decorative_image_descriptions(tmp_path):
+    """A decorative-only item carries no image descriptions — avatars / reaction
+    memes are filtered at the same seam the api path uses, so no topic noise."""
+    path = tmp_path / "ws.json"
+    export_worksheet(
+        [_photo_item("1", _described_photo(description="ignored", decorative=True))],
+        VOCAB,
+        path,
+        "manual",
+        "English",
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["image_descriptions"] == []
+
+
+def test_export_worksheet_omits_image_descriptions_when_no_described_photos(tmp_path):
+    """An item with no described photos is unchanged: an empty image list.
+
+    Regression guard so an item that never went through `xbrain describe`
+    exports a clean, empty `image_descriptions` rather than a missing key.
+    """
+    path = tmp_path / "ws.json"
+    export_worksheet([_item("1")], VOCAB, path, "manual", "English")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["image_descriptions"] == []
+
+
 def _video_item(item_id: str, *, text: str, has_speech: bool = True) -> Item:
     """An item carrying an `x_video` transcript content source (#44)."""
     from xbrain.models import Content, ContentSourceSuccess

--- a/tests/test_worksheet_consumer_wiring.py
+++ b/tests/test_worksheet_consumer_wiring.py
@@ -1,0 +1,43 @@
+# tests/test_worksheet_consumer_wiring.py
+"""Guard the claude-code *consumers* of the topic worksheet (#34, #56).
+
+The producer tests (`test_topic_synth.py`) prove `export_topic_worksheet`
+EMITS `image_descriptions` and `video_transcripts`. They cannot catch a
+consumer that silently drops those fields — and a dropped field means the
+claude-code topics track never sees the evidence, which is exactly the bug
+this branch fixes. These text-level assertions fail if a future edit removes
+the new fields from either consumer artifact (the resynth workflow's per-topic
+extraction command / prompt, or the skill's field list).
+"""
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_WORKFLOW = _REPO_ROOT / ".claude/workflows/resynth-topic-overviews.js"
+_SKILL = _REPO_ROOT / ".claude/skills/enriching-x-knowledge/SKILL.md"
+
+
+def test_resynth_workflow_extracts_new_evidence_fields():
+    """The resynth workflow's per-topic extraction MUST print the new evidence.
+
+    The agent is told to work ONLY with what the command prints ("No leas otros
+    ficheros"), so a field absent from the extraction is invisible to it.
+    """
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert "image_descriptions" in text
+    assert "video_transcripts" in text
+
+
+def test_resynth_workflow_prompts_for_new_evidence_blocks():
+    """The agent prompt must name the new evidence so the LLM weighs it."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert "Images across" in text
+    assert "Video transcripts across" in text
+
+
+def test_skill_lists_new_topic_evidence_fields():
+    """The skill's topic-object field list MUST mention the new fields, else a
+    session driving the flow by hand never reads them."""
+    text = _SKILL.read_text(encoding="utf-8")
+    assert "image_descriptions" in text
+    assert "video_transcripts" in text


### PR DESCRIPTION
Closes #34.

## Problem
`xbrain describe` produces a prose description for every content-bearing photo, and the **API** enrich/topics executors already inject them ("Images in this post:" / "Images across the N content-bearing photos in this topic"). But the **worksheet** (`claude-code` / `manual`) tracks dropped them — so on a subscription-only pipeline (where *all* items are enriched via the claude-code track) the 817 non-decorative descriptions reached neither the enrich judgments nor the topic overviews. Image-only knowledge stayed undiscoverable.

## What this does — producer + consumer wiring
Mirror the API path into the worksheet tracks, end to end (produce **and** consume), so the descriptions reach the LLM on the claude-code track, not just the API track.

**Producers (worksheet exporters):**
- `worksheet.export_worksheet` — each item entry now carries an `image_descriptions` list, reusing `executors.api._content_image_descriptions` (shared, not duplicated) so the non-decorative selection is byte-identical to the API path's section.
- `topic_synth.export_topic_worksheet` — each topic entry now carries `image_descriptions` (and `video_transcripts`, see #56 below) from the `TopicInput` already computed + decorative-filtered by `topics.build_topic_inputs`.

**Consumers (the claude-code topics track — the real Critical the panel caught):**
- `.claude/workflows/resynth-topic-overviews.js` — the per-topic extraction command now prints `image_descriptions` + `video_transcripts`, and the agent prompt (PASO 1/2/3) gained "Images across…" / "Video transcripts across…" evidence blocks mirroring `topic_synth._user_prompt`. The agent is told to use only what the command prints, so the fields must be in that output.
- `.claude/skills/enriching-x-knowledge/SKILL.md` — the topic-object field list now names `image_descriptions` + `video_transcripts`, and the session is instructed to weigh them as visual/transcript evidence.

## Also closes the transcript-to-topics half of #56
`export_topic_worksheet` also dropped `video_transcripts` (already on `TopicInput`, injected by the API topic path). Folded the symmetric fix through the same producer + consumer path. Frame-descriptions→topics remains for #56 (frames aren't on `TopicInput`).

## Guard
`tests/test_worksheet_consumer_wiring.py` — text-level regression asserting the workflow extraction/prompt and the skill field list carry BOTH `image_descriptions` and `video_transcripts`. Producer tests structurally can't catch a consumer that silently drops a field; this fails if a future edit removes them.

## Tests & gate
TDD throughout (every new assertion watched fail first). Full `bash scripts/check.sh` GREEN — ruff/format/mypy, radon A/B, bandit/vulture/interrogate/detect-secrets/deptry, **925 tests**, coverage **94%**.

## Propagation note (out of scope; run separately)
This is wiring: the descriptions flow whenever `enrich` / `topics` next run for an item. Back-filling the 817 descriptions onto already-enriched items is a one-time forced re-run (real LLM cost): `xbrain vocab --regenerate` (clears enrichments) → `xbrain enrich`, and `xbrain topics --resynth`. No auto-re-enrich trigger added.

Did NOT touch the API path (already correct) or the #44 video code beyond the single `export_topic_worksheet` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)