### PR TITLE
feat(video-digest): xbrain video-digest step (long-form digest per video)

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -1365,6 +1365,10 @@ def video_digest_command(
     store = load_store(cfg.items_path)
 
     if apply is not None:
+        # Snapshot on the APPLY branch — this is the one that mutates `items.json`
+        # (writes every `source.digest` + `save_store`); export only writes the
+        # worksheet JSON. Mirrors `describe`'s `describe-apply` snapshot.
+        _auto_snapshot(cfg, "video-digest-apply")
         judgments = import_video_digest_worksheet(apply)
         applied, invalid = apply_video_digest_judgments(store, judgments)
         save_store(store, cfg.items_path)
@@ -1381,7 +1385,6 @@ def video_digest_command(
     if not pending:
         typer.echo("No hay vídeos pendientes de digest.")
         return
-    _auto_snapshot(cfg, "video-digest")
     worksheet = cfg.data_dir / "video-digest-worksheet.json"
     export_video_digest_worksheet(pending, worksheet, chosen, cfg.output_language)
     typer.echo(

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -87,6 +87,12 @@ from xbrain.vocab import (
     import_vocab_worksheet,
     induce_vocab,
 )
+from xbrain.video_digest import (
+    apply_video_digest_judgments,
+    export_video_digest_worksheet,
+    import_video_digest_worksheet,
+    items_pending_video_digest,
+)
 from xbrain.worksheet import export_worksheet, import_worksheet
 
 app = typer.Typer(help="XBrain — bookmarks y tweets de X a un wiki de Obsidian")
@@ -1342,6 +1348,47 @@ def enrich(
     save_store(store, cfg.items_path)
     typer.echo(f"Enriquecidos: {enriched} items")
     _report_invalid(invalid)
+
+
+@app.command(name="video-digest")
+@_handle_cli_errors
+def video_digest_command(
+    executor: str | None = typer.Option(
+        None, help="manual | claude-code (default: the executor set in config.toml)"
+    ),
+    apply: Path | None = typer.Option(
+        None, "--apply", help="Import a filled worksheet and apply it"
+    ),
+) -> None:
+    """Genera un digest legible (largo) por vídeo, desde su transcripción + frames."""
+    cfg = _config()
+    store = load_store(cfg.items_path)
+
+    if apply is not None:
+        judgments = import_video_digest_worksheet(apply)
+        applied, invalid = apply_video_digest_judgments(store, judgments)
+        save_store(store, cfg.items_path)
+        typer.echo(f"Worksheet aplicada: {applied} digests de vídeo")
+        _report_invalid(invalid)
+        return
+
+    chosen = executor or cfg.enrich_executor
+    if chosen not in ("manual", "claude-code"):
+        raise ValueError(
+            f"Ejecutor {chosen!r} no soportado para video-digest — usa manual|claude-code."
+        )
+    pending = items_pending_video_digest(store)
+    if not pending:
+        typer.echo("No hay vídeos pendientes de digest.")
+        return
+    _auto_snapshot(cfg, "video-digest")
+    worksheet = cfg.data_dir / "video-digest-worksheet.json"
+    export_video_digest_worksheet(pending, worksheet, chosen, cfg.output_language)
+    typer.echo(
+        f"{len(pending)} vídeos exportados a {worksheet}\n"
+        f"Rellena el array `judgments` (con Claude Code o a mano) y ejecuta:\n"
+        f"  xbrain video-digest --apply {worksheet}"
+    )
 
 
 def _mark_for_regenerate(store: dict, cfg: Config, regenerate: bool) -> None:

--- a/src/xbrain/rubrics/rubric-video-digest.md
+++ b/src/xbrain/rubrics/rubric-video-digest.md
@@ -1,0 +1,23 @@
+# Rubric — Video digest
+
+Produce a `digest` for one X video: a short, readable synthesis of what the video
+**says** (its transcript) and **shows** (its on-screen frames). This is the
+headline a reader sees instead of the raw transcript + frame dump.
+
+- **Language:** {language}, regardless of the video's own language.
+- **Format** — structured and scannable, Markdown:
+  - **What it is:** one line — the format, the speaker(s), and the length/kind if
+    known (a podcast interview, a conference talk, a screen-share demo, a clip).
+  - **Key points:** 3-6 bullets — the actual claims, frameworks, numbers,
+    techniques or news. Ground each in the transcript (what is said) and the frame
+    descriptions (what is shown on screen: slides, charts, code, UI). Capture the
+    whole video's substance, not just its opening.
+  - **Why it matters:** one OPTIONAL closing line. Drop it when it would be generic.
+- **Faithful:** state only what the video actually says or shows. Never invent
+  facts, numbers, names or claims. No hype.
+- **Mute slide / screen-share video** (no transcript): build the digest from the
+  frame descriptions alone.
+- **Misleading caption:** the tweet caption is often clickbait ("watch this
+  incredible talk") — summarise the video, not the caption.
+- Output the digest text only (the headings/bullets above). No preamble, no
+  "This video is about…", no surrounding quotes or code fences.

--- a/src/xbrain/video_digest.py
+++ b/src/xbrain/video_digest.py
@@ -1,0 +1,145 @@
+"""The `video-digest` step: a long-form readable digest per `x_video` source.
+
+Mirrors the `enrich` worksheet handoff (`worksheet.py`) but for a different
+judgment shape: `{item_id, digest}`. `xbrain video-digest --executor manual|
+claude-code` exports the pending videos + the rubric into one JSON worksheet; a
+human or a Claude Code session fills the `judgments` array; `xbrain video-digest
+--apply <file>` reads it back and writes each `digest` onto the item's `x_video`
+source. XBrain never handles a Claude OAuth token — it only moves JSON.
+
+The digest is what `generate` renders as the headline of the `## Video digest`
+note section (PR-A), demoting the raw transcript + frames to collapsible evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from xbrain.executors.api import _video_frame_descriptions
+from xbrain.models import ContentSourceSuccess, Item
+from xbrain.rubrics import load_rubric
+from xbrain.worksheet import _video_transcript
+
+
+def _video_source(item: Item) -> ContentSourceSuccess | None:
+    """The item's first `x_video` content source, or None when it has none."""
+    if item.content is None:
+        return None
+    for source in item.content.sources:
+        if isinstance(source, ContentSourceSuccess) and source.kind == "x_video":
+            return source
+    return None
+
+
+def _has_digestible_content(source: ContentSourceSuccess) -> bool:
+    """True when the `x_video` source carries content to digest.
+
+    A with-speech transcript (`has_speech` not False and non-empty `text`) OR any
+    key frames. A silent video with no frames has nothing to synthesise — it is
+    skipped, exactly as `generate` renders it as a one-line silent-video marker.
+    """
+    has_text = source.has_speech is not False and bool(source.text)
+    return has_text or bool(source.frames)
+
+
+def items_pending_video_digest(store: dict[str, Item]) -> list[Item]:
+    """Items whose `x_video` source has content but no digest yet.
+
+    Selection is `has content AND empty digest`. Re-digesting a video whose
+    transcript later changed is out of scope here (there is no digest timestamp);
+    clear the `digest` field (or a future `--regenerate`) to force one.
+    """
+    pending: list[Item] = []
+    for item in store.values():
+        source = _video_source(item)
+        if source is None or not _has_digestible_content(source):
+            continue
+        if not source.digest:
+            pending.append(item)
+    return pending
+
+
+def export_video_digest_worksheet(
+    items: list[Item],
+    path: Path,
+    executor: str,
+    output_language: str,
+) -> None:
+    """Write a worksheet with everything needed to digest `items` by hand.
+
+    Each entry carries the FULL transcript (what the video says) + the frame
+    descriptions (what it shows) + the tweet text — the same visual/spoken signal
+    the digest must synthesise. `executor` is recorded so `--apply` attributes the
+    judgments to the track that produced the worksheet.
+    """
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "executor": executor,
+        "instructions": (
+            "For each entry in `items`, append one object to `judgments` with keys "
+            "{item_id, digest}. Write the `digest` following `rubric` — grounded in "
+            "`video_transcript` (what the video says) and `video_frame_descriptions` "
+            "(what it shows), NOT the tweet `text`/caption. Then run: xbrain "
+            "video-digest --apply <this file>."
+        ),
+        "rubric": load_rubric("video-digest", language=output_language),
+        "items": [
+            {
+                "item_id": item.id,
+                "author": item.author.handle,
+                "text": item.text,
+                "title": (source.title if (source := _video_source(item)) else None),
+                "video_transcript": _video_transcript(item),
+                "video_frame_descriptions": _video_frame_descriptions(item),
+            }
+            for item in items
+        ],
+        "judgments": [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def import_video_digest_worksheet(path: Path) -> list[dict]:
+    """Read the `judgments` list from a filled worksheet."""
+    if not path.exists():
+        raise FileNotFoundError(f"Worksheet not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("worksheet must be a JSON object")
+    judgments = data.get("judgments", [])
+    if not isinstance(judgments, list):
+        raise ValueError("worksheet `judgments` must be a list")
+    return judgments
+
+
+def apply_video_digest_judgments(
+    store: dict[str, Item], judgments: list[dict]
+) -> tuple[int, list[tuple[str, list[str]]]]:
+    """Write each `{item_id, digest}` onto its item's `x_video` source.
+
+    Returns `(applied_count, invalid)` where `invalid` is `(item_id, errors)`.
+    An unknown item, an item without an `x_video` source, or an empty/non-string
+    digest is rejected (recorded in `invalid`), never silently dropped.
+    """
+    applied = 0
+    invalid: list[tuple[str, list[str]]] = []
+    for judgment in judgments:
+        item_id = str(judgment.get("item_id"))
+        digest = judgment.get("digest")
+        item = store.get(item_id)
+        if item is None:
+            invalid.append((item_id, ["unknown item id"]))
+            continue
+        source = _video_source(item)
+        if source is None:
+            invalid.append((item_id, ["item has no x_video source"]))
+            continue
+        if not isinstance(digest, str) or not digest.strip():
+            invalid.append((item_id, ["digest is empty or not a string"]))
+            continue
+        source.digest = digest.strip()
+        applied += 1
+    return applied, invalid

--- a/src/xbrain/video_digest.py
+++ b/src/xbrain/video_digest.py
@@ -34,14 +34,20 @@ def _video_source(item: Item) -> ContentSourceSuccess | None:
 
 
 def _has_digestible_content(source: ContentSourceSuccess) -> bool:
-    """True when the `x_video` source carries content to digest.
+    """True when the `x_video` source carries content the worksheet will actually
+    serialise to digest.
 
-    A with-speech transcript (`has_speech` not False and non-empty `text`) OR any
-    key frames. A silent video with no frames has nothing to synthesise — it is
-    skipped, exactly as `generate` renders it as a one-line silent-video marker.
+    Aligned with the exporter so selection never outruns the payload: the
+    worksheet's transcript comes from `worksheet._video_transcript` (requires
+    `has_speech` truthy + non-empty `text`) and its frames from
+    `_video_frame_descriptions` (keeps only frames with a NON-EMPTY description).
+    A looser predicate (e.g. counting frames whose descriptions are all empty)
+    would export an item with nothing to digest and re-select it every run,
+    forever. A silent video with no described frames has nothing to synthesise.
     """
-    has_text = source.has_speech is not False and bool(source.text)
-    return has_text or bool(source.frames)
+    has_transcript = bool(source.has_speech) and bool(source.text)
+    has_frame_descriptions = any(frame.description for frame in source.frames)
+    return has_transcript or has_frame_descriptions
 
 
 def items_pending_video_digest(store: dict[str, Item]) -> list[Item]:

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -107,3 +107,18 @@ def test_describe_image_rubric_preserves_placeholder_when_language_none():
     """No-language calls (tests, manual inspection) keep the literal placeholder."""
     text = load_rubric("describe-image")
     assert "{language}" in text
+
+
+def test_video_digest_rubric_loads_and_substitutes_language():
+    """The video-digest rubric ships a `{language}` placeholder the loader must
+    substitute; its structural section keys must reach the LLM."""
+    text = load_rubric("video-digest", language="Spanish")
+    assert "{language}" not in text
+    assert "Spanish" in text
+    assert "Key points" in text
+    assert "What it is" in text
+
+
+def test_video_digest_rubric_preserves_placeholder_when_language_none():
+    text = load_rubric("video-digest")
+    assert "{language}" in text

--- a/tests/test_video_digest.py
+++ b/tests/test_video_digest.py
@@ -86,6 +86,14 @@ def test_pending_skips_silent_video_without_frames():
     assert items_pending_video_digest(store) == []
 
 
+def test_pending_skips_mute_video_whose_frames_have_empty_descriptions():
+    """Selection must match the exporter: a mute video whose frames all carry EMPTY
+    descriptions serialises to an empty worksheet (`_video_frame_descriptions` drops
+    them), so it must NOT be selected — else it is re-exported every run forever."""
+    store = {"7": _video_item(text="", has_speech=False, frame_descs=("", ""))}
+    assert items_pending_video_digest(store) == []
+
+
 def test_pending_skips_already_digested_video():
     store = {"7": _video_item(text="deep talk", digest="Already has a digest.")}
     assert items_pending_video_digest(store) == []

--- a/tests/test_video_digest.py
+++ b/tests/test_video_digest.py
@@ -1,0 +1,191 @@
+# tests/test_video_digest.py
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from xbrain.models import Author, Content, ContentSourceSuccess, Item, VideoFrame
+from xbrain.video_digest import (
+    apply_video_digest_judgments,
+    export_video_digest_worksheet,
+    import_video_digest_worksheet,
+    items_pending_video_digest,
+)
+
+
+def _video_item(
+    item_id: str = "7",
+    *,
+    text: str = "a talk about scaling laws",
+    has_speech: bool = True,
+    frame_descs: tuple[str, ...] = (),
+    digest: str = "",
+) -> Item:
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="a", name="A"),
+        text="watch this",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        content=Content(
+            fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video",
+                    url="https://x.com/v",
+                    title="A great talk",
+                    text=text,
+                    has_speech=has_speech,
+                    frames=[
+                        VideoFrame(
+                            timestamp=float(i),
+                            local_path=f"{item_id}/frames/{i}.png",
+                            description=d,
+                        )
+                        for i, d in enumerate(frame_descs)
+                    ],
+                    digest=digest,
+                )
+            ],
+        ),
+    )
+
+
+def _text_item(item_id: str = "9") -> Item:
+    """A non-video item — must never be selected for a video digest."""
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="a", name="A"),
+        text="a plain text post",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------- selection
+
+
+def test_pending_selects_video_with_transcript_and_no_digest():
+    store = {"7": _video_item(text="deep talk")}
+    assert [it.id for it in items_pending_video_digest(store)] == ["7"]
+
+
+def test_pending_selects_mute_video_with_frames():
+    """A silent slide/screen video (no transcript) but WITH frames is digestible."""
+    store = {"7": _video_item(text="", has_speech=False, frame_descs=("A slide.",))}
+    assert [it.id for it in items_pending_video_digest(store)] == ["7"]
+
+
+def test_pending_skips_silent_video_without_frames():
+    """No transcript AND no frames → nothing to digest."""
+    store = {"7": _video_item(text="", has_speech=False)}
+    assert items_pending_video_digest(store) == []
+
+
+def test_pending_skips_already_digested_video():
+    store = {"7": _video_item(text="deep talk", digest="Already has a digest.")}
+    assert items_pending_video_digest(store) == []
+
+
+def test_pending_skips_non_video_item():
+    store = {"9": _text_item()}
+    assert items_pending_video_digest(store) == []
+
+
+# ---------------------------------------------------------------- export
+
+
+def test_export_worksheet_carries_transcript_frames_and_rubric(tmp_path):
+    path = tmp_path / "ws.json"
+    export_video_digest_worksheet(
+        [_video_item(text="the full transcript", frame_descs=("A chart.", "A code slide."))],
+        path,
+        "claude-code",
+        "English",
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    entry = data["items"][0]
+    assert entry["video_transcript"] == "the full transcript"
+    assert entry["video_frame_descriptions"] == ["A chart.", "A code slide."]
+    assert entry["title"] == "A great talk"
+    assert data["executor"] == "claude-code"
+    assert data["judgments"] == []
+    # The rubric ships with {language} already substituted.
+    assert "{language}" not in data["rubric"]
+    assert "English" in data["rubric"]
+
+
+def test_export_worksheet_carries_full_untruncated_transcript(tmp_path):
+    """The worksheet is agent-judged, so it carries the whole transcript (no cap)."""
+    from xbrain.rubrics import TRANSCRIPT_CHAR_LIMIT
+
+    long_text = "word " * TRANSCRIPT_CHAR_LIMIT
+    path = tmp_path / "ws.json"
+    export_video_digest_worksheet([_video_item(text=long_text)], path, "manual", "English")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["video_transcript"] == long_text
+
+
+# ---------------------------------------------------------------- import
+
+
+def test_import_reads_judgments(tmp_path):
+    path = tmp_path / "ws.json"
+    export_video_digest_worksheet([_video_item()], path, "claude-code", "English")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["judgments"] = [{"item_id": "7", "digest": "A digest."}]
+    path.write_text(json.dumps(data), encoding="utf-8")
+    assert import_video_digest_worksheet(path) == [{"item_id": "7", "digest": "A digest."}]
+
+
+def test_import_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        import_video_digest_worksheet(tmp_path / "nope.json")
+
+
+def test_import_rejects_non_list_judgments(tmp_path):
+    path = tmp_path / "ws.json"
+    path.write_text(json.dumps({"judgments": {}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a list"):
+        import_video_digest_worksheet(path)
+
+
+# ---------------------------------------------------------------- apply
+
+
+def test_apply_writes_digest_onto_the_video_source():
+    store = {"7": _video_item(text="talk")}
+    applied, invalid = apply_video_digest_judgments(
+        store, [{"item_id": "7", "digest": "  A crisp digest.  "}]
+    )
+    assert applied == 1
+    assert invalid == []
+    source = store["7"].content.sources[0]
+    assert source.digest == "A crisp digest."  # stripped
+
+
+def test_apply_rejects_unknown_item():
+    store = {"7": _video_item()}
+    applied, invalid = apply_video_digest_judgments(store, [{"item_id": "404", "digest": "x"}])
+    assert applied == 0
+    assert invalid == [("404", ["unknown item id"])]
+
+
+def test_apply_rejects_item_without_video_source():
+    store = {"9": _text_item()}
+    applied, invalid = apply_video_digest_judgments(store, [{"item_id": "9", "digest": "x"}])
+    assert applied == 0
+    assert invalid[0][0] == "9"
+    assert "no x_video source" in invalid[0][1][0]
+
+
+def test_apply_rejects_empty_digest():
+    store = {"7": _video_item()}
+    applied, invalid = apply_video_digest_judgments(store, [{"item_id": "7", "digest": "   "}])
+    assert applied == 0
+    assert "empty" in invalid[0][1][0]
+    assert store["7"].content.sources[0].digest == ""  # unchanged


### PR DESCRIPTION
**PR-B** of the long-form video digest ([plan](../blob/develop/zz-support-files/docs/implementation-plans/video-longform-digest.md)). Produces the `digest` that PR-A (#77) renders.

## What
A new `xbrain video-digest` step, mirroring `enrich`'s worksheet handoff but for `{item_id, digest}`:
- **`rubric-video-digest.md`** — structured (*What it is · Key points · Why it matters*), language-aware via `{language}` (configured `[output].language`, not hardcoded).
- **`video_digest.py`** — `items_pending_video_digest` (x_video with transcript **or** frames + empty digest; **mute slide videos included**), `export/import_video_digest_worksheet` (full transcript + frame descriptions + rubric), `apply_video_digest_judgments` (writes `digest` onto the x_video source; rejects unknown item / no source / empty digest).
- **CLI** `xbrain video-digest` (`--executor manual|claude-code`, `--apply`, auto-snapshot) — the same keyless worksheet+agents engine as `enrich`.

## Scope
Worksheet engine only. The `api` (headless) path is a deliberate follow-up — this ships what the PR-C backfill needs, keyless.

## Tests
selection (transcript / mute-with-frames / silent-no-frames / already-digested / non-video) · worksheet carries full transcript + frames + language-substituted rubric · import (reads / missing / non-list) · apply (writes+strips / unknown / no-source / empty) · rubric loads + substitutes language.

## Gate
✅ 1127 tests · 95% cov · all checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)