### PR TITLE
feat(digest): dedupe near-duplicate slide frames + configurable [frames] (frames-redesign PR-A)

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -91,3 +91,14 @@ command = "parakeet-mlx"
 #   cloud (needs ANTHROPIC_API_KEY):      opus | sonnet | haiku | claude-<id>
 # command = "/absolute/path/to/scripts/xbrain-vision"
 # model = "qwen-3b"                       # omit → the wrapper's default (qwen-3b)
+
+[frames]
+# `digest-video --frames` key-frame extraction. Pipeline: ffmpeg (scene-change +
+# interval) → dedupe (perceptual hash drops near-identical held slides) → cap.
+# dedupe is the real reducer, so the budget covers DISTINCT slides; max_frames is
+# a safety ceiling for a pathological continuous-motion clip.
+# max_frames       = 60      # safety ceiling AFTER dedup
+# scene_threshold  = 0.4     # ffmpeg scene-change sensitivity (higher = fewer cuts)
+# interval_seconds = 15      # also keep a frame every N s (covers static tails)
+# dedupe           = true    # perceptual-hash near-duplicate removal
+# dedupe_distance  = 6        # max dHash Hamming distance to call two frames "same" (0-64)

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -66,8 +66,6 @@ from xbrain.video_fetch import (
     format_fetch_summary,
 )
 from xbrain.video_frames import (
-    DEFAULT_MAX_FRAMES,
-    DEFAULT_SCENE_THRESHOLD,
     KeyFrame,
     extract_key_frames,
 )
@@ -1142,7 +1140,12 @@ def _build_visual_config(cfg: Config, vision_model: str | None = None) -> Visual
 
     def _extract(path: Path) -> list[KeyFrame]:
         return extract_key_frames(
-            path, threshold=DEFAULT_SCENE_THRESHOLD, max_frames=DEFAULT_MAX_FRAMES
+            path,
+            threshold=cfg.frames_scene_threshold,
+            max_frames=cfg.frames_max_frames,
+            interval_seconds=cfg.frames_interval_seconds,
+            dedupe=cfg.frames_dedupe,
+            dedupe_distance=cfg.frames_dedupe_distance,
         )
 
     def _describe(path: Path) -> str:

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -68,6 +68,7 @@ from xbrain.video_fetch import (
 from xbrain.video_frames import (
     KeyFrame,
     extract_key_frames,
+    select_frames,
 )
 from xbrain.video_media import (
     VideoDownloadPlan,
@@ -1139,19 +1140,29 @@ def _build_visual_config(cfg: Config, vision_model: str | None = None) -> Visual
     model = vision_model or cfg.vision_model
 
     def _extract(path: Path) -> list[KeyFrame]:
+        # RAW frames (cap=False): classification runs on the full distribution; the
+        # reduce step below dedupes + caps only what the vision model describes.
         return extract_key_frames(
             path,
             threshold=cfg.frames_scene_threshold,
-            max_frames=cfg.frames_max_frames,
             interval_seconds=cfg.frames_interval_seconds,
+            cap=False,
+        )
+
+    def _reduce(frames: list[KeyFrame]) -> list[KeyFrame]:
+        return select_frames(
+            frames,
             dedupe=cfg.frames_dedupe,
             dedupe_distance=cfg.frames_dedupe_distance,
+            max_frames=cfg.frames_max_frames,
         )
 
     def _describe(path: Path) -> str:
         return describe_image(path, command=cfg.vision_command, model=model)
 
-    return VisualConfig(media_root=cfg.media_dir, extract_fn=_extract, describe_fn=_describe)
+    return VisualConfig(
+        media_root=cfg.media_dir, extract_fn=_extract, describe_fn=_describe, reduce_fn=_reduce
+    )
 
 
 def _run_digest_video(

--- a/src/xbrain/config.py
+++ b/src/xbrain/config.py
@@ -9,6 +9,12 @@ from typing import get_args
 
 from xbrain.i18n import strings_for
 from xbrain.models import ExecutorName
+from xbrain.video_frames import (
+    DEFAULT_DEDUPE_DISTANCE,
+    DEFAULT_INTERVAL_SECONDS,
+    DEFAULT_MAX_FRAMES,
+    DEFAULT_SCENE_THRESHOLD,
+)
 
 # In-body `**Topics:**` line styles. `wikilink` (default) keeps the current
 # navigation-first behaviour; `hashtag` emits Obsidian tags so the line pivots
@@ -57,6 +63,13 @@ class Config:
     # (`None` → the vision tool's own default).
     vision_command: str
     vision_model: str | None
+    # `[frames]` — the `digest-video --frames` visual layer. Defaults live in
+    # `xbrain.video_frames`. Pipeline: extract → dedupe (perceptual hash) → cap.
+    frames_max_frames: int
+    frames_scene_threshold: float
+    frames_interval_seconds: float
+    frames_dedupe: bool
+    frames_dedupe_distance: int
 
     @property
     def items_path(self) -> Path:
@@ -126,6 +139,13 @@ def load_config(repo_root: Path) -> Config:
     describe = settings.get("describe", {})
     transcribe = settings.get("transcribe", {})
     vision = settings.get("vision", {})
+    frames = settings.get("frames", {})
+    frames_max_frames = int(frames.get("max_frames", DEFAULT_MAX_FRAMES))
+    if frames_max_frames < 1:
+        raise ValueError("config.toml: [frames].max_frames must be >= 1")
+    frames_dedupe_distance = int(frames.get("dedupe_distance", DEFAULT_DEDUPE_DISTANCE))
+    if frames_dedupe_distance < 0:
+        raise ValueError("config.toml: [frames].dedupe_distance must be >= 0")
     return Config(
         repo_root=repo_root,
         vault=vault,
@@ -144,4 +164,9 @@ def load_config(repo_root: Path) -> Config:
         transcribe_model=transcribe.get("model"),
         vision_command=vision.get("command", ""),
         vision_model=vision.get("model"),
+        frames_max_frames=frames_max_frames,
+        frames_scene_threshold=float(frames.get("scene_threshold", DEFAULT_SCENE_THRESHOLD)),
+        frames_interval_seconds=float(frames.get("interval_seconds", DEFAULT_INTERVAL_SECONDS)),
+        frames_dedupe=bool(frames.get("dedupe", True)),
+        frames_dedupe_distance=frames_dedupe_distance,
     )

--- a/src/xbrain/config.py
+++ b/src/xbrain/config.py
@@ -146,6 +146,14 @@ def load_config(repo_root: Path) -> Config:
     frames_dedupe_distance = int(frames.get("dedupe_distance", DEFAULT_DEDUPE_DISTANCE))
     if frames_dedupe_distance < 0:
         raise ValueError("config.toml: [frames].dedupe_distance must be >= 0")
+    frames_scene_threshold = float(frames.get("scene_threshold", DEFAULT_SCENE_THRESHOLD))
+    if not 0.0 <= frames_scene_threshold <= 1.0:
+        raise ValueError("config.toml: [frames].scene_threshold must be in [0.0, 1.0]")
+    frames_interval_seconds = float(frames.get("interval_seconds", DEFAULT_INTERVAL_SECONDS))
+    if frames_interval_seconds <= 0:
+        raise ValueError(
+            "config.toml: [frames].interval_seconds must be > 0 (0 selects every frame)"
+        )
     return Config(
         repo_root=repo_root,
         vault=vault,
@@ -165,8 +173,8 @@ def load_config(repo_root: Path) -> Config:
         vision_command=vision.get("command", ""),
         vision_model=vision.get("model"),
         frames_max_frames=frames_max_frames,
-        frames_scene_threshold=float(frames.get("scene_threshold", DEFAULT_SCENE_THRESHOLD)),
-        frames_interval_seconds=float(frames.get("interval_seconds", DEFAULT_INTERVAL_SECONDS)),
+        frames_scene_threshold=frames_scene_threshold,
+        frames_interval_seconds=frames_interval_seconds,
         frames_dedupe=bool(frames.get("dedupe", True)),
         frames_dedupe_distance=frames_dedupe_distance,
     )

--- a/src/xbrain/digest.py
+++ b/src/xbrain/digest.py
@@ -69,6 +69,16 @@ TranscribeFn = Callable[[Path], Transcript]
 ExtractFn = Callable[[Path], list[KeyFrame]]
 DescribeFn = Callable[[Path], str]
 ClassifyFn = Callable[[list[KeyFrame]], str]
+# `reduce_fn` runs on the RAW extracted frames AFTER classification (so dedup can't
+# skew the slides-vs-talking-head vote) and BEFORE describe — it dedupes + caps the
+# set the vision model actually captions. Default = identity (describe them all).
+ReduceFn = Callable[[list[KeyFrame]], list[KeyFrame]]
+
+
+def _no_reduce(frames: list[KeyFrame]) -> list[KeyFrame]:
+    """Default `reduce_fn` — identity (describe every frame `extract_fn` returned)."""
+    return frames
+
 
 # The per-video visual-layer outcome. `disabled` = no `--frames`; `slides` = kept
 # + described + embedded (counts as a "with slides" video); `talking_head` = a
@@ -93,6 +103,7 @@ class VisualConfig:
     extract_fn: ExtractFn
     describe_fn: DescribeFn
     classify_fn: ClassifyFn = classify_visual
+    reduce_fn: ReduceFn = _no_reduce
 
 
 @dataclass(frozen=True)
@@ -371,6 +382,8 @@ def _extract_described_slides(path: Path, visual: VisualConfig, *, item_id: str)
             item_id,
         )
         return _VisualResult(classification="skipped")
+    # Classification saw the RAW frames; now dedupe + cap only the describe set.
+    frames = visual.reduce_fn(frames)
     try:
         slides = [
             _DescribedSlide(frame.timestamp, frame.path, visual.describe_fn(frame.path))

--- a/src/xbrain/video_frames.py
+++ b/src/xbrain/video_frames.py
@@ -73,10 +73,18 @@ DEFAULT_FFMPEG_COMMAND = "ffmpeg"
 # enough to catch a slide transition.
 DEFAULT_SCENE_THRESHOLD = 0.4
 
-# Upper bound on kept frames. A 72-min slide deck can yield hundreds of scene +
-# interval samples; 40 is enough to represent a talk's slides without bloating
-# the note or the vision-call budget.
-DEFAULT_MAX_FRAMES = 40
+# SAFETY ceiling on kept frames — applied AFTER perceptual dedup, which is the
+# real reducer. Dedup drops near-identical slides so the budget covers DISTINCT
+# ones; this cap only stops a pathological continuous-motion clip (gameplay) from
+# emitting hundreds of frames. Raise it (`[frames].max_frames`) for very long decks.
+DEFAULT_MAX_FRAMES = 60
+
+# Perceptual-hash (dHash) near-duplicate removal. Two frames whose 64-bit dHashes
+# differ by <= this Hamming distance are "the same slide" — the later one is
+# dropped. 6/64 tolerates JPEG/scale noise + a cursor/laser-pointer moving on a
+# held slide, without merging two genuinely different slides.
+DEFAULT_DEDUPE_DISTANCE = 6
+_DHASH_SIZE = 8  # 8x8 difference hash → 64-bit fingerprint
 
 # The periodic interval (seconds) for the static-tail fallback: the `select`
 # filter also keeps a frame whenever this long has elapsed since the last kept
@@ -251,12 +259,61 @@ def _cap_evenly(frames: list[KeyFrame], max_frames: int) -> list[KeyFrame]:
     return [frames[index] for index in indices]
 
 
+def _dhash(path: Path, hash_size: int = _DHASH_SIZE) -> int | None:
+    """Perceptual difference-hash of a frame as an int, or None if unreadable.
+
+    Downscales to (hash_size+1) x hash_size grayscale and encodes each row's
+    left>right gradient as one bit — a compact fingerprint robust to scale / JPEG
+    noise. Reads bytes fully before decode (same cold-FS guard as `_edge_density`).
+    """
+    try:
+        with Image.open(io.BytesIO(path.read_bytes())) as img:
+            small = img.convert("L").resize((hash_size + 1, hash_size), Image.Resampling.LANCZOS)
+    except (OSError, ValueError) as exc:
+        logger.warning("digest-video: could not hash frame %s for dedup: %s", path, exc)
+        return None
+    px = small.tobytes()  # "L" mode → one byte per pixel, row-major (width = hash_size+1)
+    bits = 0
+    for row in range(hash_size):
+        base = row * (hash_size + 1)
+        for col in range(hash_size):
+            bits = (bits << 1) | int(px[base + col] > px[base + col + 1])
+    return bits
+
+
+def _hamming(a: int, b: int) -> int:
+    return (a ^ b).bit_count()
+
+
+def dedupe_frames(
+    frames: list[KeyFrame], *, max_distance: int = DEFAULT_DEDUPE_DISTANCE
+) -> list[KeyFrame]:
+    """Drop consecutive near-duplicate frames (a held slide) by perceptual hash.
+
+    Keeps a frame when its dHash differs from the LAST KEPT frame's by more than
+    `max_distance` bits — so a slide held across several interval samples costs one
+    kept frame, not many, and the frame budget covers DISTINCT slides. An
+    unreadable frame is kept (never silently dropped) and resets the comparison.
+    Order-preserving.
+    """
+    kept: list[KeyFrame] = []
+    last_hash: int | None = None
+    for frame in frames:
+        h = _dhash(frame.path)
+        if h is None or last_hash is None or _hamming(h, last_hash) > max_distance:
+            kept.append(frame)
+            last_hash = h
+    return kept
+
+
 def extract_key_frames(
     video_path: Path | str,
     *,
     threshold: float = DEFAULT_SCENE_THRESHOLD,
     max_frames: int = DEFAULT_MAX_FRAMES,
     interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
+    dedupe: bool = True,
+    dedupe_distance: int = DEFAULT_DEDUPE_DISTANCE,
     command: str = DEFAULT_FFMPEG_COMMAND,
     runner: Runner | None = None,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
@@ -265,10 +322,13 @@ def extract_key_frames(
 
     Combines scene-change detection (`threshold`) with periodic interval sampling
     (`interval_seconds`) in ONE ffmpeg `select` pass, so extraction covers the
-    WHOLE video — including a long static tail — not just the front. The result is
-    subsampled EVENLY to at most `max_frames` (front + tail preserved). Frames are
-    written under a temp subdir of the video's parent and returned as `KeyFrame`s;
-    the CALLER owns cleanup (the digest's ephemeral temp dir reclaims them).
+    WHOLE video — including a long static tail — not just the front. The pipeline
+    is **extract → dedupe → cap**: `dedupe` (default on) drops near-identical
+    consecutive frames (a held slide) by perceptual hash so the budget covers
+    DISTINCT slides, then the result is subsampled EVENLY to at most `max_frames`
+    (a safety ceiling; front + tail preserved). Frames are written under a temp
+    subdir of the video's parent and returned as `KeyFrame`s; the CALLER owns
+    cleanup (the digest's ephemeral temp dir reclaims them).
 
     A missing ffmpeg raises `FrameExtractionToolNotFound` (aborts the run); a
     non-zero exit / timeout raises `FrameExtractionFailed` (per-video — the digest
@@ -283,6 +343,10 @@ def extract_key_frames(
     argv = _build_argv(command, video, out_pattern, select_expr)
     stderr = _run_ffmpeg(argv, active_runner, timeout_seconds)
     frames = _pair_frames(out_dir, _parse_timestamps(stderr))
+    if dedupe:
+        before = len(frames)
+        frames = dedupe_frames(frames, max_distance=dedupe_distance)
+        logger.debug("digest-video: dedup kept %d/%d frames", len(frames), before)
     return _cap_evenly(frames, max_frames)
 
 

--- a/src/xbrain/video_frames.py
+++ b/src/xbrain/video_frames.py
@@ -312,8 +312,7 @@ def extract_key_frames(
     threshold: float = DEFAULT_SCENE_THRESHOLD,
     max_frames: int = DEFAULT_MAX_FRAMES,
     interval_seconds: float = DEFAULT_INTERVAL_SECONDS,
-    dedupe: bool = True,
-    dedupe_distance: int = DEFAULT_DEDUPE_DISTANCE,
+    cap: bool = True,
     command: str = DEFAULT_FFMPEG_COMMAND,
     runner: Runner | None = None,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
@@ -322,13 +321,13 @@ def extract_key_frames(
 
     Combines scene-change detection (`threshold`) with periodic interval sampling
     (`interval_seconds`) in ONE ffmpeg `select` pass, so extraction covers the
-    WHOLE video — including a long static tail — not just the front. The pipeline
-    is **extract → dedupe → cap**: `dedupe` (default on) drops near-identical
-    consecutive frames (a held slide) by perceptual hash so the budget covers
-    DISTINCT slides, then the result is subsampled EVENLY to at most `max_frames`
-    (a safety ceiling; front + tail preserved). Frames are written under a temp
-    subdir of the video's parent and returned as `KeyFrame`s; the CALLER owns
-    cleanup (the digest's ephemeral temp dir reclaims them).
+    WHOLE video — including a long static tail — not just the front. When `cap` is
+    on (default) the result is subsampled EVENLY to at most `max_frames` (front +
+    tail preserved); the digest passes `cap=False` to get the RAW set so it can
+    **classify slides-vs-talking-head on the raw distribution** and dedupe/cap only
+    the describe path (`select_frames`). Frames are written under a temp subdir of
+    the video's parent and returned as `KeyFrame`s; the CALLER owns cleanup (the
+    digest's ephemeral temp dir reclaims them).
 
     A missing ffmpeg raises `FrameExtractionToolNotFound` (aborts the run); a
     non-zero exit / timeout raises `FrameExtractionFailed` (per-video — the digest
@@ -343,11 +342,38 @@ def extract_key_frames(
     argv = _build_argv(command, video, out_pattern, select_expr)
     stderr = _run_ffmpeg(argv, active_runner, timeout_seconds)
     frames = _pair_frames(out_dir, _parse_timestamps(stderr))
+    return _cap_evenly(frames, max_frames) if cap else frames
+
+
+def select_frames(
+    frames: list[KeyFrame],
+    *,
+    dedupe: bool = True,
+    dedupe_distance: int = DEFAULT_DEDUPE_DISTANCE,
+    max_frames: int = DEFAULT_MAX_FRAMES,
+) -> list[KeyFrame]:
+    """Reduce RAW key frames for the describe path: dedupe near-dups, then cap.
+
+    Runs AFTER slide/talking-head classification so dedup never skews that vote
+    (which frames the vision model actually describes is a separate decision from
+    what the video *is*). `dedupe` drops near-identical held slides so the budget
+    covers DISTINCT slides; `max_frames` is a safety ceiling (a genuine deck with
+    more distinct slides than the ceiling loses some to even subsampling — WARNED,
+    not silent).
+    """
     if dedupe:
         before = len(frames)
         frames = dedupe_frames(frames, max_distance=dedupe_distance)
         logger.debug("digest-video: dedup kept %d/%d frames", len(frames), before)
-    return _cap_evenly(frames, max_frames)
+    capped = _cap_evenly(frames, max_frames)
+    if len(capped) < len(frames):
+        logger.warning(
+            "digest-video: capped %d distinct frames to max_frames=%d — raise "
+            "[frames].max_frames to describe them all",
+            len(frames),
+            max_frames,
+        )
+    return capped
 
 
 def _edge_density(path: Path) -> float | None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2474,14 +2474,21 @@ def _setup_repo_with_vision(tmp_path: Path, monkeypatch, command: str = "vlm-des
 
 
 def _write_slide_png(path: Path) -> None:
-    """A high-edge (text/line) image so the REAL `classify_visual` reads 'slides'."""
+    """A high-edge (text/line) image so the REAL `classify_visual` reads 'slides'.
+
+    Content varies by the frame index in the filename (a big filled bar in a
+    distinct vertical band) so DISTINCT frames get distinct perceptual hashes and
+    survive dedup — two identically-drawn frames would (correctly) collapse to one.
+    """
     from PIL import Image, ImageDraw
 
+    idx = int("".join(c for c in path.stem if c.isdigit()) or "0")
     img = Image.new("RGB", (640, 360), "white")
     draw = ImageDraw.Draw(img)
     for y in range(40, 320, 24):
         draw.line([(40, y), (600, y)], fill="black", width=3)
-    draw.rectangle([300, 200, 560, 330], outline="black", width=4)
+    band = 30 + (idx % 5) * 60
+    draw.rectangle([120, band, 560, band + 50], fill="black")
     img.save(path)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -329,3 +329,23 @@ def test_load_config_frames_rejects_non_positive_max(tmp_path: Path):
     )
     with pytest.raises(ValueError, match="max_frames"):
         load_config(tmp_path)
+
+
+def test_load_config_frames_rejects_bad_scene_threshold(tmp_path: Path):
+    (tmp_path / "config.toml").write_text(
+        '[paths]\nvault = "/tmp/vault"\noutput_subdir = "x"\ndata_dir = "data"\n'
+        '[x]\nhandle = "vgonpa"\n[frames]\nscene_threshold = 1.5\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="scene_threshold"):
+        load_config(tmp_path)
+
+
+def test_load_config_frames_rejects_non_positive_interval(tmp_path: Path):
+    (tmp_path / "config.toml").write_text(
+        '[paths]\nvault = "/tmp/vault"\noutput_subdir = "x"\ndata_dir = "data"\n'
+        '[x]\nhandle = "vgonpa"\n[frames]\ninterval_seconds = 0\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="interval_seconds"):
+        load_config(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -277,3 +277,55 @@ def test_load_config_round_trips_describe_overrides(tmp_path: Path):
     cfg = load_config(tmp_path)
     assert cfg.describe_model == "claude-opus-4-1"
     assert cfg.describe_version == "v3"
+
+
+def test_load_config_frames_defaults(tmp_path: Path):
+    """No [frames] section → the visual-layer knobs take their video_frames
+    defaults: safety-ceiling cap, dedup on."""
+    _write_repo(tmp_path)
+    cfg = load_config(tmp_path)
+    assert cfg.frames_max_frames == 60
+    assert cfg.frames_scene_threshold == 0.4
+    assert cfg.frames_interval_seconds == 15.0
+    assert cfg.frames_dedupe is True
+    assert cfg.frames_dedupe_distance == 6
+
+
+def test_load_config_frames_overrides(tmp_path: Path):
+    (tmp_path / "config.toml").write_text(
+        "[paths]\n"
+        'vault = "/tmp/vault"\n'
+        'output_subdir = "learnings/x-knowledge"\n'
+        'data_dir = "data"\n'
+        "[x]\n"
+        'handle = "vgonpa"\n'
+        "[frames]\n"
+        "max_frames = 120\n"
+        "scene_threshold = 0.5\n"
+        "interval_seconds = 20\n"
+        "dedupe = false\n"
+        "dedupe_distance = 10\n",
+        encoding="utf-8",
+    )
+    cfg = load_config(tmp_path)
+    assert cfg.frames_max_frames == 120
+    assert cfg.frames_scene_threshold == 0.5
+    assert cfg.frames_interval_seconds == 20.0
+    assert cfg.frames_dedupe is False
+    assert cfg.frames_dedupe_distance == 10
+
+
+def test_load_config_frames_rejects_non_positive_max(tmp_path: Path):
+    (tmp_path / "config.toml").write_text(
+        "[paths]\n"
+        'vault = "/tmp/vault"\n'
+        'output_subdir = "learnings/x-knowledge"\n'
+        'data_dir = "data"\n'
+        "[x]\n"
+        'handle = "vgonpa"\n'
+        "[frames]\n"
+        "max_frames = 0\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="max_frames"):
+        load_config(tmp_path)

--- a/tests/test_video_frames.py
+++ b/tests/test_video_frames.py
@@ -25,7 +25,9 @@ from xbrain.video_frames import (
     FrameExtractionFailed,
     FrameExtractionToolNotFound,
     KeyFrame,
+    _dhash,
     classify_visual,
+    dedupe_frames,
     extract_key_frames,
 )
 
@@ -320,3 +322,51 @@ def test_video_frames_imports_no_ml_or_vision_library():
         "transformers",
     ):
         assert forbidden not in source
+
+
+def _frame(tmp_path: Path, name: str, boxes: list[tuple[int, int, int, int]]) -> KeyFrame:
+    """A structured 'slide' PNG (white with black boxes) → a KeyFrame.
+
+    dHash captures STRUCTURE, not brightness (a uniform image hashes to 0), so the
+    fixtures draw distinct box layouts to exercise the perceptual hash meaningfully.
+    """
+    img = Image.new("RGB", (256, 144), "white")
+    draw = ImageDraw.Draw(img)
+    for box in boxes:
+        draw.rectangle(box, fill="black")
+    path = tmp_path / name
+    img.save(path)
+    return KeyFrame(timestamp=0.0, path=path)
+
+
+def test_dhash_is_stable_and_discriminates(tmp_path: Path):
+    a = _frame(tmp_path, "a.png", [(10, 10, 100, 130)]).path
+    a_copy = _frame(tmp_path, "a2.png", [(10, 10, 100, 130)]).path  # identical drawing
+    b = _frame(tmp_path, "b.png", [(150, 10, 240, 130)]).path  # box on the far side
+    assert _dhash(a) == _dhash(a_copy)  # identical structure → same fingerprint
+    assert _dhash(a) != _dhash(b)  # different structure → different fingerprint
+    assert _dhash(tmp_path / "missing.png") is None  # unreadable → None
+
+
+def test_dedupe_drops_consecutive_near_duplicates(tmp_path: Path):
+    a = _frame(tmp_path, "a.png", [(10, 10, 100, 130)])
+    a_dup = _frame(tmp_path, "a2.png", [(10, 10, 100, 130)])  # a held slide, re-sampled
+    b = _frame(tmp_path, "b.png", [(150, 10, 240, 130)])
+    kept = dedupe_frames([a, a_dup, b], max_distance=6)
+    assert [f.path.name for f in kept] == ["a.png", "b.png"]  # the duplicate is dropped
+
+
+def test_dedupe_keeps_distinct_slides(tmp_path: Path):
+    frames = [
+        _frame(tmp_path, "tl.png", [(10, 10, 90, 60)]),  # top-left
+        _frame(tmp_path, "br.png", [(170, 90, 250, 135)]),  # bottom-right
+        _frame(tmp_path, "wide.png", [(10, 10, 250, 40)]),  # wide top bar
+    ]
+    assert len(dedupe_frames(frames, max_distance=6)) == 3
+
+
+def test_dedupe_keeps_unreadable_frames(tmp_path: Path):
+    good = _frame(tmp_path, "good.png", [(10, 10, 100, 130)])
+    bad = KeyFrame(timestamp=1.0, path=tmp_path / "nope.png")  # no file → unreadable
+    kept = dedupe_frames([good, bad, good], max_distance=6)
+    assert bad in kept  # unreadable is never silently dropped

--- a/tests/test_video_frames.py
+++ b/tests/test_video_frames.py
@@ -29,6 +29,7 @@ from xbrain.video_frames import (
     classify_visual,
     dedupe_frames,
     extract_key_frames,
+    select_frames,
 )
 
 
@@ -370,3 +371,30 @@ def test_dedupe_keeps_unreadable_frames(tmp_path: Path):
     bad = KeyFrame(timestamp=1.0, path=tmp_path / "nope.png")  # no file → unreadable
     kept = dedupe_frames([good, bad, good], max_distance=6)
     assert bad in kept  # unreadable is never silently dropped
+
+
+def test_extract_cap_false_returns_raw_frames(tmp_path: Path):
+    """`cap=False` returns the RAW extraction (no even-subsample) — the digest
+    classifies slides-vs-talking-head on this full distribution before reducing."""
+    runner = _ffmpeg_runner([float(t) for t in range(10)])
+    frames = extract_key_frames(tmp_path / "vid.mp4", max_frames=3, cap=False, runner=runner)
+    assert len(frames) == 10  # not capped to 3
+
+
+def test_select_frames_dedupes_then_caps(tmp_path: Path):
+    """`select_frames` = dedupe (drop held-slide near-dups) → cap evenly."""
+    a = _frame(tmp_path, "a.png", [(10, 10, 100, 130)])
+    a_dup = _frame(tmp_path, "a2.png", [(10, 10, 100, 130)])  # dropped by dedup
+    frames = [
+        a,
+        a_dup,
+        _frame(tmp_path, "b.png", [(10, 10, 90, 40)]),
+        _frame(tmp_path, "c.png", [(160, 100, 250, 140)]),
+        _frame(tmp_path, "d.png", [(10, 100, 250, 140)]),
+    ]
+    # dedup → [a, b, c, d] (4 distinct); cap 2 → 2, front+tail preserved.
+    kept = select_frames(frames, dedupe=True, dedupe_distance=6, max_frames=2)
+    assert len(kept) == 2
+    assert kept[0].path.name == "a.png"  # front kept
+    # dedupe=False → no dedup, cap 3 of the 5.
+    assert len(select_frames(frames, dedupe=False, max_frames=3)) == 3


### PR DESCRIPTION
First PR of the [frames-layer redesign](../zz-support-files/docs/implementation-plans/frames-layer-redesign.md). The extractor kept up to 40 frames spread evenly across a video with **no dedup** — a slide held across interval samples cost several near-identical vision calls, and the even-cap dropped distinct slides in long decks.

## What
- **`dedupe_frames`** — perceptual dHash (8×8, Hamming distance) drops **consecutive near-duplicate** frames (a held slide), so the frame budget covers **distinct** slides. `extract_key_frames` is now **extract → dedupe → cap**; the cap is a safety ceiling (default 40 → **60**) since dedup is the real reducer. No new dependency (Pillow dHash).
- **`[frames]` config** (`max_frames`, `scene_threshold`, `interval_seconds`, `dedupe`, `dedupe_distance`), plumbed through `_build_visual_config` → `extract_key_frames`. Defaults preserve behaviour except dedup on (strictly fewer, distinct frames).

## Tests
dHash stability + discrimination + None-on-unreadable; dedupe drops dups / keeps distinct / keeps unreadable; `[frames]` defaults + overrides + validation. **1095 tests, 95% cov, gate green.**

Next in the branch series: PR-B warm server, PR-C transcript-informed selection, PR-D captioning context, PR-E frame worklist/resume.