### PR TITLE
fix(verify+enrich): ground judges in author metadata & guard unfetched links

### DIFF
--- a/src/xbrain/executors/api.py
+++ b/src/xbrain/executors/api.py
@@ -10,10 +10,17 @@ from __future__ import annotations
 
 import json
 import sys
+from collections.abc import Collection
 
 from xbrain.executors.base import EnrichmentJudgment
 from xbrain.llm_json import json_from_response
-from xbrain.models import ContentSourceSuccess, Item, MediaPhotoDescribed, Topic
+from xbrain.models import (
+    LINK_CONTENT_KINDS,
+    ContentSourceSuccess,
+    Item,
+    MediaPhotoDescribed,
+    Topic,
+)
 from xbrain.rubrics import (
     ARTICLE_CHAR_LIMIT,
     FRAME_DESC_CHAR_LIMIT,
@@ -145,33 +152,106 @@ def _images_section(item: Item) -> list[str]:
     return lines
 
 
-# The guardrail note stamped wherever an item links out but nothing was fetched.
-# One constant shared by every LLM surface (api prompt, enrich worksheet, verify
-# source) so the generator and the judge read the SAME contract.
-UNFETCHED_LINKS_NOTE = (
-    "The linked content was NOT fetched. Beyond the URL/domain itself, nothing "
-    "about the linked content is known — never describe, reconstruct or guess it "
-    "from the URL, the domain or world knowledge."
+# The rule half of every "this was never downloaded" guardrail note. One wording,
+# shared by every LLM surface (api prompt, enrich worksheet, verify source), so the
+# generator and the judge read the SAME contract and the judge can hold the
+# generator to it.
+_UNFETCHED_RULE = (
+    "Beyond the URL/domain itself, nothing about it is known — never describe, "
+    "reconstruct or guess it from the URL, the domain or world knowledge."
 )
+
+# The note stamped when an item quotes a post whose content is not on the item.
+# `quoted_id` is captured at extract time but NO fetcher downloads the quoted post,
+# so without this marker the generator is ordered (rubric-summary) to summarise
+# content that is not in its inputs — an invitation to invent.
+QUOTED_CONTENT_UNFETCHED_NOTE = f"The quoted post's content was NOT fetched. {_UNFETCHED_RULE}"
+
+
+def fetched_link_sources(item: Item) -> int:
+    """How many fetched LINK-content bodies the item carries (`LINK_CONTENT_KINDS`).
+
+    A `thread` / `quoted_tweet` / `x_video` source is NOT a fetched link, so it can
+    never mask a link nobody downloaded.
+    """
+    if item.content is None:
+        return 0
+    return sum(
+        1
+        for src in item.content.sources
+        if isinstance(src, ContentSourceSuccess) and src.kind in LINK_CONTENT_KINDS and src.text
+    )
 
 
 def links_content_unfetched(item: Item) -> bool:
-    """True when the item links out but NO linked content was fetched.
+    """True when the item links out and at least one link's content is missing.
 
-    The predicate mirrors `_article_sections`: fetched content is any
-    non-`x_video` success source with text (a transcript is manufactured text,
-    not linked content). Partial fetches (some links fetched, some not) are NOT
-    flagged — a fetched-article block is present then, and per-link matching by
-    URL is unreliable (t.co redirects vs resolved URLs).
+    A COUNT comparison, not a per-link URL match: pairing `item.links` to fetched
+    sources by URL is unreliable (a `t.co` shortlink vs the resolved URL), but
+    counting is exact — fewer fetched link bodies than links means some link's
+    content is missing, whether that is all of them or one of two.
     """
-    if not item.links:
+    return bool(item.links) and fetched_link_sources(item) < len(item.links)
+
+
+def unfetched_links_note(item: Item) -> str | None:
+    """The guardrail note for an item whose linked content is missing, or None.
+
+    A PARTIAL fetch states the counts: a `Linked article` block IS present then, and
+    would otherwise lend its credibility to a claim about the link nobody fetched.
+    """
+    if not links_content_unfetched(item):
+        return None
+    total, fetched = len(item.links), fetched_link_sources(item)
+    if fetched:
+        headline = (
+            f"Only {fetched} of {total} linked pages were fetched — the content of "
+            f"the other {total - fetched} was NOT fetched, and the fetched article "
+            "is no evidence for it."
+        )
+    else:
+        headline = "The linked content was NOT fetched."
+    return f"{headline} {_UNFETCHED_RULE}"
+
+
+def quoted_content_unfetched(item: Item) -> bool:
+    """True when the item quotes a post whose content is not on the item."""
+    if not item.quoted_id:
         return False
     if item.content is None:
         return True
     return not any(
-        isinstance(src, ContentSourceSuccess) and src.kind != "x_video" and src.text
+        isinstance(src, ContentSourceSuccess) and src.kind == "quoted_tweet" and src.text
         for src in item.content.sources
     )
+
+
+def first_source_text(item: Item, kinds: Collection[str]) -> str | None:
+    """The first success source of one of `kinds` that carries text, truncated, or None.
+
+    The one reader every surface shares (api prompt, worksheet, judge source), so a
+    thread / quoted post / linked article is never picked up under another's label.
+    """
+    if item.content is None:
+        return None
+    for src in item.content.sources:
+        if isinstance(src, ContentSourceSuccess) and src.kind in kinds and src.text:
+            return src.text[:ARTICLE_CHAR_LIMIT]
+    return None
+
+
+def thread_text(item: Item) -> str | None:
+    """The item's own expanded thread body, truncated, or None."""
+    return first_source_text(item, _THREAD_KINDS)
+
+
+def quoted_text(item: Item) -> str | None:
+    """The fetched quoted-post body, truncated, or None — today always None."""
+    return first_source_text(item, _QUOTED_KINDS)
+
+
+_THREAD_KINDS: frozenset[str] = frozenset({"thread"})
+_QUOTED_KINDS: frozenset[str] = frozenset({"quoted_tweet"})
 
 
 def _links_section(item: Item) -> list[str]:
@@ -183,25 +263,57 @@ def _links_section(item: Item) -> list[str]:
         "Links in the post (the domain is topic signal even when the article body is unavailable):",
     ]
     lines += [f"- {ln.url}  (domain: {ln.domain})" for ln in item.links]
-    if links_content_unfetched(item):
-        lines += ["", UNFETCHED_LINKS_NOTE]
+    note = unfetched_links_note(item)
+    if note:
+        lines += ["", note]
     return lines
 
 
-def _article_sections(item: Item) -> list[str]:
-    """Build one block per successfully-fetched article. Empty if no content.
+def _thread_section(item: Item) -> list[str]:
+    """Build the `Thread:` block — the poster's OWN expanded thread text.
 
-    `x_video` sources are excluded here — a video transcript is manufactured
-    text, not a linked article, and gets its own labelled `Video transcript:`
-    block (`_video_transcript_section`). Rendering it as a "Linked article"
-    would mislabel the content type to the LLM.
+    Labelled as a thread, never as a `Linked article`: it is real evidence (full
+    text, by the same author), but it is not the content of any link the post points
+    at, and passing it off as one would tell the LLM a page was downloaded when none
+    was.
+    """
+    text = thread_text(item)
+    if not text:
+        return []
+    return ["", "Thread (full text by the same author):", text]
+
+
+def _quoted_section(item: Item) -> list[str]:
+    """Build the quoted-post block: its fetched body, else the NOT-fetched marker.
+
+    No fetcher produces a `quoted_tweet` source today, so in practice this stamps the
+    marker. The fetched branch exists so that when one lands, the quoted body reaches
+    the LLM under its OWN label instead of being dropped by the `LINK_CONTENT_KINDS`
+    narrowing in `_article_sections`.
+    """
+    if not item.quoted_id:
+        return []
+    body = quoted_text(item)
+    if body:
+        return ["", "Quoted post (the content this post is sharing):", body]
+    return ["", "Quoted post — content NOT fetched:", QUOTED_CONTENT_UNFETCHED_NOTE]
+
+
+def _article_sections(item: Item) -> list[str]:
+    """Build one block per successfully-fetched LINKED article. Empty if no content.
+
+    Only `LINK_CONTENT_KINDS` are rendered here. A video transcript, a thread and a
+    quoted post are manufactured or own-authored text, not a linked article; each has
+    its own labelled block (`_video_transcript_section`, `_thread_section`,
+    `_quoted_section`). Rendering any of them as a "Linked article" would mislabel the
+    content type to the LLM — and tell it a link was fetched when it was not.
     """
     if item.content is None or not item.content.sources:
         return []
     lines: list[str] = []
     for src in item.content.sources:
         # Narrow to the success variant — only those carry `title`/`text`.
-        if isinstance(src, ContentSourceSuccess) and src.kind != "x_video" and src.text:
+        if isinstance(src, ContentSourceSuccess) and src.kind in LINK_CONTENT_KINDS and src.text:
             lines += [
                 "",
                 f"Linked article ({src.title or src.url}):",
@@ -242,9 +354,11 @@ def _user_prompt(item: Item, vocab: list[Topic]) -> str:
     ]
     if item.bookmark_folder:
         parts += ["", f"Saved by the user in the bookmark folder: {item.bookmark_folder}"]
+    parts += _thread_section(item)
     parts += _images_section(item)
     parts += _video_transcript_section(item)
     parts += _video_frames_section(item)
+    parts += _quoted_section(item)
     parts += _links_section(item)
     parts += _article_sections(item)
     return "\n".join(parts)

--- a/src/xbrain/executors/api.py
+++ b/src/xbrain/executors/api.py
@@ -145,6 +145,35 @@ def _images_section(item: Item) -> list[str]:
     return lines
 
 
+# The guardrail note stamped wherever an item links out but nothing was fetched.
+# One constant shared by every LLM surface (api prompt, enrich worksheet, verify
+# source) so the generator and the judge read the SAME contract.
+UNFETCHED_LINKS_NOTE = (
+    "The linked content was NOT fetched. Beyond the URL/domain itself, nothing "
+    "about the linked content is known — never describe, reconstruct or guess it "
+    "from the URL, the domain or world knowledge."
+)
+
+
+def links_content_unfetched(item: Item) -> bool:
+    """True when the item links out but NO linked content was fetched.
+
+    The predicate mirrors `_article_sections`: fetched content is any
+    non-`x_video` success source with text (a transcript is manufactured text,
+    not linked content). Partial fetches (some links fetched, some not) are NOT
+    flagged — a fetched-article block is present then, and per-link matching by
+    URL is unreliable (t.co redirects vs resolved URLs).
+    """
+    if not item.links:
+        return False
+    if item.content is None:
+        return True
+    return not any(
+        isinstance(src, ContentSourceSuccess) and src.kind != "x_video" and src.text
+        for src in item.content.sources
+    )
+
+
 def _links_section(item: Item) -> list[str]:
     """Build the `Links in the post:` block, or an empty list when not applicable."""
     if not item.links:
@@ -154,6 +183,8 @@ def _links_section(item: Item) -> list[str]:
         "Links in the post (the domain is topic signal even when the article body is unavailable):",
     ]
     lines += [f"- {ln.url}  (domain: {ln.domain})" for ln in item.links]
+    if links_content_unfetched(item):
+        lines += ["", UNFETCHED_LINKS_NOTE]
     return lines
 
 

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -55,6 +55,15 @@ FailureReason = Literal[
 # generate pipeline consumes it exactly like an article body.
 ContentKind = Literal["external_article", "x_article", "thread", "quoted_tweet", "x_video"]
 
+# The kinds whose body IS the content of an outbound LINK — the only evidence that
+# a link in `item.links` was actually downloaded. The other kinds are not: a
+# `thread` is the poster's OWN text, a `quoted_tweet` is a different post, an
+# `x_video` transcript is manufactured from the video. Treating any of them as "the
+# link was fetched" both silences the unfetched-links guardrail AND serves the
+# item's own words to the LLM under a `Linked article` label. ONE set, used by every
+# call site (api prompt, enrich worksheet, judge source) so the surfaces cannot drift.
+LINK_CONTENT_KINDS: frozenset[ContentKind] = frozenset({"external_article", "x_article"})
+
 
 class Author(BaseModel):
     """The X account that authored an item."""

--- a/src/xbrain/rubrics/rubric-summary.md
+++ b/src/xbrain/rubrics/rubric-summary.md
@@ -19,6 +19,12 @@ Produce a `summary` for one X post (a bookmark or the user's own tweet).
   post's own text. Do not write "article unavailable" — just describe what the
   post says. NEVER describe, reconstruct or guess the linked content from its
   URL, its domain or your own knowledge of it.
-- **Retweets / quotes:** summarise the substantive content being shared.
+- **Retweets / quotes:** summarise the shared content **when it is present** in the
+  item (a fetched article, a transcript, a quoted body). When it is not — the item
+  says `content NOT fetched`, or carries only a `quoted_content_note` — summarise
+  the post's own text instead. Never reconstruct the shared content you cannot see.
+- **Attribution:** the post's author is who POSTED it. On a repost, a quote or a clip
+  of someone else, the words are a third party's — do not name the poster as the
+  speaker or author of that content, and do not name a speaker the item never names.
 - **Noise** (greetings, one-word posts): a short factual description is fine.
 - Output the summary text only. No markdown, no headings, no quotes.

--- a/src/xbrain/rubrics/rubric-summary.md
+++ b/src/xbrain/rubrics/rubric-summary.md
@@ -14,8 +14,11 @@ Produce a `summary` for one X post (a bookmark or the user's own tweet).
   it says) and the frame descriptions (what it shows on screen). For a slide or
   screen-share video with no transcript, summarise from the frame descriptions.
   Still 1-3 sentences: capture the whole talk's subject, not just its opening.
-- **If the linked article could NOT be fetched:** summarise from the post's own
-  text. Do not write "article unavailable" — just describe what the post says.
+- **If the linked article could NOT be fetched** (the item says so explicitly —
+  an `unfetched_links_note` or a "content NOT fetched" line): summarise from the
+  post's own text. Do not write "article unavailable" — just describe what the
+  post says. NEVER describe, reconstruct or guess the linked content from its
+  URL, its domain or your own knowledge of it.
 - **Retweets / quotes:** summarise the substantive content being shared.
 - **Noise** (greetings, one-word posts): a short factual description is fine.
 - Output the summary text only. No markdown, no headings, no quotes.

--- a/src/xbrain/rubrics/rubric-verify.md
+++ b/src/xbrain/rubrics/rubric-verify.md
@@ -10,14 +10,36 @@ Two axes:
 
 ## 1. Faithfulness (PRIMARY)
 Every claim, number, name, date and quote in the output MUST be supported by the
-`source`. The `[Author]` block is trusted item metadata — attributing the post to
-its own author is supported. If the source marks links as `content NOT fetched`,
-any output claim describing that linked content (beyond the URL/domain itself) is
-unsupported — flag it. If the output states something the source does not — a hallucinated
+`source`. If the output states something the source does not — a hallucinated
 figure, a speaker/company not present, an invented conclusion — that is a
 faithfulness failure. Cite the offending span. A single unsupported factual claim
 is enough to FAIL, regardless of how well-written the output is. When the source
 is a mute video (frames only), the frame descriptions are the source of truth.
+
+**The `[Author]` block identifies WHO POSTED the item — nothing more.** It is
+trusted item metadata: naming them as the person who posted/shared it is supported,
+not a hallucination. It does NOT establish who WROTE or SPOKE the content. On a
+repost, a quote or a clip of someone else, the transcript/article belongs to a THIRD
+PARTY: the output must never name the poster as the author, speaker or presenter of
+that content unless the source itself says so. If the source does not name the
+speaker, the output must not name one either — an invented attribution is a
+faithfulness failure like any other.
+
+**Check every named speaker BEFORE you judge anything else.** Whenever the output
+names a person as the one who says / explains / argues / shows something, ask: does
+the SOURCE name them as the speaker or author of that content? The `[Author]` block
+does not — it says who posted it. Worked example: the source carries
+`[Author] @poster (Poster Name)` and a first-person transcript that never names its
+speaker; the output says *"Poster Name explains why RL is terrible"*. That is a
+faithfulness FAILURE — an invented attribution — **even when every other fact in the
+output is verbatim from the transcript**, and even when the output's only other
+problems are formatting ones. Do not let a clean-looking output past this check.
+
+**Content marked as never downloaded is not evidence.** When the source carries a
+`content NOT fetched` marker (a linked page, or a quoted post), any output claim
+describing that content — beyond the URL/domain itself — is unsupported. Flag it.
+The marker also appears on a PARTIAL fetch (some links fetched, some not): a
+present `[Linked article]` block is evidence only for the link it came from.
 
 ## 2. Adherence (SECONDARY)
 Does the output obey its own generation `rubric`?

--- a/src/xbrain/rubrics/rubric-verify.md
+++ b/src/xbrain/rubrics/rubric-verify.md
@@ -10,7 +10,10 @@ Two axes:
 
 ## 1. Faithfulness (PRIMARY)
 Every claim, number, name, date and quote in the output MUST be supported by the
-`source`. If the output states something the source does not — a hallucinated
+`source`. The `[Author]` block is trusted item metadata — attributing the post to
+its own author is supported. If the source marks links as `content NOT fetched`,
+any output claim describing that linked content (beyond the URL/domain itself) is
+unsupported — flag it. If the output states something the source does not — a hallucinated
 figure, a speaker/company not present, an invented conclusion — that is a
 faithfulness failure. Cite the offending span. A single unsupported factual claim
 is enough to FAIL, regardless of how well-written the output is. When the source

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -24,7 +24,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, cast
 
-from xbrain.executors.api import _video_frame_descriptions
+from xbrain.executors.api import (
+    UNFETCHED_LINKS_NOTE,
+    _video_frame_descriptions,
+    links_content_unfetched,
+)
 from xbrain.models import Item, Verdict, VerificationVerdict
 from xbrain.rubrics import load_rubric
 from xbrain.video_digest import _video_source
@@ -103,11 +107,14 @@ def fingerprint_output(item: Item, target: VerifyTarget) -> str | None:
 def _source_text(item: Item) -> str:
     """The ground-truth source the judge checks the output against.
 
-    Concatenates the labelled evidence present on the item — the FULL video
-    transcript (what it says), the frame descriptions (what it shows), the article
-    body, and the tweet text — so a claim in the output can be traced to it.
+    Concatenates the labelled evidence present on the item — the author metadata
+    (attributing a post to its own author is supported, not world knowledge), the
+    FULL video transcript (what it says), the frame descriptions (what it shows),
+    the article body, and the tweet text — so a claim in the output can be traced
+    to it. A link whose content was never fetched is explicitly marked, so any
+    output claim describing that linked content is checkable as unsupported.
     """
-    parts: list[str] = []
+    parts: list[str] = ["[Author]", f"@{item.author.handle} ({item.author.name})"]
     transcript = _video_transcript(item)
     if transcript:
         parts += ["[Video transcript]", transcript]
@@ -117,6 +124,12 @@ def _source_text(item: Item) -> str:
     article = _article_text(item)
     if article:
         parts += ["[Linked article]", article]
+    if links_content_unfetched(item):
+        parts += [
+            "[Links — content NOT fetched]",
+            *(f"- {link.url}  (domain: {link.domain})" for link in item.links),
+            UNFETCHED_LINKS_NOTE,
+        ]
     if item.text:
         parts += ["[Tweet]", item.text]
     return "\n".join(parts)

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -25,14 +25,17 @@ from pathlib import Path
 from typing import Literal, cast
 
 from xbrain.executors.api import (
-    UNFETCHED_LINKS_NOTE,
+    QUOTED_CONTENT_UNFETCHED_NOTE,
+    _content_image_descriptions,
     _video_frame_descriptions,
-    links_content_unfetched,
+    quoted_content_unfetched,
+    thread_text,
+    unfetched_links_note,
 )
 from xbrain.models import Item, Verdict, VerificationVerdict
-from xbrain.rubrics import load_rubric
+from xbrain.rubrics import ARTICLE_CHAR_LIMIT, load_rubric
 from xbrain.video_digest import _video_source
-from xbrain.worksheet import _article_text, _video_transcript
+from xbrain.worksheet import _link_content_source, _video_transcript
 
 logger = logging.getLogger(__name__)
 
@@ -104,32 +107,82 @@ def fingerprint_output(item: Item, target: VerifyTarget) -> str | None:
     return hashlib.sha256(output.encode("utf-8")).hexdigest()
 
 
-def _source_text(item: Item) -> str:
-    """The ground-truth source the judge checks the output against.
-
-    Concatenates the labelled evidence present on the item — the author metadata
-    (attributing a post to its own author is supported, not world knowledge), the
-    FULL video transcript (what it says), the frame descriptions (what it shows),
-    the article body, and the tweet text — so a claim in the output can be traced
-    to it. A link whose content was never fetched is explicitly marked, so any
-    output claim describing that linked content is checkable as unsupported.
-    """
-    parts: list[str] = ["[Author]", f"@{item.author.handle} ({item.author.name})"]
+def _video_parts(item: Item) -> list[str]:
+    """The video evidence: its title, the FULL transcript (what it says) and the frame
+    descriptions (what it shows). The title reaches the digest generator, so the judge
+    must see it too — a digest naming the talk is otherwise unsupported."""
+    source = _video_source(item)
+    parts: list[str] = []
+    if source and source.title:
+        parts += ["[Video title]", source.title]
     transcript = _video_transcript(item)
     if transcript:
         parts += ["[Video transcript]", transcript]
     frames = _video_frame_descriptions(item)
     if frames:
         parts += ["[Video frames shown]", *(f"- {description}" for description in frames)]
-    article = _article_text(item)
-    if article:
-        parts += ["[Linked article]", article]
-    if links_content_unfetched(item):
+    return parts
+
+
+def _article_parts(item: Item) -> list[str]:
+    """The fetched LINKED article, with its title (which the api prompt already ships).
+
+    Only `LINK_CONTENT_KINDS` reach this label. A thread or a transcript under it would
+    tell the judge a page was downloaded when none was, and hand it the wrong text as
+    that page's content.
+    """
+    source = _link_content_source(item)
+    if source is None:
+        return []
+    label = f"[Linked article — {source.title}]" if source.title else "[Linked article]"
+    return [label, source.text[:ARTICLE_CHAR_LIMIT]]
+
+
+def _unfetched_parts(item: Item) -> list[str]:
+    """The markers for content the pipeline never downloaded: links whose body is
+    missing (all of them, or the remainder of a PARTIAL fetch) and a quoted post, which
+    no fetcher retrieves. An output describing either is then checkable as unsupported
+    instead of being waved through against evidence that is not there."""
+    parts: list[str] = []
+    links_note = unfetched_links_note(item)
+    if links_note:
         parts += [
             "[Links — content NOT fetched]",
             *(f"- {link.url}  (domain: {link.domain})" for link in item.links),
-            UNFETCHED_LINKS_NOTE,
+            links_note,
         ]
+    if quoted_content_unfetched(item):
+        parts += ["[Quoted post — content NOT fetched]", QUOTED_CONTENT_UNFETCHED_NOTE]
+    return parts
+
+
+def _source_text(item: Item) -> str:
+    """The ground-truth source the judge checks the output against.
+
+    Concatenates the labelled evidence present on the item — the author metadata (WHO
+    POSTED it, not who wrote its content), the video title + FULL transcript (what it
+    says) + frame descriptions (what it shows), the image descriptions, the fetched
+    article body, the poster's own thread text, and the tweet text — so a claim in the
+    output can be traced to it. The judge must see everything the GENERATORS see: an
+    output grounded in a photo description or an article title would otherwise be
+    judged against a source that never held it, and flagged unsupported (a false FAIL).
+
+    Every kind of evidence keeps its OWN label. A thread is the poster's own words, not
+    a fetched page. Serving one under `[Linked article]` would affirmatively tell the
+    skeptical judge that a link was downloaded and hand it text that is not that link's
+    content — turning an unsupported claim about the linked piece into a PASS. Content
+    the pipeline never downloaded (a link's body, a quoted post) is marked as such.
+    """
+    parts: list[str] = ["[Author]", f"@{item.author.handle} ({item.author.name})"]
+    parts += _video_parts(item)
+    images = _content_image_descriptions(item)
+    if images:
+        parts += ["[Images in the post]", *(f"- {description}" for description in images)]
+    parts += _article_parts(item)
+    thread = thread_text(item)
+    if thread:
+        parts += ["[Thread — full text, same author]", thread]
+    parts += _unfetched_parts(item)
     if item.text:
         parts += ["[Tweet]", item.text]
     return "\n".join(parts)

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -13,31 +13,40 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from xbrain.executors.api import (
-    UNFETCHED_LINKS_NOTE,
+    QUOTED_CONTENT_UNFETCHED_NOTE,
     _content_image_descriptions,
     _video_frame_descriptions,
-    links_content_unfetched,
+    first_source_text,
+    quoted_content_unfetched,
+    thread_text,
+    unfetched_links_note,
 )
-from xbrain.models import ContentSourceSuccess, Item, Topic
-from xbrain.rubrics import ARTICLE_CHAR_LIMIT, load_rubric
+from xbrain.models import LINK_CONTENT_KINDS, ContentSourceSuccess, Item, Topic
+from xbrain.rubrics import load_rubric
 
 
-def _article_text(item: Item) -> str | None:
-    """First successful fetched article body, truncated, or None.
+def _link_content_source(item: Item) -> ContentSourceSuccess | None:
+    """First successfully-fetched LINKED page source (`LINK_CONTENT_KINDS`), or None.
 
-    Only the success variant of `ContentSource` carries `text`. The
-    isinstance narrowing satisfies mypy and silently skips broken-link
-    sources, matching the pre-#20 ``src.ok and src.text`` behaviour.
-    `x_video` sources are skipped — the transcript rides in its own
-    `video_transcript` field so the enrich track sees it as a transcript,
-    not an article (#44).
+    Only the success variant of `ContentSource` carries `text`. The isinstance
+    narrowing satisfies mypy and silently skips broken-link sources, matching the
+    pre-#20 ``src.ok and src.text`` behaviour. Only a linked page counts: an
+    `x_video` transcript rides in `video_transcript`, a `thread` in `thread` and a
+    quoted post in its own marker — none of them is a fetched article, and serving
+    one as `article` would tell the reader (agent or judge) a link was downloaded
+    when none was.
     """
     if not item.content:
         return None
     for src in item.content.sources:
-        if isinstance(src, ContentSourceSuccess) and src.kind != "x_video" and src.text:
-            return src.text[:ARTICLE_CHAR_LIMIT]
+        if isinstance(src, ContentSourceSuccess) and src.kind in LINK_CONTENT_KINDS and src.text:
+            return src
     return None
+
+
+def _article_text(item: Item) -> str | None:
+    """First successfully-fetched LINKED article body, truncated, or None."""
+    return first_source_text(item, LINK_CONTENT_KINDS)
 
 
 def _video_transcript(item: Item) -> str | None:
@@ -80,12 +89,15 @@ def export_worksheet(
         "instructions": (
             "For each entry in `items`, append one object to `judgments` with "
             "keys {item_id, summary, primary_topic, topics}. Use only slugs from "
-            "`vocab`. An item may also carry `links`, `article`, `video_transcript` "
-            "(the full talk — what the video SAYS), `video_frame_descriptions` (what "
-            "the video SHOWS: slides/screens, present even when there is no "
-            "transcript) and `image_descriptions` (content-bearing photos) — weigh "
-            "them all as topic signal, not just `text`. Then run: xbrain enrich "
-            "--apply <this file>."
+            "`vocab`. An item may also carry `links`, `article` (a FETCHED linked "
+            "page), `thread` (the poster's own full thread text — not a linked "
+            "page), `video_transcript` (the full talk — what the video SAYS), "
+            "`video_frame_descriptions` (what the video SHOWS: slides/screens, "
+            "present even when there is no transcript) and `image_descriptions` "
+            "(content-bearing photos) — weigh them all as topic signal, not just "
+            "`text`. `unfetched_links_note` / `quoted_content_note` mark content "
+            "that was NEVER downloaded: obey them — never describe or guess it. "
+            "Then run: xbrain enrich --apply <this file>."
         ),
         "rubrics": {
             "summary": load_rubric("summary", language=output_language),
@@ -100,11 +112,21 @@ def export_worksheet(
                 "bookmark_folder": it.bookmark_folder,
                 "links": [{"url": ln.url, "domain": ln.domain} for ln in it.links],
                 "article": _article_text(it),
-                # Guardrail: when the item links out but nothing was fetched, say so
-                # explicitly — the agent must not reconstruct the linked content
-                # from the URL/domain (see `links_content_unfetched`).
-                "unfetched_links_note": (
-                    UNFETCHED_LINKS_NOTE if links_content_unfetched(it) else None
+                # The poster's OWN expanded thread — real signal, but NOT a fetched
+                # linked page. It ships in its own field so the agent never reads the
+                # author's own words as the body of an article nobody downloaded.
+                "thread": thread_text(it),
+                # Guardrail: when the item links out and some link's content is
+                # missing, say so explicitly (with counts on a partial fetch) — the
+                # agent must not reconstruct the linked content from the URL/domain
+                # (see `links_content_unfetched`).
+                "unfetched_links_note": unfetched_links_note(it),
+                # Guardrail: `quoted_id` is captured but no fetcher downloads the
+                # quoted post, so the shared content is NOT in this worksheet. Without
+                # this note the summary rubric's "summarise the shared content" rule
+                # would be an order to invent it.
+                "quoted_content_note": (
+                    QUOTED_CONTENT_UNFETCHED_NOTE if quoted_content_unfetched(it) else None
                 ),
                 "video_transcript": _video_transcript(it),
                 # Content-bearing photo descriptions (#34): the same non-decorative

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -12,7 +12,12 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.executors.api import _content_image_descriptions, _video_frame_descriptions
+from xbrain.executors.api import (
+    UNFETCHED_LINKS_NOTE,
+    _content_image_descriptions,
+    _video_frame_descriptions,
+    links_content_unfetched,
+)
 from xbrain.models import ContentSourceSuccess, Item, Topic
 from xbrain.rubrics import ARTICLE_CHAR_LIMIT, load_rubric
 
@@ -95,6 +100,12 @@ def export_worksheet(
                 "bookmark_folder": it.bookmark_folder,
                 "links": [{"url": ln.url, "domain": ln.domain} for ln in it.links],
                 "article": _article_text(it),
+                # Guardrail: when the item links out but nothing was fetched, say so
+                # explicitly — the agent must not reconstruct the linked content
+                # from the URL/domain (see `links_content_unfetched`).
+                "unfetched_links_note": (
+                    UNFETCHED_LINKS_NOTE if links_content_unfetched(it) else None
+                ),
                 "video_transcript": _video_transcript(it),
                 # Content-bearing photo descriptions (#34): the same non-decorative
                 # selection the `api` executor injects as its `Images in this post:`

--- a/tests/test_executors_api.py
+++ b/tests/test_executors_api.py
@@ -478,3 +478,36 @@ def test_user_prompt_video_frames_sit_after_transcript_before_links():
     article_idx = prompt.index("Linked article")
     assert transcript_idx < frames_idx < links_idx
     assert frames_idx < article_idx
+
+
+def test_user_prompt_flags_unfetched_links():
+    """When the linked content was never fetched, the prompt says so explicitly —
+    the model must not reconstruct the linked content from the URL/domain."""
+    from xbrain.models import Link
+
+    item = _item("1", links=[Link(url="https://t.co/x", domain="time.com")])
+    prompt = _user_prompt(item, VOCAB)
+    assert "NOT fetched" in prompt
+
+
+def test_user_prompt_does_not_flag_links_when_article_fetched():
+    from datetime import datetime, timezone
+
+    from xbrain.models import Content, ContentSourceSuccess
+
+    from xbrain.models import Link
+
+    item = _item("1", links=[Link(url="https://arxiv.org/abs/1", domain="arxiv.org")])
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        sources=[
+            ContentSourceSuccess(
+                kind="external_article",
+                url="https://arxiv.org/abs/1",
+                title="Paper",
+                text="the fetched body",
+            )
+        ],
+    )
+    prompt = _user_prompt(item, VOCAB)
+    assert "NOT fetched" not in prompt

--- a/tests/test_executors_api.py
+++ b/tests/test_executors_api.py
@@ -1,8 +1,10 @@
 # tests/test_executors_api.py
 from datetime import datetime, timezone
 
-from xbrain.executors.api import ApiExecutor, _user_prompt
-from xbrain.models import Author, Item, Link, Topic
+import pytest
+
+from xbrain.executors.api import ApiExecutor, _user_prompt, links_content_unfetched
+from xbrain.models import Author, Content, ContentSourceSuccess, Item, Link, Topic
 
 from tests.conftest import FakeAnthropic
 
@@ -480,34 +482,105 @@ def test_user_prompt_video_frames_sit_after_transcript_before_links():
     assert frames_idx < article_idx
 
 
-def test_user_prompt_flags_unfetched_links():
-    """When the linked content was never fetched, the prompt says so explicitly —
-    the model must not reconstruct the linked content from the URL/domain."""
-    from xbrain.models import Link
+# -------------------------------------------------- unfetched-content guardrails
 
-    item = _item("1", links=[Link(url="https://t.co/x", domain="time.com")])
-    prompt = _user_prompt(item, VOCAB)
+
+def _linked_item(*, links: int = 1, sources: list[ContentSourceSuccess] | None = None, **extra):
+    """An item with `links` outbound links and an optional content source list."""
+    return _item(
+        "1",
+        links=[Link(url=f"https://t.co/{i}", domain=f"site{i}.com") for i in range(links)],
+        content=(
+            Content(fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc), sources=list(sources))
+            if sources is not None
+            else None
+        ),
+        **extra,
+    )
+
+
+def _source(kind: str, text: str = "some body", **extra) -> ContentSourceSuccess:
+    return ContentSourceSuccess(kind=kind, url="https://x/1", text=text, **extra)
+
+
+# The predicate is the WHOLE guardrail: when it is False no surface is marked, so
+# every content shape it can meet is pinned here. Only a fetched LINKED page
+# (`external_article` / `x_article`) counts as "the link was fetched" — a `thread`
+# is the item's OWN text, a `quoted_tweet` is another post, an `x_video` is a
+# manufactured transcript. None of them is evidence an outbound link was read.
+@pytest.mark.parametrize(
+    ("links", "kinds", "expected"),
+    [
+        (0, [], False),  # no links → nothing to guard
+        (1, [], True),  # links, content is None → nothing fetched
+        (1, ["external_article"], False),  # the link WAS fetched
+        (1, ["x_article"], False),  # an X longform article counts too
+        (1, ["thread"], True),  # F1: a thread is the item's own text
+        (1, ["quoted_tweet"], True),  # a quoted post is not the linked page
+        (1, ["x_video"], True),  # a transcript is not the linked page
+        (1, ["thread", "x_video"], True),  # F1: still nothing linked was fetched
+        (2, ["external_article"], True),  # F5: 1 of 2 links fetched → still flagged
+        (2, ["external_article", "x_article"], False),  # both links fetched
+        (1, ["external_article", "thread"], False),  # article + own thread → fetched
+    ],
+)
+def test_links_content_unfetched_only_counts_fetched_linked_pages(links, kinds, expected):
+    item = _linked_item(links=links, sources=[_source(k) for k in kinds] if kinds else None)
+    assert links_content_unfetched(item) is expected
+
+
+def test_links_content_unfetched_ignores_a_textless_source():
+    """A success source with empty text (a no-speech video) is not fetched content."""
+    item = _linked_item(sources=[_source("x_video", text="", has_speech=False)])
+    assert links_content_unfetched(item) is True
+
+
+def test_user_prompt_flags_unfetched_links():
+    """When the linked content was never fetched, the prompt carries the guardrail
+    note — the model must not reconstruct the linked content from the URL/domain."""
+    prompt = _user_prompt(_linked_item(), VOCAB)
     assert "NOT fetched" in prompt
+    assert "never describe, reconstruct or guess" in prompt
 
 
 def test_user_prompt_does_not_flag_links_when_article_fetched():
-    from datetime import datetime, timezone
-
-    from xbrain.models import Content, ContentSourceSuccess
-
-    from xbrain.models import Link
-
-    item = _item("1", links=[Link(url="https://arxiv.org/abs/1", domain="arxiv.org")])
-    item.content = Content(
-        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
-        sources=[
-            ContentSourceSuccess(
-                kind="external_article",
-                url="https://arxiv.org/abs/1",
-                title="Paper",
-                text="the fetched body",
-            )
-        ],
-    )
+    item = _linked_item(sources=[_source("external_article", "the fetched body")])
     prompt = _user_prompt(item, VOCAB)
     assert "NOT fetched" not in prompt
+    assert "the fetched body" in prompt
+
+
+def test_user_prompt_labels_thread_text_as_thread_not_article():
+    """F1: a thread's own text is the item's own words, NOT a fetched linked page.
+    It must reach the model under its own label, and it must not suppress the
+    unfetched-links guardrail for a link nobody downloaded."""
+    item = _linked_item(sources=[_source("thread", "1/ my thread\n\n2/ about agents")])
+    prompt = _user_prompt(item, VOCAB)
+    assert "1/ my thread" in prompt  # the thread text is NOT dropped — it is signal
+    thread_idx = prompt.index("Thread (full text by the same author):")
+    assert thread_idx < prompt.index("1/ my thread")
+    assert "Linked article" not in prompt  # …but it is not served as a fetched article
+    assert "NOT fetched" in prompt  # …and the unfetched link is still flagged
+
+
+def test_user_prompt_partial_fetch_flags_the_missing_link_with_counts():
+    """F5: 2 links, 1 fetched — the fetched body is present AND the note says how
+    many links were left unfetched, so a claim about the other one is checkable."""
+    item = _linked_item(links=2, sources=[_source("external_article", "the fetched body")])
+    prompt = _user_prompt(item, VOCAB)
+    assert "the fetched body" in prompt
+    assert "1 of 2" in prompt
+    assert "NOT fetched" in prompt
+
+
+def test_user_prompt_marks_an_unfetched_quoted_post():
+    """F3: the quoted post's content is never downloaded — say so, so the generator
+    does not invent the content it was told to summarise."""
+    item = _item("1", quoted_id="123")
+    prompt = _user_prompt(item, VOCAB)
+    assert "Quoted post" in prompt
+    assert "NOT fetched" in prompt
+
+
+def test_user_prompt_has_no_quoted_marker_without_a_quote():
+    assert "Quoted post" not in _user_prompt(_item("1"), VOCAB)

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -140,3 +140,30 @@ def test_verify_audit_rubric_loads_and_substitutes_language():
     assert "Spanish" in text
     assert "CONFIRM" in text
     assert "REVOKE" in text
+
+
+def test_verify_rubric_author_block_licenses_only_who_posted():
+    """F2: the `[Author]` block says who POSTED the item — nothing about who wrote or
+    spoke its CONTENT. The two come apart on a repost/quote/clip of someone else: a
+    digest naming the poster as the speaker of a clip is a MISATTRIBUTION the judge
+    caught before this rule existed. The rubric must grant only the true half.
+    """
+    text = load_rubric("verify", language="English").lower()
+    # The permissive wording that licensed attributing anyone's words to the poster.
+    assert "attributing the post to its own author is supported" not in text
+    # What the block DOES establish: who posted it.
+    assert "posted" in text
+    # What it does NOT establish: authorship/voice of the content, on a repost/quote/clip.
+    assert "repost" in text or "quote" in text or "clip" in text
+    assert "speaker" in text
+    assert "does not establish" in text or "not establish" in text
+
+
+def test_summary_rubric_only_summarises_shared_content_when_present():
+    """F3: no fetcher downloads a quoted post, so ordering the generator to
+    'summarise the substantive content being shared' orders it to invent. The rule
+    must be conditional on that content actually being in the source."""
+    text = load_rubric("summary", language="English").lower()
+    assert "summarise the substantive content being shared." not in text
+    assert "when it is present" in text or "when its content is present" in text
+    assert "post's own text" in text

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -465,3 +465,122 @@ def test_source_text_no_unfetched_marker_when_article_fetched():
     )
     text = _source_text(item)
     assert "NOT fetched" not in text
+    assert "[Linked article" in text
+    assert "the fetched article body" in text
+
+
+def _label_of(text: str, needle: str) -> str:
+    """The `[Label]` block heading the line `needle` appears under, in `_source_text`."""
+    label = "<none>"
+    for line in text.splitlines():
+        if line.startswith("["):
+            label = line
+        if needle in line:
+            return label
+    raise AssertionError(f"{needle!r} not found in source:\n{text}")
+
+
+def test_source_text_labels_thread_text_as_thread_not_a_fetched_article():
+    """F1 (the regression this PR must not ship): a THREAD's own text is the
+    poster's own words. Served under `[Linked article]` it tells the skeptical judge
+    an article was fetched and hands it the thread body as that article's content —
+    so a claim about the linked piece would be judged SUPPORTED against text that is
+    not the piece. It must keep its own label AND still flag the unfetched link."""
+    from xbrain.models import Link
+    from xbrain.verification import _source_text
+
+    item = _item()
+    item.links = [Link(url="https://t.co/x", domain="time.com")]
+    item.content.sources.append(
+        ContentSourceSuccess(
+            kind="thread",
+            url="https://x.com/a/status/7",
+            text="1/ my thread about agents",
+        )
+    )
+    text = _source_text(item)
+    assert "1/ my thread about agents" in text  # not dropped — a thread is real evidence
+    assert _label_of(text, "1/ my thread about agents") == "[Thread — full text, same author]"
+    assert "[Linked article" not in text
+    assert "[Links — content NOT fetched]" in text
+
+
+def test_source_text_partial_fetch_marks_the_unfetched_link_with_counts():
+    """F5: 2 links, 1 fetched — the article block is present, but the judge is told
+    only 1 of 2 links was fetched, so a claim about the other one stays checkable."""
+    from xbrain.models import Link
+    from xbrain.verification import _source_text
+
+    item = _item()
+    item.links = [
+        Link(url="https://example.com/a", domain="example.com"),
+        Link(url="https://t.co/x", domain="time.com"),
+    ]
+    item.content.sources.append(
+        ContentSourceSuccess(
+            kind="external_article",
+            url="https://example.com/a",
+            title="The piece",
+            text="the fetched article body",
+        )
+    )
+    text = _source_text(item)
+    assert "the fetched article body" in text
+    assert "[Links — content NOT fetched]" in text
+    assert "1 of 2" in text
+
+
+def test_source_text_marks_an_unfetched_quoted_post():
+    """F3: `quoted_id` is captured but the quoted post is never fetched — the judge
+    must be told, so a summary describing the quoted content is unsupported."""
+    from xbrain.verification import _source_text
+
+    item = _item()
+    item.quoted_id = "999"
+    text = _source_text(item)
+    assert "[Quoted post — content NOT fetched]" in text
+
+
+def test_source_text_carries_images_and_titles_the_generators_ship():
+    """F4: the judge must not see LESS than the generator. The image descriptions,
+    the article title and the video title all reach the generators — a summary
+    grounded in them would otherwise be judged unsupported (a false FAIL)."""
+    from xbrain.models import Link, MediaPhotoDescribed
+    from xbrain.verification import _source_text
+
+    item = _item()
+    item.links = [Link(url="https://example.com/a", domain="example.com")]
+    item.media = [
+        MediaPhotoDescribed(
+            url="https://pbs.twimg.com/media/X.jpg",
+            local_path="7/0.jpg",
+            width=4,
+            height=3,
+            bytes_size=512,
+            downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+            is_decorative=False,
+            description="A bar chart of GPU prices.",
+            description_lang="English",
+            description_version="v1",
+            described_at=datetime(2026, 5, 24, 12, tzinfo=timezone.utc),
+        )
+    ]
+    item.content.sources.append(
+        ContentSourceSuccess(
+            kind="external_article",
+            url="https://example.com/a",
+            title="The TIME piece",
+            text="the fetched article body",
+        )
+    )
+    text = _source_text(item)
+    assert _label_of(text, "A bar chart of GPU prices.") == "[Images in the post]"
+    assert "The TIME piece" in text  # the article title the api prompt already ships
+    assert _label_of(text, "A talk") == "[Video title]"  # the video title the digest ships
+
+
+def test_source_text_omits_decorative_image_descriptions():
+    """A decorative photo carries no description — it must not add an empty bullet."""
+    from xbrain.verification import _source_text
+
+    assert "[Images in the post]" not in _source_text(_item())

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -420,3 +420,48 @@ def test_apply_verdicts_tallies_skipped_records_with_reasons():
     assert reasons == {"item-gone", "fingerprint-missing", "malformed-record"}
     assert result.attempted == 4
     assert "1 de 4" in result.summary() and "item-gone" in result.summary()
+
+
+# ---------------------------------------------------------------- source text
+
+
+def test_source_text_includes_author():
+    """The judge's source carries the item's author metadata — attributing a post
+    to its own author must be verifiable from the source, not world knowledge."""
+    from xbrain.verification import _source_text
+
+    text = _source_text(_item())
+    assert "[Author]" in text
+    assert "@a (A)" in text
+
+
+def test_source_text_marks_unfetched_links():
+    """A link whose content was never fetched is explicitly marked, so a judge
+    treats any claim about the linked content as unsupported."""
+    from xbrain.models import Link
+    from xbrain.verification import _source_text
+
+    item = _item()
+    item.links = [Link(url="https://t.co/x", domain="time.com")]
+    # the only content source is the x_video transcript — no fetched article
+    text = _source_text(item)
+    assert "NOT fetched" in text
+    assert "time.com" in text
+
+
+def test_source_text_no_unfetched_marker_when_article_fetched():
+    from xbrain.models import Link
+    from xbrain.verification import _source_text
+
+    item = _item()
+    item.links = [Link(url="https://example.com/a", domain="example.com")]
+    item.content.sources.append(
+        ContentSourceSuccess(
+            kind="external_article",
+            url="https://example.com/a",
+            title="The piece",
+            text="the fetched article body",
+        )
+    )
+    text = _source_text(item)
+    assert "NOT fetched" not in text

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -355,3 +355,65 @@ def test_export_worksheet_no_unfetched_note_without_links(tmp_path):
     export_worksheet([item], VOCAB, path, "claude-code", "English")
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["items"][0]["unfetched_links_note"] is None
+
+
+def _exported(item, tmp_path) -> dict:
+    """Export one item and return its worksheet entry."""
+    path = tmp_path / "ws.json"
+    export_worksheet([item], VOCAB, path, "claude-code", "English")
+    return json.loads(path.read_text(encoding="utf-8"))["items"][0]
+
+
+def _with_sources(item, *sources):
+    from xbrain.models import Content
+
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc), sources=list(sources)
+    )
+    return item
+
+
+def _success(kind: str, text: str, **extra):
+    from xbrain.models import ContentSourceSuccess
+
+    return ContentSourceSuccess(kind=kind, url="https://x.com/a/status/1", text=text, **extra)
+
+
+def test_export_worksheet_thread_text_is_a_thread_not_an_article(tmp_path):
+    """F1: a thread's own text must NOT be exported as the fetched `article` — the
+    enrich agent would read the poster's own words as a downloaded linked page."""
+    item = _with_sources(_item("1"), _success("thread", "1/ my thread\n\n2/ about agents"))
+    entry = _exported(item, tmp_path)
+    assert entry["article"] is None
+    assert entry["thread"] == "1/ my thread\n\n2/ about agents"
+    # …and the link nobody fetched is still flagged.
+    assert entry["unfetched_links_note"] is not None
+
+
+def test_export_worksheet_partial_fetch_notes_the_missing_link(tmp_path):
+    """F5: 2 links, 1 fetched — the article is exported AND the note states the counts."""
+    from xbrain.models import Link
+
+    item = _item("1")
+    item.links = [
+        Link(url="https://arxiv.org/abs/1", domain="arxiv.org"),
+        Link(url="https://t.co/x", domain="time.com"),
+    ]
+    _with_sources(item, _success("external_article", "the fetched body", title="Paper"))
+    entry = _exported(item, tmp_path)
+    assert entry["article"] == "the fetched body"
+    assert "1 of 2" in entry["unfetched_links_note"]
+
+
+def test_export_worksheet_marks_an_unfetched_quoted_post(tmp_path):
+    """F3: the quoted post is never fetched — the worksheet says so, so the agent
+    does not invent the shared content the summary rubric asks it to describe."""
+    item = _item("1")
+    item.quoted_id = "999"
+    entry = _exported(item, tmp_path)
+    assert entry["quoted_content_note"] is not None
+    assert "NOT fetched" in entry["quoted_content_note"]
+
+
+def test_export_worksheet_no_quoted_note_without_a_quote(tmp_path):
+    assert _exported(_item("1"), tmp_path)["quoted_content_note"] is None

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -314,3 +314,44 @@ def test_export_worksheet_omits_video_frame_descriptions_when_none(tmp_path):
     export_worksheet([_video_item("1", text="a talk")], VOCAB, path, "manual", "English")
     data = json.loads(path.read_text(encoding="utf-8"))
     assert data["items"][0]["video_frame_descriptions"] == []
+
+
+def test_export_worksheet_notes_unfetched_links(tmp_path):
+    """A linking item with no fetched content carries an explicit guardrail note,
+    so the enrich agent never guesses the linked content from the URL/domain."""
+    path = tmp_path / "ws.json"
+    export_worksheet([_item("1")], VOCAB, path, "claude-code", "English")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    note = data["items"][0]["unfetched_links_note"]
+    assert note is not None
+    assert "NOT fetched" in note
+
+
+def test_export_worksheet_no_unfetched_note_when_article_fetched(tmp_path):
+    from xbrain.models import Content, ContentSourceSuccess
+
+    item = _item("1")
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        sources=[
+            ContentSourceSuccess(
+                kind="external_article",
+                url="https://arxiv.org/abs/1",
+                title="Paper",
+                text="the fetched body",
+            )
+        ],
+    )
+    path = tmp_path / "ws.json"
+    export_worksheet([item], VOCAB, path, "claude-code", "English")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["unfetched_links_note"] is None
+
+
+def test_export_worksheet_no_unfetched_note_without_links(tmp_path):
+    item = _item("1")
+    item.links = []
+    path = tmp_path / "ws.json"
+    export_worksheet([item], VOCAB, path, "claude-code", "English")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["items"][0]["unfetched_links_note"] is None


### PR DESCRIPTION
## Qué

Dos huecos de grounding que salieron en el run de verificación del 2026-07-10 (193 outputs juzgados):

### 1. El juez no veía el autor del ítem
`_source_text` no incluía el autor, así que los jueces marcaban como alucinación atribuciones correctas al propio autor del post (@emollick, Sam Altman vía display name, Epoch AI) — **36+ falsos flags de faithfulness en un solo run**. Ahora el source del juez abre con un bloque `[Author] @handle (Name)` y `rubric-verify.md` lo declara metadato confiable.

### 2. Nada marcaba un enlace cuyo contenido no se descargó
Un tweet solo-enlace acabó con un summary que **inventaba el artículo completo** (tema, empresa, contenido). El guardarraíl es estructural, no solo de rúbrica: cuando un ítem tiene links pero ningún contenido descargado, TODAS las superficies LLM llevan la misma nota explícita (`UNFETCHED_LINKS_NOTE`, constante única compartida):

- prompt del executor `api` → línea en la sección de links
- worksheet de `enrich` → campo `unfetched_links_note` por ítem
- source de `verify` → bloque `[Links — content NOT fetched]` con los links

Generador y juez leen el mismo contrato: el generador no puede describir lo no descargado, y si lo hace, el juez tiene la evidencia para flaggearlo.

**Semántica del predicado** (`links_content_unfetched`): links presentes y NINGÚN source de contenido no-`x_video` con texto. Los fetch parciales no se marcan (hay bloque de artículo presente y el matching por URL es poco fiable con redirects t.co).

## Tests

- 8 tests nuevos (TDD: rojos primero): `[Author]` en source, marcador presente/ausente según fetch, nota en worksheet, guardarraíl en prompt api.
- Suite completa: **1234 passed**, cobertura 95%, `scripts/check.sh` todo verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Revisión adversarial → 6 defectos corregidos (commit `93e6f9a`)

Una revisión adversarial encontró **seis defectos** en la primera versión de este PR. Tres eran BLOQUEANTES: dejaban al juez **más permisivo que antes del PR**, que es estrictamente peor que los falsos positivos que el PR venía a arreglar. Los seis están corregidos, cada uno con un test que falla primero.

## Lo que se midió (jueces LLM reales, Sonnet, N=8 por celda)

Mismo `output` bajo juicio, renderizando `source` + rúbricas con el código de cada versión. "Se coló" = el juez dio `faithfulness: PASS` a una atribución falsa.

| Escenario | pre-#86 (develop) | #86 (como estaba) | corregido |
|---|---|---|---|
| **F1** — hilo servido como `[Linked article]`; el output atribuye la tesis del hilo al artículo de TIME que nadie descargó | 3/8 se colaron | 1/8 | **0/8** |
| **F2** — clip de un tercero; el output nombra al *poster* como el ponente (todo lo demás es literal del transcript) | 0/8 | **8/8 se colaron** | **0/8** |

F2 es la regresión que importaba: **#86 convertía una atribución falsa que el juez cazaba (0/8) en un pase unánime (8/8)**. El código corregido queda en 0/8 en ambos: nunca más permisivo que pre-#86, en ninguna forma.

## Los seis defectos

**F1 (crítico) — el guardarraíl era inerte en hilos, y el texto del hilo se servía al juez como artículo descargado.**
`links_content_unfetched` contaba CUALQUIER source no-`x_video` como "el link se descargó". Pero `extract/threads.py` adjunta un `ContentSourceSuccess(kind="thread")` con el texto propio del hilo a TODO ítem-hilo. Resultado: hilo + link sin descargar ⇒ predicado False ⇒ **ninguna superficie marcada**. Y `_article_text` tenía el mismo filtro, así que el juez recibía el texto del hilo bajo la etiqueta `[Linked article]` — se le decía afirmativamente que un artículo se había descargado, y se le daba el cuerpo del hilo como su contenido.
**Fix:** un único conjunto nombrado, `LINK_CONTENT_KINDS = {external_article, x_article}` (en `models.py`), usado por el predicado, el worksheet y el source del juez. El texto del hilo NO se pierde (es señal real): va con etiqueta propia — `[Thread — full text, same author]` / `Thread (full text by the same author):`.

**F2 (alto) — la regla del autor licenciaba atribuir a otros lo que dice cualquiera.**
"attributing the post to its own author is supported" es ambiguo entre *este post lo publicó X* (metadato cierto) y *X dice/argumenta Y* (afirmación sobre quién escribió el CONTENIDO). Se separan en reposts, clips y quotes.
**Fix:** el bloque `[Author]` ahora concede solo lo cierto (QUIÉN PUBLICÓ), niega explícitamente que establezca autoría/voz del contenido en un repost/quote/clip, y lleva un ejemplo trabajado para que el chequeo del ponente no se pueda saltar (el juez que se colaba se distraía con adherencia y nunca llegaba a preguntarse quién hablaba).

**F3 (alto) — se ordenaba al generador resumir contenido que nadie descarga.**
`quoted_id` se captura, pero **ningún fetcher construye un source `kind="quoted_tweet"`**; el texto del quote nunca se descarga. Y `rubric-summary.md` decía "Retweets / quotes: summarise the substantive content being shared" — una invitación a inventar que, compuesta con F2, aterrizaba atribuida al poster.
**Fix:** marcador `[Quoted post — content NOT fetched]` en las tres superficies + la regla pasa a ser condicional a que ese contenido esté presente. (Descargar quotes queda fuera de alcance de este PR.)

**F4 (medio) — el juez veía estrictamente MENOS que el generador en tres columnas más.**
Sin `image_descriptions`, sin título del artículo, sin título del vídeo — pero los generadores envían los tres. Es la MISMA patología de los "36+ falsos flags" que este PR arregla en la columna del autor, dejando otras tres abiertas. Añadidos `[Images in the post]`, el título en la cabecera `[Linked article — <título>]` y `[Video title]`. (Consistente con #87, que depende de que el juez vea handle + display name + tweet text en los digests de vídeo.)

**F5 (medio) — fetch parcial sin guardar.** 2 links, 1 descargado ⇒ predicado False ⇒ sin marcador, mientras un bloque `[Linked article]` presta credibilidad a una afirmación sobre el OTRO. Comparar CUENTAS no necesita matching por URL: si `fetched_link_sources < len(item.links)`, falta contenido ⇒ marcador, con las cuentas dentro ("Only 1 of 2 linked pages were fetched…").

**F6 (bajo) — y por esto CI estaba verde con todo lo anterior.** Los tests nuevos afirmaban `"NOT fetched" in prompt`, un substring de la constante: verdes mientras apareciera CUALQUIER nota, sin fijar nunca el predicado. `links_content_unfetched` no tenía tests unitarios directos y ningún test construía un `thread`, un fetch parcial ni un quote.
**Fix:** suite table-driven sobre el predicado (sin links · links sin nada · `external_article` · `x_article` · `thread` · `quoted_tweet` · `x_video` · 2 links con 1 artículo · combinaciones), y los tests de superficie ahora afirman QUÉ texto aparece bajo QUÉ etiqueta, no la presencia de un substring.

## Estado
- 1261 tests verdes (17 nuevos; los 6 findings tienen test rojo-primero).
- `poe check` completo en verde: ruff, format, mypy, radon (todo A/B), bandit, vulture, interrogate, detect-secrets, deptry, cobertura 95%.

---

# Segunda revisión adversarial: el CONTRATO también estaba sin test (commit `115f8bd`)

Un segundo revisor hizo mutation testing sobre los guardarraíles. Buena noticia: el **cableado** estaba bien cubierto (desconecta la nota de cualquiera de las tres superficies, o fuerza el predicado → rojo). Lo que NO estaba cubierto era **el contrato en sí** — justo en un PR cuya premisa es "el generador y el juez leen el MISMO contrato".

Pasado ese mismo lente sobre el código ya refactorizado, **2 mutaciones sobrevivían en VERDE**, las dos en la nota de quote que añadí para F3:

| Mutación | Antes | Ahora |
|---|---|---|
| `M2` — vaciar `QUOTED_CONTENT_UNFETCHED_NOTE` a la cadena pelada `"NOT fetched."` (borrando *"never describe, reconstruct or guess…"*) | 🟢 **sobrevivía** | 🔴 cazada |
| `M7` — quitar la nota de `_source_text` **manteniendo la cabecera** `[Quoted post — content NOT fetched]` | 🟢 **sobrevivía** | 🔴 cazada |
| `M1` vaciar la regla de links · `M3` idem en verify · `M4`/`M5`/`M6` cada superficie deriva a su propia redacción · `C1` predicado siempre False · `C2` borrar el bloque `[Author]` | 🔴 | 🔴 |

**10/10 mutaciones cazadas, 0 supervivientes.**

`M7` es la tautología accidental que el revisor nombró: `assert "NOT fetched" in text` **ya lo satisface la CABECERA de sección**, así que la aserción parecía cubrir la instrucción cuando solo cubría el título.

**Fix (G1+G2+G3, uno solo):** `tests/test_guardrail_contract.py` fija el invariante que el propio docstring de la constante afirmaba y nadie comprobaba — prompt del `api`, worksheet de `enrich` y source de `verify` llevan la nota **IDÉNTICA y literal** (identidad, nunca substring), para la nota de links y la de quote, en fetch total y parcial — más el núcleo semántico de la nota (debe prohibir describir / reconstruir / adivinar el contenido a partir de la URL, el dominio o conocimiento del mundo). Las aserciones por substring de los tests de F1–F5 se re-apuntan a las constantes compartidas por el mismo motivo.

**G4:** `_source_text` emitía `[Author]\n@ ()` con un handle vacío. No es alcanzable hoy (la extracción descarta ítems sin handle), pero la rúbrica nueva le dice al juez que el bloque `[Author]` es metadato **de confianza** — un ancla basura no puede presentarse como fiable. Sin handle, sin bloque: el juez se queda sin nadie a quien atribuir nada, que es la dirección estricta.

---

## ⚠️ Precondición de merge: los verdicts existentes están OBSOLETOS EN SUSTANCIA

Este PR **cambia el contrato de juicio** (source + rúbricas). `fingerprint_output` hashea **solo el OUTPUT**, no el contrato que el juez leyó: por tanto, todo verdict almacenado **antes** de este PR sigue haciendo fingerprint-match y se muestra como FRESCO, aunque fue emitido bajo un contrato distinto — el mismo que producía los 36+ falsos flags de atribución que este PR existe para arreglar, y el que (medido) dejaba pasar 8/8 la atribución falsa del ponente.

En claro: **todo verdict existente es obsoleto en sustancia aunque no en fingerprint. Un re-verify de todo el corpus es precondición para confiar en cualquier badge.** No se arregla aquí (cambia el significado de cada verdict almacenado y va en su propio PR); se declara.