### PR TITLE
fix(digest): handle silent (no-audio) videos instead of failing them (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,11 +453,19 @@ uv tool install mlx-vlm
 
 # 3. Point config.toml at them (absolute paths survive any PATH):
 #    [transcribe]
-#    command = "/Users/<you>/.local/bin/parakeet-mlx"
+#    command = "/path/to/xbrain/scripts/xbrain-transcribe"   # wraps parakeet-mlx
 #    [vision]
 #    command = "/path/to/xbrain/scripts/xbrain-vision"
 #    model   = "qwen-3b"
 ```
+
+**Transcriber wrapper — `scripts/xbrain-transcribe`.** Points `[transcribe]` at a
+thin parakeet-mlx wrapper: parakeet writes no file for a video with **no audio
+track** (silent clips, GIFs, muted screencasts), which xbrain would otherwise
+count as a failure. The wrapper checks with `ffprobe` and emits the empty-speech
+JSON so such videos attach as `has_speech=false` ("silent video"), while a real
+parakeet failure on an audio-bearing file still surfaces. You can point
+`[transcribe].command` straight at `parakeet-mlx` if you don't need this.
 
 **Vision model selector — `scripts/xbrain-vision`.** One `[vision].command`
 serves both local and cloud models; the `--model` name is routed by a registry:

--- a/config.toml.example
+++ b/config.toml.example
@@ -62,7 +62,13 @@ version = "v1"
 # <TMPDIR>/<stem>.json ({"text", "language", "segments":[{start,end,text}]}).
 # Note: --language is NOT passed (parakeet auto-detects and rejects it). A wrapper
 # that emits JSON on stdout instead of a file is also supported.
+#
+# The bundled `scripts/xbrain-transcribe` wraps parakeet-mlx so videos with NO
+# audio track (silent clips, GIFs) attach as has_speech=false instead of failing
+# (parakeet writes no file for them). Point at the wrapper, or straight at
+# `parakeet-mlx` if you don't need silent-video handling.
 command = "parakeet-mlx"
+# command = "/absolute/path/to/scripts/xbrain-transcribe"
 # Optional model id passed through to the transcriber. Omit for the tool default.
 # model = "parakeet-tdt-0.6b-v2"
 

--- a/scripts/xbrain-transcribe
+++ b/scripts/xbrain-transcribe
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""xbrain `[transcribe].command` wrapper — parakeet-mlx + graceful no-audio handling.
+
+xbrain invokes `<cmd> [--model M] --output-format json --output-dir <DIR> <media>`
+and reads `<DIR>/<stem>.json`. parakeet-mlx writes that file when there is speech,
+but writes NOTHING for a video with no audio track (silent clips, GIFs, muted
+screencasts) — which xbrain then treats as a hard transcribe failure. This wrapper
+runs parakeet and, when it exits 0 but produced no file, uses `ffprobe` to check
+whether the media actually has an audio stream:
+
+  - no audio stream  → write the empty-speech JSON xbrain's contract expects, so
+    the video attaches as `has_speech=false` (a "silent video" note), not a failure.
+  - HAS an audio stream but parakeet still produced nothing → a REAL failure
+    (parakeet choked on audio); surface it (exit 1) rather than masking it as silent.
+
+A non-zero parakeet exit always propagates unchanged. `parakeet-mlx` is looked up
+on PATH; override with the `XBRAIN_PARAKEET` env var. Local, no API.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PARAKEET = os.environ.get("XBRAIN_PARAKEET", "parakeet-mlx")  # PATH lookup; override with the env var
+
+
+def _has_audio_stream(media: str) -> bool:
+    """True if ffprobe finds an audio stream in `media`.
+
+    Best-effort: if ffprobe is unavailable or the path is empty we cannot verify,
+    so we return False (treat as silent) — that preserves the primary goal of not
+    failing genuinely silent videos; ffprobe is present whenever `--frames` runs.
+    """
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe or not media:
+        return False
+    probe = subprocess.run(
+        [ffprobe, "-v", "error", "-select_streams", "a",
+         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
+        capture_output=True,
+        text=True,
+    )
+    return "audio" in probe.stdout
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    out_dir = "."
+    for i, a in enumerate(args):
+        if a == "--output-dir" and i + 1 < len(args):
+            out_dir = args[i + 1]
+    media = args[-1] if args else ""
+    rc = subprocess.run([PARAKEET, *args]).returncode
+    expected = Path(out_dir) / f"{Path(media).stem}.json"
+    if expected.exists():
+        return rc  # parakeet wrote the transcript; xbrain reads the file
+    if rc != 0:
+        return rc  # a genuine parakeet failure propagates unchanged
+    if _has_audio_stream(media):
+        # exit 0, no output, but the file HAS audio ⇒ real transcribe failure, not silent.
+        print(
+            f"xbrain-transcribe: parakeet produced no output for an audio-bearing file: {media}",
+            file=sys.stderr,
+        )
+        return 1
+    # exit 0, no output, no audio stream ⇒ genuinely silent video.
+    expected.parent.mkdir(parents=True, exist_ok=True)
+    expected.write_text(
+        json.dumps({"text": "", "language": None, "segments": [], "has_speech": False})
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/xbrain-transcribe
+++ b/scripts/xbrain-transcribe
@@ -2,47 +2,83 @@
 """xbrain `[transcribe].command` wrapper — parakeet-mlx + graceful no-audio handling.
 
 xbrain invokes `<cmd> [--model M] --output-format json --output-dir <DIR> <media>`
-and reads `<DIR>/<stem>.json`. parakeet-mlx writes that file when there is speech,
-but writes NOTHING for a video with no audio track (silent clips, GIFs, muted
-screencasts) — which xbrain then treats as a hard transcribe failure. This wrapper
-runs parakeet and, when it exits 0 but produced no file, uses `ffprobe` to check
-whether the media actually has an audio stream:
+and reads the transcript from the first NON-EMPTY `*.json` in `<DIR>`. parakeet-mlx
+writes that file when there is speech, but writes no usable output for a video with
+no audio track (silent clips, GIFs, muted screencasts) — which xbrain then treats
+as a hard transcribe failure. This wrapper runs parakeet and, when it produced no
+non-empty JSON, decides:
 
-  - no audio stream  → write the empty-speech JSON xbrain's contract expects, so
-    the video attaches as `has_speech=false` (a "silent video" note), not a failure.
-  - HAS an audio stream but parakeet still produced nothing → a REAL failure
-    (parakeet choked on audio); surface it (exit 1) rather than masking it as silent.
+  - `ffprobe` POSITIVELY confirms the media has no audio stream → write the
+    empty-speech JSON so the video attaches as `has_speech=false` (a "silent
+    video" note), not a failure.
+  - otherwise (audio present, OR ffprobe can't confirm) → a REAL failure; surface
+    it (exit 1) rather than masking it as silent.
 
-A non-zero parakeet exit always propagates unchanged. `parakeet-mlx` is looked up
-on PATH; override with the `XBRAIN_PARAKEET` env var. Local, no API.
+"Produced output" is judged the same way xbrain judges it — a non-empty `*.json`,
+by content, not by filename — so an empty stub file or an unexpected output name
+never fools the wrapper. A non-zero parakeet exit always propagates unchanged.
+`parakeet-mlx` is looked up on PATH (multi-token override via `XBRAIN_PARAKEET`,
+split with shlex). Local, no API.
 """
+
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
-PARAKEET = os.environ.get("XBRAIN_PARAKEET", "parakeet-mlx")  # PATH lookup; override with the env var
+# Multi-token so a wrapper command ("python -m my_asr") works like xbrain's own
+# shlex-split transcriber command; default is a bare PATH lookup of parakeet-mlx.
+PARAKEET_ARGV = shlex.split(os.environ.get("XBRAIN_PARAKEET", "parakeet-mlx"))
 
 
-def _has_audio_stream(media: str) -> bool:
-    """True if ffprobe finds an audio stream in `media`.
+def _has_nonempty_json(out_dir: Path) -> bool:
+    """True if `out_dir` holds any `*.json` with non-whitespace content.
 
-    Best-effort: if ffprobe is unavailable or the path is empty we cannot verify,
-    so we return False (treat as silent) — that preserves the primary goal of not
-    failing genuinely silent videos; ffprobe is present whenever `--frames` runs.
+    Mirrors xbrain's own reader (`sorted(dir.glob('*.json'))`, first non-empty),
+    so wrapper and consumer agree on what "parakeet produced a transcript" means.
+    """
+    for path in sorted(out_dir.glob("*.json")):
+        try:
+            if path.read_text().strip():
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _confirmed_no_audio(media: str) -> bool:
+    """True ONLY if ffprobe positively confirms `media` has no audio stream.
+
+    Unknown (ffprobe absent / errors / empty path) → False, so we never MASK a real
+    transcribe failure as "silent". A genuinely silent video is still classified
+    correctly whenever ffprobe is available — which it is throughout the digest
+    pipeline (`--frames` needs ffmpeg/ffprobe).
     """
     ffprobe = shutil.which("ffprobe")
     if not ffprobe or not media:
         return False
     probe = subprocess.run(
-        [ffprobe, "-v", "error", "-select_streams", "a",
-         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            media,
+        ],
         capture_output=True,
         text=True,
     )
-    return "audio" in probe.stdout
+    if probe.returncode != 0:
+        return False  # can't trust an empty result from a failed probe
+    return "audio" not in probe.stdout
 
 
 def main() -> int:
@@ -52,25 +88,24 @@ def main() -> int:
         if a == "--output-dir" and i + 1 < len(args):
             out_dir = args[i + 1]
     media = args[-1] if args else ""
-    rc = subprocess.run([PARAKEET, *args]).returncode
-    expected = Path(out_dir) / f"{Path(media).stem}.json"
-    if expected.exists():
-        return rc  # parakeet wrote the transcript; xbrain reads the file
+    rc = subprocess.run([*PARAKEET_ARGV, *args]).returncode
+    out = Path(out_dir)
+    if _has_nonempty_json(out):
+        return rc  # parakeet produced a transcript; xbrain reads it
     if rc != 0:
         return rc  # a genuine parakeet failure propagates unchanged
-    if _has_audio_stream(media):
-        # exit 0, no output, but the file HAS audio ⇒ real transcribe failure, not silent.
-        print(
-            f"xbrain-transcribe: parakeet produced no output for an audio-bearing file: {media}",
-            file=sys.stderr,
+    if _confirmed_no_audio(media):
+        out.mkdir(parents=True, exist_ok=True)
+        (out / f"{Path(media).stem}.json").write_text(
+            json.dumps({"text": "", "language": None, "segments": [], "has_speech": False})
         )
-        return 1
-    # exit 0, no output, no audio stream ⇒ genuinely silent video.
-    expected.parent.mkdir(parents=True, exist_ok=True)
-    expected.write_text(
-        json.dumps({"text": "", "language": None, "segments": [], "has_speech": False})
+        return 0
+    # exit 0, no transcript, and audio is present or unverifiable ⇒ real failure.
+    print(
+        f"xbrain-transcribe: parakeet produced no transcript for: {media}",
+        file=sys.stderr,
     )
-    return 0
+    return 1
 
 
 if __name__ == "__main__":

--- a/tests/test_xbrain_transcribe.py
+++ b/tests/test_xbrain_transcribe.py
@@ -1,0 +1,68 @@
+# tests/test_xbrain_transcribe.py — the scripts/xbrain-transcribe parakeet wrapper.
+import importlib.util
+import json
+import sys
+import types
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "xbrain-transcribe"
+_LOADER = SourceFileLoader("xbrain_transcribe", str(_PATH))
+_SPEC = importlib.util.spec_from_loader("xbrain_transcribe", _LOADER)
+xt = importlib.util.module_from_spec(_SPEC)
+_LOADER.exec_module(xt)
+
+
+def _run(monkeypatch, tmp_path, *, parakeet_rc, writes_file, has_audio):
+    """Drive main() with parakeet + ffprobe mocked; return (rc, expected_json_path)."""
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    expected = tmp_path / "clip.json"
+
+    def fake_run(cmd, *a, **k):
+        if writes_file and parakeet_rc == 0:  # parakeet "wrote" a real transcript
+            expected.write_text(
+                '{"text": "hola", "segments": [{"start": 0, "end": 1, "text": "hola"}]}'
+            )
+        return types.SimpleNamespace(returncode=parakeet_rc, stdout="", stderr="")
+
+    monkeypatch.setattr(xt.subprocess, "run", fake_run)
+    monkeypatch.setattr(xt, "_has_audio_stream", lambda m: has_audio)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["xbrain-transcribe", "--output-format", "json", "--output-dir", str(tmp_path), str(media)],
+    )
+    return xt.main(), expected
+
+
+def test_speech_passes_parakeet_output_through(monkeypatch, tmp_path):
+    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=0, writes_file=True, has_audio=True)
+    assert rc == 0
+    assert json.loads(expected.read_text())["text"] == "hola"  # not overwritten
+
+
+def test_silent_video_gets_empty_speech_json(monkeypatch, tmp_path):
+    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=0, writes_file=False, has_audio=False)
+    assert rc == 0
+    data = json.loads(expected.read_text())
+    assert data["has_speech"] is False and data["text"] == ""
+
+
+def test_audio_but_no_output_is_a_real_failure(monkeypatch, tmp_path):
+    # exit 0, no file, but the media HAS audio → parakeet choked → surface as failure.
+    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=0, writes_file=False, has_audio=True)
+    assert rc == 1
+    assert not expected.exists()  # never masked as silent
+
+
+def test_parakeet_nonzero_exit_propagates(monkeypatch, tmp_path):
+    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=2, writes_file=False, has_audio=False)
+    assert rc == 2
+    assert not expected.exists()
+
+
+def test_has_audio_stream_false_without_ffprobe(monkeypatch):
+    monkeypatch.setattr(xt.shutil, "which", lambda _: None)  # ffprobe unavailable
+    assert xt._has_audio_stream("/some/clip.mp4") is False
+    assert xt._has_audio_stream("") is False

--- a/tests/test_xbrain_transcribe.py
+++ b/tests/test_xbrain_transcribe.py
@@ -13,56 +13,117 @@ xt = importlib.util.module_from_spec(_SPEC)
 _LOADER.exec_module(xt)
 
 
-def _run(monkeypatch, tmp_path, *, parakeet_rc, writes_file, has_audio):
-    """Drive main() with parakeet + ffprobe mocked; return (rc, expected_json_path)."""
+def _run(monkeypatch, tmp_path, *, parakeet_rc, writes, confirmed_no_audio):
+    """Drive main() with parakeet + ffprobe mocked.
+
+    `writes` is what parakeet "produces": None (nothing), or a (filename, content)
+    tuple written to `tmp_path` (content "" simulates an empty stub file).
+    """
     media = tmp_path / "clip.mp4"
     media.write_bytes(b"x")
-    expected = tmp_path / "clip.json"
 
     def fake_run(cmd, *a, **k):
-        if writes_file and parakeet_rc == 0:  # parakeet "wrote" a real transcript
-            expected.write_text(
-                '{"text": "hola", "segments": [{"start": 0, "end": 1, "text": "hola"}]}'
-            )
+        if writes is not None and parakeet_rc == 0:
+            name, content = writes
+            (tmp_path / name).write_text(content)
         return types.SimpleNamespace(returncode=parakeet_rc, stdout="", stderr="")
 
     monkeypatch.setattr(xt.subprocess, "run", fake_run)
-    monkeypatch.setattr(xt, "_has_audio_stream", lambda m: has_audio)
+    monkeypatch.setattr(xt, "_confirmed_no_audio", lambda m: confirmed_no_audio)
     monkeypatch.setattr(
         sys,
         "argv",
         ["xbrain-transcribe", "--output-format", "json", "--output-dir", str(tmp_path), str(media)],
     )
-    return xt.main(), expected
+    return xt.main(), tmp_path
 
 
-def test_speech_passes_parakeet_output_through(monkeypatch, tmp_path):
-    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=0, writes_file=True, has_audio=True)
+def _only_json(d: Path) -> dict:
+    return json.loads(
+        next(p for p in sorted(d.glob("*.json")) if p.read_text().strip()).read_text()
+    )
+
+
+def test_speech_passes_parakeet_transcript_through(monkeypatch, tmp_path):
+    rc, d = _run(
+        monkeypatch,
+        tmp_path,
+        parakeet_rc=0,
+        writes=("clip.json", '{"text": "hola", "segments": []}'),
+        confirmed_no_audio=False,
+    )
     assert rc == 0
-    assert json.loads(expected.read_text())["text"] == "hola"  # not overwritten
+    assert _only_json(d)["text"] == "hola"  # not overwritten
 
 
-def test_silent_video_gets_empty_speech_json(monkeypatch, tmp_path):
-    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=0, writes_file=False, has_audio=False)
+def test_transcript_detected_regardless_of_output_filename(monkeypatch, tmp_path):
+    # xbrain globs *.json by content, not <stem>.json — a differently-named non-empty
+    # file must still count as "parakeet produced a transcript" (no false failure).
+    rc, d = _run(
+        monkeypatch,
+        tmp_path,
+        parakeet_rc=0,
+        writes=("weird-name.json", '{"text": "hi"}'),
+        confirmed_no_audio=False,
+    )
     assert rc == 0
-    data = json.loads(expected.read_text())
+
+
+def test_confirmed_silent_gets_empty_speech_json(monkeypatch, tmp_path):
+    rc, d = _run(monkeypatch, tmp_path, parakeet_rc=0, writes=None, confirmed_no_audio=True)
+    assert rc == 0
+    data = _only_json(d)
     assert data["has_speech"] is False and data["text"] == ""
 
 
-def test_audio_but_no_output_is_a_real_failure(monkeypatch, tmp_path):
-    # exit 0, no file, but the media HAS audio → parakeet choked → surface as failure.
-    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=0, writes_file=False, has_audio=True)
+def test_empty_stub_json_is_not_treated_as_output(monkeypatch, tmp_path):
+    # parakeet writes a 0-content stub → must NOT count as a transcript; the silent
+    # path runs and replaces it with the empty-speech JSON (finding #1).
+    rc, d = _run(
+        monkeypatch, tmp_path, parakeet_rc=0, writes=("clip.json", "   "), confirmed_no_audio=True
+    )
+    assert rc == 0
+    assert _only_json(d)["has_speech"] is False
+
+
+def test_audio_or_unverifiable_is_a_real_failure(monkeypatch, tmp_path):
+    # exit 0, no transcript, ffprobe did NOT confirm silence → real failure, not masked.
+    rc, d = _run(monkeypatch, tmp_path, parakeet_rc=0, writes=None, confirmed_no_audio=False)
     assert rc == 1
-    assert not expected.exists()  # never masked as silent
+    assert not any(p.read_text().strip() for p in d.glob("*.json"))  # nothing written
 
 
 def test_parakeet_nonzero_exit_propagates(monkeypatch, tmp_path):
-    rc, expected = _run(monkeypatch, tmp_path, parakeet_rc=2, writes_file=False, has_audio=False)
+    rc, d = _run(monkeypatch, tmp_path, parakeet_rc=2, writes=None, confirmed_no_audio=True)
     assert rc == 2
-    assert not expected.exists()
+    assert not list(d.glob("*.json"))
 
 
-def test_has_audio_stream_false_without_ffprobe(monkeypatch):
-    monkeypatch.setattr(xt.shutil, "which", lambda _: None)  # ffprobe unavailable
-    assert xt._has_audio_stream("/some/clip.mp4") is False
-    assert xt._has_audio_stream("") is False
+def _fake_ffprobe(monkeypatch, *, returncode, stdout, has_ffprobe=True):
+    monkeypatch.setattr(xt.shutil, "which", lambda _: "/usr/bin/ffprobe" if has_ffprobe else None)
+    monkeypatch.setattr(
+        xt.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr=""),
+    )
+
+
+def test_confirmed_no_audio_true_when_ffprobe_finds_no_audio(monkeypatch):
+    _fake_ffprobe(monkeypatch, returncode=0, stdout="")
+    assert xt._confirmed_no_audio("/x/clip.mp4") is True
+
+
+def test_confirmed_no_audio_false_when_audio_present(monkeypatch):
+    _fake_ffprobe(monkeypatch, returncode=0, stdout="audio\n")
+    assert xt._confirmed_no_audio("/x/clip.mp4") is False
+
+
+def test_confirmed_no_audio_false_when_ffprobe_errors(monkeypatch):
+    _fake_ffprobe(monkeypatch, returncode=1, stdout="")  # can't trust → not silent
+    assert xt._confirmed_no_audio("/x/clip.mp4") is False
+
+
+def test_confirmed_no_audio_false_without_ffprobe_or_path(monkeypatch):
+    _fake_ffprobe(monkeypatch, returncode=0, stdout="", has_ffprobe=False)
+    assert xt._confirmed_no_audio("/x/clip.mp4") is False
+    assert xt._confirmed_no_audio("") is False


### PR DESCRIPTION
## Diagnosis
Many "transcription failed" videos in the corpus are simply **silent** — no audio track at the source (muted clips, GIFs, screencasts). Verified rigorously: `ffprobe` on the complete download shows only a video stream, and `yt-dlp -f bestaudio` errors ("no audio format") on 4/4 checked videos — ruling out the "audio is a separate HLS/DASH stream that xbrain's raw-mp4 fetch missed" hypothesis. parakeet-mlx writes no output file for these, which xbrain's transcribe contract treats as a hard failure — even though xbrain's own design wants them attached as `has_speech=false` ("silent video" note).

## Fix
`scripts/xbrain-transcribe` wraps parakeet-mlx. When parakeet exits 0 but wrote no file, it `ffprobe`-checks the media:
- **no audio stream** → emit the empty-speech JSON → attaches as `has_speech=false` (silent video).
- **has audio but no output** → surface as a **real failure** (parakeet choked) — not masked as silent.
Non-zero parakeet exit propagates unchanged. Local, no API.

Validated on real data: the 5 videos that failed before now land as `sin voz 5, fallidos 0`, and 3 of them still got slide-frame descriptions.

## Tests
`tests/test_xbrain_transcribe.py` locks all 4 branches + the no-ffprobe fallback.