### PR TITLE
feat(enrich): video frame descriptions + full transcript into enrich

### DIFF
--- a/src/xbrain/executors/api.py
+++ b/src/xbrain/executors/api.py
@@ -16,6 +16,7 @@ from xbrain.llm_json import json_from_response
 from xbrain.models import ContentSourceSuccess, Item, MediaPhotoDescribed, Topic
 from xbrain.rubrics import (
     ARTICLE_CHAR_LIMIT,
+    FRAME_DESC_CHAR_LIMIT,
     TRANSCRIPT_CHAR_LIMIT,
     load_rubric,
     truncate_transcript,
@@ -79,6 +80,53 @@ def _content_image_descriptions(item: Item) -> list[str]:
         for entry in item.media
         if isinstance(entry, MediaPhotoDescribed) and not entry.is_decorative and entry.description
     ]
+
+
+def _video_frame_descriptions(item: Item) -> list[str]:
+    """Return the key-frame descriptions of every `x_video` source, in order.
+
+    These are the slides/screens a video SHOWS — visual topic signal present even
+    when the video has no speech (`has_speech=False`, no transcript). They live on
+    the `x_video` `ContentSourceSuccess.frames` list, a DIFFERENT field from the
+    `MediaPhotoDescribed` photo descriptions on `item.media`
+    (`_content_image_descriptions`). Empty-description frames (the VLM found nothing
+    to say, or the frame was unreadable) are skipped.
+    """
+    if item.content is None:
+        return []
+    descriptions: list[str] = []
+    for src in item.content.sources:
+        if isinstance(src, ContentSourceSuccess) and src.kind == "x_video":
+            descriptions += [frame.description for frame in src.frames if frame.description]
+    return descriptions
+
+
+def _video_frames_section(item: Item) -> list[str]:
+    """Build the `Video frames` block bounded to `FRAME_DESC_CHAR_LIMIT`, or [].
+
+    A slide-heavy or screen-share talk can dedup to dozens of distinct frames; the
+    block is capped so it can't crowd the transcript out of the per-item prompt.
+    When the cap clips frames, an explicit `[… N further frames omitted …]` marker
+    signposts the cut so the LLM does not read it as the end of the deck. At least
+    one frame is always kept, even if a single description exceeds the cap.
+    """
+    descriptions = _video_frame_descriptions(item)
+    if not descriptions:
+        return []
+    lines = ["", "Video frames (slides/screens shown in the video):"]
+    used = 0
+    kept = 0
+    for description in descriptions:
+        line = f"- {description}"
+        if kept > 0 and used + len(line) > FRAME_DESC_CHAR_LIMIT:
+            break
+        lines.append(line)
+        used += len(line)
+        kept += 1
+    omitted = len(descriptions) - kept
+    if omitted > 0:
+        lines.append(f"[… {omitted} further frames omitted …]")
+    return lines
 
 
 def _images_section(item: Item) -> list[str]:
@@ -165,6 +213,7 @@ def _user_prompt(item: Item, vocab: list[Topic]) -> str:
         parts += ["", f"Saved by the user in the bookmark folder: {item.bookmark_folder}"]
     parts += _images_section(item)
     parts += _video_transcript_section(item)
+    parts += _video_frames_section(item)
     parts += _links_section(item)
     parts += _article_sections(item)
     return "\n".join(parts)

--- a/src/xbrain/rubrics.py
+++ b/src/xbrain/rubrics.py
@@ -27,13 +27,23 @@ _GUARDRAILS = _PKG / "guardrails.yaml"
 ARTICLE_CHAR_LIMIT = 4000
 
 # Max characters of an `x_video` transcript passed to the per-item ENRICH prompt
-# (#44). A 72-min talk transcribes to ~68k chars, but the LLM saturates on
-# topic + gist far sooner, so we cap at 12000 chars (~3k tokens, ~3× the article
-# limit): the first ~13 minutes of speech, enough to assign a real
-# `primary_topic` + summary without a single long talk blowing the prompt.
-# Shared by the `api` executor prompt and the worksheet export so both truncate
-# identically.
+# on the `api` engine (#44). A 72-min talk transcribes to ~68k chars, but the LLM
+# saturates on topic + gist far sooner, so we cap at 12000 chars (~3k tokens, ~3×
+# the article limit): the first ~13 minutes of speech, enough to assign a real
+# `primary_topic` + summary without a single long talk blowing the per-item prompt.
+# The `api` engine is a bounded per-item model call, so it truncates here; the
+# worksheet engine is judged by a full-context agent and carries the FULL
+# transcript instead (`worksheet._video_transcript`) — the two engines
+# legitimately diverge on input size.
 TRANSCRIPT_CHAR_LIMIT = 12000
+
+# Max characters of the `Video frames` block (key-frame descriptions of the
+# slides/screens a video shows) passed to the per-item ENRICH prompt on the `api`
+# engine. A slide deck can dedup to dozens of distinct frames (~300 chars each);
+# 6000 chars (~1.5k tokens) is plenty of visual topic signal without a screen-heavy
+# talk crowding out the transcript. Bounds the `api` engine only — the worksheet
+# engine carries every frame description (agent-judged, full context).
+FRAME_DESC_CHAR_LIMIT = 6000
 
 # Tighter per-video cap for the TOPIC-page synthesis prompt (#44). A single topic
 # can gather many video items, so each member's transcript is trimmed to 2000

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -12,14 +12,9 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.executors.api import _content_image_descriptions
+from xbrain.executors.api import _content_image_descriptions, _video_frame_descriptions
 from xbrain.models import ContentSourceSuccess, Item, Topic
-from xbrain.rubrics import (
-    ARTICLE_CHAR_LIMIT,
-    TRANSCRIPT_CHAR_LIMIT,
-    load_rubric,
-    truncate_transcript,
-)
+from xbrain.rubrics import ARTICLE_CHAR_LIMIT, load_rubric
 
 
 def _article_text(item: Item) -> str | None:
@@ -41,11 +36,13 @@ def _article_text(item: Item) -> str | None:
 
 
 def _video_transcript(item: Item) -> str | None:
-    """First with-speech `x_video` transcript body, truncated, or None (#44).
+    """First with-speech `x_video` transcript body, FULL (untruncated), or None (#44).
 
-    A no-speech source (`has_speech=False`, empty text) yields None — no
-    transcript to enrich from. Truncated to `TRANSCRIPT_CHAR_LIMIT`, matching
-    the `api` executor prompt so both tracks see identical input.
+    Unlike the `api` executor prompt — a bounded per-item model call that truncates
+    to `TRANSCRIPT_CHAR_LIMIT` — the worksheet is judged by a full-context agent, so
+    it carries the whole talk. The summary/topics are then not front-biased to the
+    first ~13 min of a long video. A no-speech source (`has_speech=False`, empty
+    text) yields None — no transcript to enrich from.
     """
     if not item.content:
         return None
@@ -56,7 +53,7 @@ def _video_transcript(item: Item) -> str | None:
             and src.has_speech
             and src.text
         ):
-            return truncate_transcript(src.text, TRANSCRIPT_CHAR_LIMIT)
+            return src.text
     return None
 
 
@@ -79,8 +76,11 @@ def export_worksheet(
             "For each entry in `items`, append one object to `judgments` with "
             "keys {item_id, summary, primary_topic, topics}. Use only slugs from "
             "`vocab`. An item may also carry `links`, `article`, `video_transcript` "
-            "and `image_descriptions` (content-bearing photos) — weigh them all as "
-            "topic signal, not just `text`. Then run: xbrain enrich --apply <this file>."
+            "(the full talk — what the video SAYS), `video_frame_descriptions` (what "
+            "the video SHOWS: slides/screens, present even when there is no "
+            "transcript) and `image_descriptions` (content-bearing photos) — weigh "
+            "them all as topic signal, not just `text`. Then run: xbrain enrich "
+            "--apply <this file>."
         ),
         "rubrics": {
             "summary": load_rubric("summary", language=output_language),
@@ -102,6 +102,13 @@ def export_worksheet(
                 # enrich track sees the identical visual signal. Empty list when the
                 # item has no described photos or only decorative ones.
                 "image_descriptions": _content_image_descriptions(it),
+                # Video key-frame descriptions: what the video SHOWS (slides/screens),
+                # the same signal the `api` executor injects as its `Video frames`
+                # section (`_video_frame_descriptions`). Present even for a mute
+                # screen-share (no transcript). Empty list when the video has no
+                # described frames. All frames are carried (agent-judged, full
+                # context) — the `api` engine bounds its block instead.
+                "video_frame_descriptions": _video_frame_descriptions(it),
             }
             for it in items
         ],

--- a/tests/test_executors_api.py
+++ b/tests/test_executors_api.py
@@ -352,3 +352,129 @@ def test_user_prompt_video_transcript_sits_between_images_and_links_and_article(
     article_idx = prompt.index("Linked article")
     assert image_idx < transcript_idx < links_idx
     assert transcript_idx < article_idx
+
+
+def _video_item_with_frames(
+    item_id: str,
+    *,
+    text: str = "a talk about scaling laws",
+    has_speech: bool = True,
+    frame_descs: tuple[str, ...] = (),
+):
+    """An `x_video` item carrying key-frame descriptions (slides/screens shown).
+
+    Frame descriptions ride on the `x_video` `ContentSourceSuccess.frames` list,
+    a different field from the `MediaPhotoDescribed` photo descriptions on
+    `item.media` — so a slide/screen-share video contributes visual topic signal
+    even with `has_speech=False` (no transcript).
+    """
+    from xbrain.models import Content, ContentSourceSuccess, VideoFrame
+
+    frames = [
+        VideoFrame(timestamp=float(i), local_path=f"1/frames/{i}.png", description=desc)
+        for i, desc in enumerate(frame_descs)
+    ]
+    return _item(
+        item_id,
+        content=Content(
+            fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video",
+                    url="https://x.com/a/status/1/video/1",
+                    title="A great talk",
+                    text=text,
+                    has_speech=has_speech,
+                    frames=frames,
+                )
+            ],
+        ),
+    )
+
+
+def test_user_prompt_includes_video_frame_descriptions():
+    """Key-frame descriptions surface under a labelled `Video frames` block so the
+    LLM reads what the video SHOWS (slides/screens), not just what it says."""
+    item = _video_item_with_frames(
+        "1", frame_descs=("A title slide: 'Scaling Laws'.", "A chart of loss vs compute.")
+    )
+    prompt = _user_prompt(item, VOCAB)
+    assert "Video frames" in prompt
+    assert "A title slide: 'Scaling Laws'." in prompt
+    assert "A chart of loss vs compute." in prompt
+
+
+def test_user_prompt_omits_video_frames_when_none():
+    """A video with no described frames must NOT have the frames section — otherwise
+    the LLM sees a hint of missing visual context and may hallucinate slides."""
+    prompt = _user_prompt(_video_item_with_frames("1", frame_descs=()), VOCAB)
+    assert "Video frames" not in prompt
+
+
+def test_user_prompt_includes_frames_even_when_no_speech():
+    """THE slide-deck case: a mute screen-share video (has_speech=False, empty text)
+    still contributes its frame descriptions as topic signal, even though it has no
+    transcript. This is the whole reason frames feed enrich."""
+    item = _video_item_with_frames(
+        "1",
+        text="",
+        has_speech=False,
+        frame_descs=("A slide comparing Postgres vs DynamoDB latency.",),
+    )
+    prompt = _user_prompt(item, VOCAB)
+    assert "Video frames" in prompt
+    assert "Postgres vs DynamoDB" in prompt
+    assert "Video transcript:" not in prompt  # no speech → no transcript block
+
+
+def test_user_prompt_bounds_the_video_frames_section():
+    """A 60-frame deck can't blow the per-item prompt: the frames block is capped at
+    `FRAME_DESC_CHAR_LIMIT` and signposts the cut."""
+
+    big = tuple(f"Frame {i}: " + ("x" * 500) for i in range(60))  # >> the cap
+    prompt = _user_prompt(_video_item_with_frames("1", frame_descs=big), VOCAB)
+    assert "Video frames" in prompt
+    # The section is bounded: not every 500-char frame made it in.
+    assert len(prompt) < sum(len(d) for d in big)
+    assert "frames omitted" in prompt
+
+
+def test_user_prompt_video_frames_sit_after_transcript_before_links():
+    """Order: post → images → transcript → frames → links → article. Voice then
+    slides, both before the links/article, so the LLM reads the video in one place."""
+    from xbrain.models import Content, ContentSourceSuccess, Link, VideoFrame
+
+    item = _item(
+        "1",
+        links=[Link(url="https://example.com/x", domain="example.com")],
+        content=Content(
+            fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video",
+                    url="https://x.com/a/status/1/video/1",
+                    title="A great talk",
+                    text="a talk about scaling laws",
+                    has_speech=True,
+                    frames=[
+                        VideoFrame(
+                            timestamp=1.0, local_path="1/frames/0.png", description="A title slide."
+                        )
+                    ],
+                ),
+                ContentSourceSuccess(
+                    kind="external_article",
+                    url="https://example.com/x",
+                    title="An article",
+                    text="the article body",
+                ),
+            ],
+        ),
+    )
+    prompt = _user_prompt(item, VOCAB)
+    transcript_idx = prompt.index("Video transcript:")
+    frames_idx = prompt.index("Video frames")
+    links_idx = prompt.index("Links in the post")
+    article_idx = prompt.index("Linked article")
+    assert transcript_idx < frames_idx < links_idx
+    assert frames_idx < article_idx

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -175,9 +175,19 @@ def test_export_worksheet_omits_image_descriptions_when_no_described_photos(tmp_
     assert data["items"][0]["image_descriptions"] == []
 
 
-def _video_item(item_id: str, *, text: str, has_speech: bool = True) -> Item:
-    """An item carrying an `x_video` transcript content source (#44)."""
-    from xbrain.models import Content, ContentSourceSuccess
+def _video_item(
+    item_id: str,
+    *,
+    text: str,
+    has_speech: bool = True,
+    frame_descs: tuple[str, ...] = (),
+) -> Item:
+    """An item carrying an `x_video` transcript + key-frame content source (#44).
+
+    `frame_descs` populate the `x_video` `frames` list (slides/screens shown in the
+    video), a different field from the `MediaPhotoDescribed` photos on `item.media`.
+    """
+    from xbrain.models import Content, ContentSourceSuccess, VideoFrame
 
     return Item(
         id=item_id,
@@ -195,6 +205,14 @@ def _video_item(item_id: str, *, text: str, has_speech: bool = True) -> Item:
                     url="https://x.com/v",
                     text=text,
                     has_speech=has_speech,
+                    frames=[
+                        VideoFrame(
+                            timestamp=float(i),
+                            local_path=f"{item_id}/frames/{i}.png",
+                            description=d,
+                        )
+                        for i, d in enumerate(frame_descs)
+                    ],
                 )
             ],
         ),
@@ -224,16 +242,75 @@ def test_export_worksheet_omits_no_speech_video_transcript(tmp_path):
     assert data["items"][0]["video_transcript"] is None
 
 
-def test_export_worksheet_truncates_an_over_cap_video_transcript(tmp_path):
-    """A 72-min-talk-scale transcript is capped in the worksheet's `video_transcript`
-    field (same `TRANSCRIPT_CHAR_LIMIT` as the `api` prompt) so the manual/claude-code
-    track sees identical, bounded input and one long talk can't bloat the worksheet."""
+def test_export_worksheet_carries_the_full_video_transcript(tmp_path):
+    """The worksheet carries the FULL transcript — unlike the `api` prompt, which is
+    truncated to `TRANSCRIPT_CHAR_LIMIT`. The worksheet is judged by a full-context
+    agent (not a bounded per-item model call), so it reads the whole talk and its
+    summary/topics are not front-biased to the first ~13 min. The two engines
+    legitimately diverge on input size (see `worksheet._video_transcript`)."""
     from xbrain.rubrics import TRANSCRIPT_CHAR_LIMIT
 
-    long_text = "word " * TRANSCRIPT_CHAR_LIMIT  # >> the cap
+    long_text = "word " * TRANSCRIPT_CHAR_LIMIT  # >> the api cap
     path = tmp_path / "ws.json"
     export_worksheet([_video_item("1", text=long_text)], VOCAB, path, "manual", "English")
     data = json.loads(path.read_text(encoding="utf-8"))
     transcript = data["items"][0]["video_transcript"]
-    assert "transcript truncated" in transcript
-    assert len(transcript) < len(long_text)
+    assert transcript == long_text  # full, untruncated
+    assert "transcript truncated" not in transcript
+
+
+def test_export_worksheet_includes_video_frame_descriptions(tmp_path):
+    """Key-frame descriptions surface under `video_frame_descriptions` so the
+    manual/claude-code enrich track sees what the video SHOWS (slides/screens),
+    mirroring the api path's `Video frames` section."""
+    path = tmp_path / "ws.json"
+    export_worksheet(
+        [
+            _video_item(
+                "1",
+                text="a talk",
+                frame_descs=("A title slide: 'Scaling'.", "A chart of loss curves."),
+            )
+        ],
+        VOCAB,
+        path,
+        "manual",
+        "English",
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["video_frame_descriptions"] == [
+        "A title slide: 'Scaling'.",
+        "A chart of loss curves.",
+    ]
+
+
+def test_export_worksheet_frame_descriptions_present_when_no_speech(tmp_path):
+    """A mute slide/screen-share video (has_speech=False) contributes its frame
+    descriptions even with no transcript — the whole point of feeding frames."""
+    path = tmp_path / "ws.json"
+    export_worksheet(
+        [
+            _video_item(
+                "1",
+                text="",
+                has_speech=False,
+                frame_descs=("A slide: Postgres vs DynamoDB latency.",),
+            )
+        ],
+        VOCAB,
+        path,
+        "manual",
+        "English",
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    entry = data["items"][0]
+    assert entry["video_frame_descriptions"] == ["A slide: Postgres vs DynamoDB latency."]
+    assert entry["video_transcript"] is None  # no speech → no transcript
+
+
+def test_export_worksheet_omits_video_frame_descriptions_when_none(tmp_path):
+    """A video without described frames exports a clean empty list, not a missing key."""
+    path = tmp_path / "ws.json"
+    export_worksheet([_video_item("1", text="a talk")], VOCAB, path, "manual", "English")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["video_frame_descriptions"] == []


### PR DESCRIPTION
## What
Make digested videos get the same treatment as text: a content-based summary + topic assignment grounded in **what the video says (ASR)** and **what it shows (frame descriptions)**.

### The gap (verified in code)
A digested video carries a full transcript and per-frame descriptions, but `enrich` only saw a **12k-truncated transcript** and **never the frame descriptions** (those live on `x_video.frames[].description`, a different field from the `MediaPhotoDescribed` photo descriptions). So slide/screen-share videos with no speech contributed **zero** content signal → tweet-only summary/topics.

### Change
- New shared `_video_frame_descriptions(item)` helper (`executors/api.py`), threaded into **both** enrich engines:
  - **api** prompt: a `Video frames (slides/screens shown)` block, bounded by the new `FRAME_DESC_CHAR_LIMIT` with a `[… N further frames omitted …]` marker.
  - **worksheet** (manual/claude-code): `video_frame_descriptions` field (all frames).
- A **mute screen-share** video now contributes visual topic signal even with `has_speech=False`.
- The **worksheet carries the FULL transcript** (judged by a full-context agent, so summary/topics aren't front-biased to the first ~13 min); the **api** engine keeps its `TRANSCRIPT_CHAR_LIMIT` bound. The two engines diverge on input size **by design** (documented).

### Why now
Unblocks the backfill of the 433 pending-enrich items (217 videos) via the worksheet engine ("our Claude") — see plan `zz-support-files/docs/implementation-plans/video-content-enrich.md`.

## Tests
- api: frames section present/absent/bounded/ordering + **frames present when no speech**.
- worksheet: frame descriptions field + **full (untruncated) transcript** (replaces the old truncation test — intentional behaviour change).

## Gate
✅ 1107 tests · 95% cov · ruff/format/mypy/radon/bandit/vulture/interrogate/deptry all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)