### PR TITLE
feat(verify): xbrain verify — LLM-as-judge machinery for enrichment (PR-1 of #79)

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -87,6 +87,14 @@ from xbrain.vocab import (
     import_vocab_worksheet,
     induce_vocab,
 )
+from xbrain.verification import (
+    aggregate_verify_judgments,
+    export_verify_worksheet,
+    import_verify_judgments,
+    items_for_verification,
+    parse_targets,
+    render_verify_report,
+)
 from xbrain.video_digest import (
     apply_video_digest_judgments,
     export_video_digest_worksheet,
@@ -1391,6 +1399,49 @@ def video_digest_command(
         f"{len(pending)} vídeos exportados a {worksheet}\n"
         f"Rellena el array `judgments` (con Claude Code o a mano) y ejecuta:\n"
         f"  xbrain video-digest --apply {worksheet}"
+    )
+
+
+@app.command(name="verify")
+@_handle_cli_errors
+def verify_command(
+    target: str = typer.Option("all", help="summary | digest | topics | all"),
+    executor: str | None = typer.Option(
+        None, help="manual | claude-code (default: the executor set in config.toml)"
+    ),
+    apply: list[Path] = typer.Option(
+        None, "--apply", help="Filled worksheet(s), one per judge — aggregated into a report"
+    ),
+) -> None:
+    """Verifica los outputs de enriquecimiento (fidelidad + adherencia) con jueces LLM."""
+    cfg = _config()
+
+    if apply:
+        # Report-only: aggregate the N judges' passes; the store is not mutated.
+        aggregated = aggregate_verify_judgments([import_verify_judgments(path) for path in apply])
+        json_report, md_report = render_verify_report(aggregated)
+        (cfg.data_dir / "verify-report.json").write_text(json_report, encoding="utf-8")
+        (cfg.data_dir / "verify-report.md").write_text(md_report, encoding="utf-8")
+        typer.echo(
+            md_report.splitlines()[2] if len(md_report.splitlines()) > 2 else "Report escrito"
+        )
+        typer.echo(f"Report: {cfg.data_dir / 'verify-report.md'}")
+        return
+
+    chosen = executor or cfg.enrich_executor
+    if chosen not in ("manual", "claude-code"):
+        raise ValueError(f"Ejecutor {chosen!r} no soportado para verify — usa manual|claude-code.")
+    store = load_store(cfg.items_path)
+    pairs = items_for_verification(store, parse_targets(target))
+    if not pairs:
+        typer.echo("No hay outputs que verificar.")
+        return
+    worksheet = cfg.data_dir / "verify-worksheet.json"
+    export_verify_worksheet(pairs, worksheet, chosen, cfg.output_language)
+    typer.echo(
+        f"{len(pairs)} outputs exportados a {worksheet}\n"
+        f"Copia N veces (una por juez), rellena `judgments` en cada una, y ejecuta:\n"
+        f"  xbrain verify --apply ws1.json --apply ws2.json ..."
     )
 
 

--- a/src/xbrain/rubrics/rubric-verify.md
+++ b/src/xbrain/rubrics/rubric-verify.md
@@ -1,0 +1,47 @@
+# Rubric — Enrichment verification (LLM-as-judge)
+
+You are an independent judge. You receive one generated enrichment `output` (a
+short `summary`, a long-form video `digest`, or a `topics` assignment), the
+`source` it was made from (video transcript + frame descriptions, article body,
+tweet text), and the generation `rubric` that produced it. Judge the output —
+default to SKEPTICAL.
+
+Two axes:
+
+## 1. Faithfulness (PRIMARY)
+Every claim, number, name, date and quote in the output MUST be supported by the
+`source`. If the output states something the source does not — a hallucinated
+figure, a speaker/company not present, an invented conclusion — that is a
+faithfulness failure. Cite the offending span. A single unsupported factual claim
+is enough to FAIL, regardless of how well-written the output is. When the source
+is a mute video (frames only), the frame descriptions are the source of truth.
+
+## 2. Adherence (SECONDARY)
+Does the output obey its own generation `rubric`?
+- **summary:** 1-3 sentences, concise, in the configured language, no preamble.
+- **digest:** the structured shape (*What it is · Key points · Why it matters*),
+  grounded in transcript + frames, not the caption.
+- **topics:** the assigned topics genuinely fit the content (this is CORRECTNESS,
+  beyond mere slug validity — a valid-but-wrong topic is an adherence failure).
+
+## Verdict
+- **PASS** — faithful AND adherent.
+- **REVIEW** — faithful but a soft adherence issue (too long, weak structure, a
+  borderline topic), OR you are genuinely uncertain.
+- **FAIL** — any unsupported factual claim, or a hard rubric violation.
+
+## Output
+Respond with the judgment object only:
+
+```
+{"item_id": "...", "target": "summary|digest|topics",
+ "verdict": "PASS|REVIEW|FAIL",
+ "faithfulness": "PASS|FAIL",
+ "adherence": "PASS|REVIEW|FAIL",
+ "flags": [{"claim": "<the offending span from the output>",
+            "issue": "<why: unsupported / wrong topic / too long / …>"}]}
+```
+
+`flags` is empty on a clean PASS. Never invent a flag to look thorough; never wave
+through an unsupported claim to be agreeable. Language of the `issue` text: the
+configured {language}.

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -171,19 +171,32 @@ def _union_flags(judgments: list[dict]) -> list[dict]:
 
 
 def _group_verdict(faithfulness: str, adherence: str, verdicts: list[str]) -> str:
-    """FAIL if faithfulness/adherence failed, else REVIEW if any reviewed, else PASS."""
-    if faithfulness == "FAIL" or adherence == "FAIL":
+    """FAIL if any axis OR any judge's own verdict failed, else REVIEW, else PASS.
+
+    A raw `verdict == "FAIL"` must sink the group even when the judge left the
+    `faithfulness`/`adherence` axes at their lenient defaults — otherwise a
+    FAIL-but-under-populated judgment would silently render as PASS, the worst
+    failure mode for a verification layer. Symmetric with the REVIEW clause.
+    """
+    if faithfulness == "FAIL" or adherence == "FAIL" or "FAIL" in verdicts:
         return "FAIL"
     if adherence == "REVIEW" or "REVIEW" in verdicts:
         return "REVIEW"
     return "PASS"
 
 
+def _verdict_of(judgment: dict, key: str, default: str = "PASS") -> str:
+    """Read a verdict-like field, upper-cased + trimmed, so `fail`/`Fail` == `FAIL`."""
+    return str(judgment.get(key, default)).strip().upper()
+
+
 def _aggregate_group(item_id: str, target: str, judgments: list[dict]) -> dict:
     """Combine one `(item_id, target)` group's N judgments into a verdict record."""
-    faithfulness = "FAIL" if any(j.get("faithfulness") == "FAIL" for j in judgments) else "PASS"
-    adherence = _worst([str(j.get("adherence", "PASS")) for j in judgments])
-    verdicts = [str(j.get("verdict", "PASS")) for j in judgments]
+    faithfulness = (
+        "FAIL" if any(_verdict_of(j, "faithfulness") == "FAIL" for j in judgments) else "PASS"
+    )
+    adherence = _worst([_verdict_of(j, "adherence") for j in judgments])
+    verdicts = [_verdict_of(j, "verdict") for j in judgments]
     return {
         "item_id": item_id,
         "target": target,

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -1,0 +1,245 @@
+"""The `verify` step: semantic verification of generated enrichment.
+
+An LLM-as-judge ensemble scores each generated output (a short `summary`, a
+long-form video `digest`, or a `topics` assignment) for **faithfulness** (are its
+claims supported by the source?) and **rubric-adherence**, producing a per-item
+verdict PASS / REVIEW / FAIL + cited flags. This module is the deterministic
+plumbing (select → export worksheet → import → aggregate → render report); the
+judging itself is done by agents filling the worksheet, and the consequential
+verdicts are audited by a judge≠party pass (`verification_audit`, PR-2).
+
+Report-only: it never mutates the store. Mirrors `cv-guardrail` (judges →
+aggregate → verifier). Keyless worksheet+agents engine, like `enrich`.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, cast
+
+from xbrain.executors.api import _video_frame_descriptions
+from xbrain.models import Item
+from xbrain.rubrics import load_rubric
+from xbrain.video_digest import _video_source
+from xbrain.worksheet import _article_text, _video_transcript
+
+VerifyTarget = Literal["summary", "digest", "topics"]
+ALL_TARGETS: tuple[VerifyTarget, ...] = ("summary", "digest", "topics")
+
+# The generation rubric each target is judged against (a valid-but-wrong topic is
+# an adherence failure, so the topics judge reads the topics rubric).
+_TARGET_RUBRIC: dict[VerifyTarget, str] = {
+    "summary": "summary",
+    "digest": "video-digest",
+    "topics": "topics",
+}
+
+# Verdict ordering for "worst wins" aggregation.
+_VERDICT_ORDER: dict[str, int] = {"PASS": 0, "REVIEW": 1, "FAIL": 2}
+_ORDER_VERDICT: dict[int, str] = {0: "PASS", 1: "REVIEW", 2: "FAIL"}
+
+
+def parse_targets(target: str) -> tuple[VerifyTarget, ...]:
+    """Resolve the `--target` flag to a typed tuple, or raise on an unknown value."""
+    if target == "all":
+        return ALL_TARGETS
+    if target in ALL_TARGETS:
+        return (cast(VerifyTarget, target),)
+    raise ValueError(f"--target must be summary|digest|topics|all, got {target!r}")
+
+
+def _output_for(item: Item, target: VerifyTarget) -> str | None:
+    """The generated output for `target` on `item`, or None when absent.
+
+    `summary`/`topics` live on `item.enriched`; `digest` lives on the `x_video`
+    source. None means "nothing generated for this target" → skip it.
+    """
+    if target == "summary":
+        return item.enriched.summary if item.enriched and item.enriched.summary else None
+    if target == "topics":
+        if not item.enriched or not item.enriched.topics:
+            return None
+        return f"primary_topic: {item.enriched.primary_topic}\ntopics: {', '.join(item.enriched.topics)}"
+    source = _video_source(item)
+    return source.digest if (source and source.digest) else None
+
+
+def _source_text(item: Item) -> str:
+    """The ground-truth source the judge checks the output against.
+
+    Concatenates the labelled evidence present on the item — the FULL video
+    transcript (what it says), the frame descriptions (what it shows), the article
+    body, and the tweet text — so a claim in the output can be traced to it.
+    """
+    parts: list[str] = []
+    transcript = _video_transcript(item)
+    if transcript:
+        parts += ["[Video transcript]", transcript]
+    frames = _video_frame_descriptions(item)
+    if frames:
+        parts += ["[Video frames shown]", *(f"- {description}" for description in frames)]
+    article = _article_text(item)
+    if article:
+        parts += ["[Linked article]", article]
+    if item.text:
+        parts += ["[Tweet]", item.text]
+    return "\n".join(parts)
+
+
+def items_for_verification(
+    store: dict[str, Item], targets: tuple[VerifyTarget, ...]
+) -> list[tuple[Item, VerifyTarget]]:
+    """Every `(item, target)` pair that has a generated output to verify."""
+    pairs: list[tuple[Item, VerifyTarget]] = []
+    for item in store.values():
+        for target in targets:
+            if _output_for(item, target) is not None:
+                pairs.append((item, target))
+    return pairs
+
+
+def export_verify_worksheet(
+    pairs: list[tuple[Item, VerifyTarget]],
+    path: Path,
+    executor: str,
+    output_language: str,
+) -> None:
+    """Write a worksheet the judge fills: per `(item, target)`, the source + the
+    generated output + the target's generation rubric + the verify rubric.
+    """
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "executor": executor,
+        "instructions": (
+            "You are an independent judge. For each entry in `items`, judge its "
+            "`output` against its `source` and `generation_rubric` following "
+            "`verify_rubric`, and append one object to `judgments` with keys "
+            "{item_id, target, verdict, faithfulness, adherence, flags}. Then run: "
+            "xbrain verify --apply <this file>."
+        ),
+        "verify_rubric": load_rubric("verify", language=output_language),
+        "items": [
+            {
+                "item_id": item.id,
+                "target": target,
+                "author": item.author.handle,
+                "output": _output_for(item, target),
+                "source": _source_text(item),
+                "generation_rubric": load_rubric(_TARGET_RUBRIC[target], language=output_language),
+            }
+            for item, target in pairs
+        ],
+        "judgments": [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def import_verify_judgments(path: Path) -> list[dict]:
+    """Read the `judgments` list from one filled worksheet (one judge's pass)."""
+    if not path.exists():
+        raise FileNotFoundError(f"Worksheet not found: {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("worksheet must be a JSON object")
+    judgments = data.get("judgments", [])
+    if not isinstance(judgments, list):
+        raise ValueError("worksheet `judgments` must be a list")
+    return judgments
+
+
+def _worst(verdicts: list[str]) -> str:
+    """The most severe verdict (FAIL > REVIEW > PASS); PASS for an empty list."""
+    return _ORDER_VERDICT[max((_VERDICT_ORDER.get(v, 0) for v in verdicts), default=0)]
+
+
+def _union_flags(judgments: list[dict]) -> list[dict]:
+    """Every judge's flags, de-duplicated by `(claim, issue)`, in first-seen order."""
+    seen: set[tuple[str, str]] = set()
+    flags: list[dict] = []
+    for judgment in judgments:
+        for flag in judgment.get("flags") or []:
+            pair = (str(flag.get("claim")), str(flag.get("issue")))
+            if pair not in seen:
+                seen.add(pair)
+                flags.append({"claim": flag.get("claim"), "issue": flag.get("issue")})
+    return flags
+
+
+def _group_verdict(faithfulness: str, adherence: str, verdicts: list[str]) -> str:
+    """FAIL if faithfulness/adherence failed, else REVIEW if any reviewed, else PASS."""
+    if faithfulness == "FAIL" or adherence == "FAIL":
+        return "FAIL"
+    if adherence == "REVIEW" or "REVIEW" in verdicts:
+        return "REVIEW"
+    return "PASS"
+
+
+def _aggregate_group(item_id: str, target: str, judgments: list[dict]) -> dict:
+    """Combine one `(item_id, target)` group's N judgments into a verdict record."""
+    faithfulness = "FAIL" if any(j.get("faithfulness") == "FAIL" for j in judgments) else "PASS"
+    adherence = _worst([str(j.get("adherence", "PASS")) for j in judgments])
+    verdicts = [str(j.get("verdict", "PASS")) for j in judgments]
+    return {
+        "item_id": item_id,
+        "target": target,
+        "verdict": _group_verdict(faithfulness, adherence, verdicts),
+        "faithfulness": faithfulness,
+        "adherence": adherence,
+        "divergent": len(set(verdicts)) > 1,
+        "n_judges": len(judgments),
+        "flags": _union_flags(judgments),
+    }
+
+
+def aggregate_verify_judgments(judgment_sets: list[list[dict]]) -> list[dict]:
+    """Combine N judges' passes into one verdict per `(item_id, target)`.
+
+    Faithfulness is unforgiving — one judge's `faithfulness=FAIL` makes the group
+    FAIL. Adherence takes the worst. `divergent` is True when the judges' own
+    verdicts were not unanimous (a signal for the judge≠party audit). Flags are
+    unioned + de-duplicated. Worst verdicts (then divergent) sort first.
+    """
+    groups: dict[tuple[str, str], list[dict]] = {}
+    for judgments in judgment_sets:
+        for judgment in judgments:
+            key = (str(judgment.get("item_id")), str(judgment.get("target")))
+            groups.setdefault(key, []).append(judgment)
+    aggregated = [_aggregate_group(iid, target, js) for (iid, target), js in groups.items()]
+    aggregated.sort(key=lambda r: (-_VERDICT_ORDER[r["verdict"]], not r["divergent"]))
+    return aggregated
+
+
+def render_verify_report(aggregated: list[dict]) -> tuple[str, str]:
+    """Render `(json_report, markdown_report)` from the aggregated verdicts."""
+    counts = {"PASS": 0, "REVIEW": 0, "FAIL": 0}
+    for record in aggregated:
+        counts[record["verdict"]] = counts.get(record["verdict"], 0) + 1
+    total = len(aggregated)
+    report = {"total": total, "counts": counts, "records": aggregated}
+
+    lines = [
+        "# Verify report",
+        "",
+        f"**{total}** outputs judged — "
+        f"✅ {counts['PASS']} PASS · ⚠️ {counts['REVIEW']} REVIEW · ❌ {counts['FAIL']} FAIL",
+        "",
+    ]
+    for record in aggregated:
+        if record["verdict"] == "PASS" and not record["divergent"]:
+            continue  # the report leads with what needs a human; clean passes are in the JSON
+        badge = {"FAIL": "❌", "REVIEW": "⚠️", "PASS": "✅"}[record["verdict"]]
+        divergent = " · divergent" if record["divergent"] else ""
+        lines.append(
+            f"- {badge} **{record['verdict']}** `{record['target']}` "
+            f"[{record['item_id']}] "
+            f"(faithfulness {record['faithfulness']}, adherence {record['adherence']}, "
+            f"{record['n_judges']} judges{divergent})"
+        )
+        for flag in record["flags"]:
+            lines.append(f"    - ⚑ {flag['issue']}: “{flag['claim']}”")
+    if counts["FAIL"] == 0 and counts["REVIEW"] == 0:
+        lines.append("_No FAIL/REVIEW verdicts — the corpus passed._")
+    return json.dumps(report, indent=2, ensure_ascii=False), "\n".join(lines) + "\n"

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -161,6 +161,8 @@ def _union_flags(judgments: list[dict]) -> list[dict]:
     flags: list[dict] = []
     for judgment in judgments:
         for flag in judgment.get("flags") or []:
+            if not isinstance(flag, dict):
+                continue  # a malformed judge may emit a bare string flag — skip, don't crash
             pair = (str(flag.get("claim")), str(flag.get("issue")))
             if pair not in seen:
                 seen.add(pair)
@@ -205,6 +207,8 @@ def aggregate_verify_judgments(judgment_sets: list[list[dict]]) -> list[dict]:
     groups: dict[tuple[str, str], list[dict]] = {}
     for judgments in judgment_sets:
         for judgment in judgments:
+            if not isinstance(judgment, dict):
+                continue  # a malformed judge worksheet may hold a non-object — skip it
             key = (str(judgment.get("item_id")), str(judgment.get("target")))
             groups.setdefault(key, []).append(judgment)
     aggregated = [_aggregate_group(iid, target, js) for (iid, target), js in groups.items()]

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -122,3 +122,12 @@ def test_video_digest_rubric_loads_and_substitutes_language():
 def test_video_digest_rubric_preserves_placeholder_when_language_none():
     text = load_rubric("video-digest")
     assert "{language}" in text
+
+
+def test_verify_rubric_loads_and_substitutes_language():
+    """The verify rubric ships a `{language}` placeholder + names its axes/verdicts."""
+    text = load_rubric("verify", language="Spanish")
+    assert "{language}" not in text
+    assert "Spanish" in text
+    assert "Faithfulness" in text
+    assert "FAIL" in text

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -222,6 +222,33 @@ def test_aggregate_tolerates_malformed_judgments_and_flags():
     assert [f["claim"] for f in out[0]["flags"]] == ["X"]  # the bare-string flag was dropped
 
 
+def test_aggregate_raw_fail_verdict_forces_fail_even_without_axes():
+    """A judge's verdict=FAIL with the axis fields omitted must still yield group FAIL —
+    a FAIL must never be swallowed to PASS (the worst failure mode for a verifier)."""
+    out = aggregate_verify_judgments(
+        [
+            [
+                {
+                    "item_id": "7",
+                    "target": "summary",
+                    "verdict": "FAIL",
+                    "flags": [{"claim": "€150M", "issue": "unsupported"}],
+                }
+            ]
+        ]
+    )
+    assert out[0]["verdict"] == "FAIL"
+
+
+def test_aggregate_verdict_casing_is_normalised():
+    """Lowercase verdicts still count (`fail` == `FAIL`)."""
+    out = aggregate_verify_judgments(
+        [[{"item_id": "7", "target": "summary", "verdict": "fail", "faithfulness": "fail"}]]
+    )
+    assert out[0]["verdict"] == "FAIL"
+    assert out[0]["faithfulness"] == "FAIL"
+
+
 def test_aggregate_groups_by_item_and_target():
     sets = [[_j("PASS", target="summary"), _j("FAIL", faithfulness="FAIL", target="digest")]]
     out = aggregate_verify_judgments(sets)

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,0 +1,245 @@
+# tests/test_verification.py
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from xbrain.models import (
+    Author,
+    Content,
+    ContentSourceSuccess,
+    Enrichment,
+    Item,
+    VideoFrame,
+)
+from xbrain.verification import (
+    ALL_TARGETS,
+    aggregate_verify_judgments,
+    export_verify_worksheet,
+    import_verify_judgments,
+    items_for_verification,
+    parse_targets,
+    render_verify_report,
+)
+
+
+def test_parse_targets_resolves_and_validates():
+    assert parse_targets("all") == ALL_TARGETS
+    assert parse_targets("digest") == ("digest",)
+    with pytest.raises(ValueError, match=r"summary\|digest"):
+        parse_targets("bogus")
+
+
+def _item(
+    item_id: str = "7",
+    *,
+    summary: str = "A crisp summary.",
+    topics: tuple[str, ...] = ("ai-coding",),
+    transcript: str = "the full transcript body",
+    frame_descs: tuple[str, ...] = ("A chart.",),
+    digest: str = "A long digest.",
+) -> Item:
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="a", name="A"),
+        text="watch this",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        enriched=Enrichment(
+            enriched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+            executor="claude-code",
+            summary=summary,
+            primary_topic=topics[0],
+            topics=list(topics),
+        ),
+        content=Content(
+            fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video",
+                    url="https://x.com/v",
+                    title="A talk",
+                    text=transcript,
+                    has_speech=True,
+                    frames=[
+                        VideoFrame(
+                            timestamp=float(i),
+                            local_path=f"{item_id}/frames/{i}.png",
+                            description=d,
+                        )
+                        for i, d in enumerate(frame_descs)
+                    ],
+                    digest=digest,
+                )
+            ],
+        ),
+    )
+
+
+# ---------------------------------------------------------------- selection
+
+
+def test_items_for_verification_pairs_each_target_with_output():
+    store = {"7": _item()}
+    pairs = items_for_verification(store, ("summary", "digest", "topics"))
+    assert {t for _, t in pairs} == {"summary", "digest", "topics"}
+
+
+def test_items_for_verification_skips_absent_output():
+    """An item with a summary but no digest yields only the summary pair."""
+    store = {"7": _item(digest="")}
+    pairs = items_for_verification(store, ("summary", "digest"))
+    assert [t for _, t in pairs] == ["summary"]
+
+
+# ---------------------------------------------------------------- export
+
+
+def test_export_worksheet_carries_source_output_and_rubrics(tmp_path):
+    path = tmp_path / "ws.json"
+    store = {"7": _item(summary="S.", transcript="deep talk", frame_descs=("A chart.",))}
+    export_verify_worksheet(
+        items_for_verification(store, ("summary",)), path, "claude-code", "English"
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    entry = data["items"][0]
+    assert entry["target"] == "summary"
+    assert entry["output"] == "S."
+    assert "deep talk" in entry["source"]  # transcript in the source
+    assert "A chart." in entry["source"]  # frames in the source
+    assert "{language}" not in entry["generation_rubric"]  # summary rubric, substituted
+    assert "{language}" not in data["verify_rubric"]
+    assert "English" in data["verify_rubric"]
+    assert data["judgments"] == []
+
+
+def test_export_topics_output_shows_primary_and_topics(tmp_path):
+    path = tmp_path / "ws.json"
+    store = {"7": _item(topics=("ai-coding", "ai-industry"))}
+    export_verify_worksheet(items_for_verification(store, ("topics",)), path, "manual", "English")
+    entry = json.loads(path.read_text(encoding="utf-8"))["items"][0]
+    assert "ai-coding" in entry["output"]
+    assert "ai-industry" in entry["output"]
+
+
+# ---------------------------------------------------------------- import
+
+
+def test_import_reads_judgments(tmp_path):
+    path = tmp_path / "ws.json"
+    export_verify_worksheet(
+        items_for_verification({"7": _item()}, ("summary",)), path, "claude-code", "English"
+    )
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["judgments"] = [{"item_id": "7", "target": "summary", "verdict": "PASS"}]
+    path.write_text(json.dumps(data), encoding="utf-8")
+    assert import_verify_judgments(path)[0]["verdict"] == "PASS"
+
+
+def test_import_missing_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        import_verify_judgments(tmp_path / "nope.json")
+
+
+def test_import_rejects_non_list(tmp_path):
+    path = tmp_path / "ws.json"
+    path.write_text(json.dumps({"judgments": {}}), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be a list"):
+        import_verify_judgments(path)
+
+
+# ---------------------------------------------------------------- aggregate
+
+
+def _j(verdict, faithfulness="PASS", adherence="PASS", flags=None, item_id="7", target="summary"):
+    return {
+        "item_id": item_id,
+        "target": target,
+        "verdict": verdict,
+        "faithfulness": faithfulness,
+        "adherence": adherence,
+        "flags": flags or [],
+    }
+
+
+def test_aggregate_unanimous_pass():
+    out = aggregate_verify_judgments([[_j("PASS")], [_j("PASS")], [_j("PASS")]])
+    assert len(out) == 1
+    assert out[0]["verdict"] == "PASS"
+    assert out[0]["divergent"] is False
+    assert out[0]["n_judges"] == 3
+
+
+def test_aggregate_one_faithfulness_fail_forces_fail():
+    """One judge's faithfulness FAIL sinks the group, even if two say PASS."""
+    out = aggregate_verify_judgments(
+        [
+            [_j("PASS")],
+            [_j("FAIL", faithfulness="FAIL", flags=[{"claim": "€150M", "issue": "unsupported"}])],
+            [_j("PASS")],
+        ]
+    )
+    assert out[0]["verdict"] == "FAIL"
+    assert out[0]["faithfulness"] == "FAIL"
+    assert out[0]["divergent"] is True  # verdicts disagreed
+    assert {f["claim"] for f in out[0]["flags"]} == {"€150M"}
+
+
+def test_aggregate_adherence_review_yields_review():
+    out = aggregate_verify_judgments([[_j("PASS")], [_j("REVIEW", adherence="REVIEW")]])
+    assert out[0]["verdict"] == "REVIEW"
+    assert out[0]["adherence"] == "REVIEW"
+    assert out[0]["divergent"] is True
+
+
+def test_aggregate_dedupes_flags_across_judges():
+    same = {"claim": "X", "issue": "unsupported"}
+    out = aggregate_verify_judgments(
+        [
+            [_j("FAIL", faithfulness="FAIL", flags=[same])],
+            [_j("FAIL", faithfulness="FAIL", flags=[same])],
+        ]
+    )
+    assert len(out[0]["flags"]) == 1
+
+
+def test_aggregate_groups_by_item_and_target():
+    sets = [[_j("PASS", target="summary"), _j("FAIL", faithfulness="FAIL", target="digest")]]
+    out = aggregate_verify_judgments(sets)
+    by_target = {r["target"]: r["verdict"] for r in out}
+    assert by_target == {"summary": "PASS", "digest": "FAIL"}
+
+
+# ---------------------------------------------------------------- report
+
+
+def test_render_report_counts_and_leads_with_fail():
+    aggregated = aggregate_verify_judgments(
+        [
+            [_j("PASS", item_id="1")],
+            [
+                _j(
+                    "FAIL",
+                    faithfulness="FAIL",
+                    item_id="2",
+                    flags=[{"claim": "bad", "issue": "unsupported"}],
+                )
+            ],
+        ]
+    )
+    json_report, md = render_verify_report(aggregated)
+    data = json.loads(json_report)
+    assert data["counts"] == {"PASS": 1, "REVIEW": 0, "FAIL": 1}
+    assert data["total"] == 2
+    # The FAIL is surfaced with its flag; the clean PASS is not cluttering the md.
+    assert "FAIL" in md
+    assert "unsupported" in md
+    assert "[1]" not in md  # clean pass omitted from the human report
+
+
+def test_render_report_all_pass_says_so():
+    aggregated = aggregate_verify_judgments([[_j("PASS", item_id="1")]])
+    _, md = render_verify_report(aggregated)
+    assert "passed" in md.lower()

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -205,6 +205,23 @@ def test_aggregate_dedupes_flags_across_judges():
     assert len(out[0]["flags"]) == 1
 
 
+def test_aggregate_tolerates_malformed_judgments_and_flags():
+    """A non-dict judgment or a non-dict flag from a broken judge is skipped, not fatal."""
+    out = aggregate_verify_judgments(
+        [
+            [
+                "not a dict",  # non-dict judgment
+                _j(
+                    "FAIL", faithfulness="FAIL", flags=["bare string", {"claim": "X", "issue": "y"}]
+                ),
+            ]
+        ]
+    )
+    assert len(out) == 1
+    assert out[0]["verdict"] == "FAIL"
+    assert [f["claim"] for f in out[0]["flags"]] == ["X"]  # the bare-string flag was dropped
+
+
 def test_aggregate_groups_by_item_and_target():
     sets = [[_j("PASS", target="summary"), _j("FAIL", faithfulness="FAIL", target="digest")]]
     out = aggregate_verify_judgments(sets)


### PR DESCRIPTION
**PR-1** of the enrichment verification layer (#79). The deterministic machinery for an LLM-as-judge ensemble — faithfulness + adherence verdicts on summaries/digests/topics. Report-only; mirrors `cv-guardrail`.

## What
- **`rubric-verify.md`** — faithfulness (PRIMARY: any claim/number/name unsupported by the source → FAIL, cite the span) + adherence (length, digest structure, topic *correctness*) + verdict PASS/REVIEW/FAIL. `{language}`.
- **`verification.py`** — pure, fully-tested: `parse_targets`, `items_for_verification`, `export_verify_worksheet` (per item+target: **source** [full transcript + frames + article + tweet] + generated **output** + the target's **generation rubric** + the verify rubric), `import_verify_judgments`, `aggregate_verify_judgments` (N judge sets → per-item+target verdict; **worst-faithfulness wins**, worst-adherence, `divergent` flag, deduped flag union, worst-first sort), `render_verify_report` (json + human md).
- **CLI** `xbrain verify --target summary|digest|topics|all --executor manual|claude-code` (export) · `--apply ws1 --apply ws2 …` (aggregate N judges → `data/verify-report.{json,md}`). Keyless worksheet engine.

## Scope
Machinery only. **PR-2** = the judge≠party audit of FAIL/divergent clusters. **PR-3** = run over the 178 summaries + 193 digests. `api` engine + verdict-on-record are follow-ups.

## Tests
parse/select/export (source+output+rubrics, language-substituted) · import (reads/missing/non-list) · **aggregate** (unanimous PASS · one faithfulness-FAIL forces FAIL · adherence-REVIEW → REVIEW · divergence · flag dedup · group-by item+target) · report (counts, FAIL-leads, clean-PASS omitted, all-pass message).

## Gate
✅ 1144 tests · 95% cov · all A/B · every check green.

Closes part of #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)