### PR TITLE
docs(rubrics): video transcript + frames as explicit summary/topic sources

### DIFF
--- a/src/xbrain/rubrics/rubric-summary.md
+++ b/src/xbrain/rubrics/rubric-summary.md
@@ -4,10 +4,16 @@ Produce a `summary` for one X post (a bookmark or the user's own tweet).
 
 - **Language:** {language}, regardless of the post's language.
 - **Length:** 1-3 sentences. Concise. No preamble ("Este post trata de...").
-- **Faithful:** state only what the post (and its fetched article, if any) says.
-  Never invent facts, numbers or claims. No hallucination.
+- **Faithful:** state only what the post — and its fetched article, video
+  transcript or on-screen frames, if any — actually says. Never invent facts,
+  numbers or claims. No hallucination.
 - **If the post links an article** whose text was fetched: summarise the
   *article's* substance.
+- **If the post has a video** (a `Video transcript:` and/or `Video frames`
+  block): summarise what the *video* is about — grounded in the transcript (what
+  it says) and the frame descriptions (what it shows on screen). For a slide or
+  screen-share video with no transcript, summarise from the frame descriptions.
+  Still 1-3 sentences: capture the whole talk's subject, not just its opening.
 - **If the linked article could NOT be fetched:** summarise from the post's own
   text. Do not write "article unavailable" — just describe what the post says.
 - **Retweets / quotes:** summarise the substantive content being shared.

--- a/src/xbrain/rubrics/rubric-topics.md
+++ b/src/xbrain/rubrics/rubric-topics.md
@@ -24,3 +24,12 @@ articles). **A missing article is NOT a reason to fall back to `misc`.**
 - Use `misc` **only** when the post has genuinely no identifiable subject (a
   pure greeting, a single word, an image with no text). Never use `misc` merely
   because the article body is absent.
+
+## Classifying a video
+
+A `Video transcript:` (what the video says) and a `Video frames` block (what it
+shows on screen — slides, charts, screens) are **strong subject signal**.
+Classify a video from what it actually says and shows, not from the tweet's
+one-line caption — a bare "watch this incredible talk" caption is not a reason
+to fall back to `misc`. A slide or screen-share video with no transcript is
+still classifiable from its frame descriptions.


### PR DESCRIPTION
The `summary` and `topics` rubrics predated `digest-video` and named only "the post and its fetched article" as sources. Enrich now also sees a `Video transcript:` (what the video says) and a `Video frames` block (what it shows) — so the rubrics now say to summarise/classify a video from its actual content, and to use frame descriptions when there is no transcript. Summary length stays 1-3 sentences, with an explicit nudge to capture the whole talk's subject (not just its opening) to counter front-bias on long videos.

Guidance only, no logic change. Ships inside the enrich worksheet + the api system prompt. Gate green: 1107 tests, 95%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)