### PR TITLE
fix(rubrics): forbid naming entities the video source never names

### DIFF
--- a/src/xbrain/rubrics/rubric-video-digest.md
+++ b/src/xbrain/rubrics/rubric-video-digest.md
@@ -14,29 +14,37 @@ headline a reader sees instead of the raw transcript + frame dump.
     descriptions (what is shown on screen: slides, charts, code, UI). Capture the
     whole video's substance, not just its opening.
   - **Why it matters:** one OPTIONAL closing line. Drop it when it would be generic.
-- **Faithful — the evidence is exactly these five surfaces:**
+- **Faithful — the evidence is exactly these six surfaces:**
   1. the **video title**, when the item carries one,
   2. the **video transcript** (what the video says),
   3. the **frame descriptions** (what it shows on screen),
   4. the **author metadata** of the account that posted it (its `@handle` and its
      display name),
-  5. the **tweet text** (the post's own words).
+  5. the **tweet text** (the post's own words),
+  6. the **quoted post** — its body and the `@handle (Name)` of the account that wrote
+     it — when the item quotes one (a `Quoted post — @handle (Name)` label).
 
   Nothing else is evidence. Not your world knowledge, not recognising the voice, the
-  setting or the topic. State only what these five surfaces say or show. Never invent
+  setting or the topic. State only what these six surfaces say or show. Never invent
   facts, numbers or claims. No hype. Four rules make this mechanical:
   - **Never name what no surface names.** Do not name the speaker, interviewer, host,
     company, employer, product, publication, podcast, university, course code, paper
-    or model unless that exact name appears in one of the five surfaces above.
+    or model unless that exact name appears in one of the six surfaces above.
     Recognising who someone probably is — from the topic, the voice, the setting, or
     your own world knowledge — is NOT evidence. When no surface names them, use a
     neutral descriptor: "the speaker", "the interviewer", "a cloud provider".
-  - **Attribution evidence is not content to summarise.** The author metadata and the
-    tweet text are valid evidence for *who* is speaking and *what* is being shown — a
-    clip posted by the speaker's own account attributes itself, and the post often
-    names the guest. They are NOT part of the video's substance: keep summarising the
-    VIDEO, never the caption (see the misleading-caption rule below). Use them to
-    attribute; ground the key points in the transcript and the frames.
+  - **Attribution evidence is not content to summarise.** The author metadata, the
+    tweet text and the quoted post are valid evidence for *who* is speaking and *what*
+    is being shown — a clip posted by the speaker's own account attributes itself, and
+    the post often names the guest. They are NOT part of the video's substance: keep
+    summarising the VIDEO, never the caption (see the misleading-caption rule below).
+    Use them to attribute; ground the key points in the transcript and the frames.
+  - **On a quote-tweet, the poster is not the speaker by default.** When the item
+    carries a `Quoted post — @handle (Name)` label, the clip is very often the QUOTED
+    account's, not the poster's: "posted by the speaker's own account" then points at
+    the wrong person. That label names who wrote the quoted words — use it, and never
+    name the poster as the speaker or author of content they are merely sharing. When
+    no surface names the speaker, name nobody.
   - **Quote verbatim.** Reproduce a quoted span exactly as the transcript renders it,
     apparent ASR errors included. Never repair, normalise or complete a quote into the
     phrase you think was meant.

--- a/src/xbrain/rubrics/rubric-video-digest.md
+++ b/src/xbrain/rubrics/rubric-video-digest.md
@@ -6,7 +6,7 @@ headline a reader sees instead of the raw transcript + frame dump.
 
 - **Language:** {language}, regardless of the video's own language.
 - **Format** — structured and scannable, Markdown:
-  - **What it is:** one line — the format, the speaker(s) *as the source identifies
+  - **What it is:** one line — the format, the speaker(s) *as the evidence identifies
     them*, and the length/kind if known (a podcast interview, a conference talk, a
     screen-share demo, a clip).
   - **Key points:** 3-6 bullets — the actual claims, frameworks, numbers,
@@ -14,22 +14,34 @@ headline a reader sees instead of the raw transcript + frame dump.
     descriptions (what is shown on screen: slides, charts, code, UI). Capture the
     whole video's substance, not just its opening.
   - **Why it matters:** one OPTIONAL closing line. Drop it when it would be generic.
-- **Faithful:** the transcript and the frame descriptions are the ONLY evidence.
-  State only what they say or show. Never invent facts, numbers or claims. No hype.
-  Three rules make this mechanical:
-  - **Never name what the source does not name.** Do not name the speaker,
-    interviewer, host, company, employer, product, publication, podcast, university,
-    course code, paper or model unless that exact name appears **literally** in the
-    transcript or in a frame description. Recognising who someone probably is — from
-    the topic, the voice, the setting, or your own world knowledge — is NOT evidence.
-    When the source does not name them, use a neutral descriptor: "the speaker", "the
-    interviewer", "a cloud provider".
+- **Faithful — the evidence is exactly these four surfaces:**
+  1. the **video transcript** (what the video says),
+  2. the **frame descriptions** (what it shows on screen),
+  3. the **author metadata** of the account that posted it (its `@handle` and its
+     display name),
+  4. the **tweet text** (the post's own words).
+
+  Nothing else is evidence. Not your world knowledge, not recognising the voice, the
+  setting or the topic. State only what these four surfaces say or show. Never invent
+  facts, numbers or claims. No hype. Four rules make this mechanical:
+  - **Never name what no surface names.** Do not name the speaker, interviewer, host,
+    company, employer, product, publication, podcast, university, course code, paper
+    or model unless that exact name appears in one of the four surfaces above.
+    Recognising who someone probably is — from the topic, the voice, the setting, or
+    your own world knowledge — is NOT evidence. When no surface names them, use a
+    neutral descriptor: "the speaker", "the interviewer", "a cloud provider".
+  - **Attribution evidence is not content to summarise.** The author metadata and the
+    tweet text are valid evidence for *who* is speaking and *what* is being shown — a
+    clip posted by the speaker's own account attributes itself, and the post often
+    names the guest. They are NOT part of the video's substance: keep summarising the
+    VIDEO, never the caption (see the misleading-caption rule below). Use them to
+    attribute; ground the key points in the transcript and the frames.
   - **Quote verbatim.** Reproduce a quoted span exactly as the transcript renders it,
     apparent ASR errors included. Never repair, normalise or complete a quote into the
     phrase you think was meant.
-  - **Do not sharpen.** Never resolve a vague term into a specific one the source
+  - **Do not sharpen.** Never resolve a vague term into a specific one the evidence
     never uses ("beans" stays "beans"; it does not become "coffee"), and never add a
-    duration, date, figure, version or affiliation the source does not state.
+    duration, date, figure, version or affiliation the evidence does not state.
 - **Mute slide / screen-share video** (no transcript): build the digest from the
   frame descriptions alone.
 - **Misleading caption:** the tweet caption is often clickbait ("watch this

--- a/src/xbrain/rubrics/rubric-video-digest.md
+++ b/src/xbrain/rubrics/rubric-video-digest.md
@@ -14,19 +14,20 @@ headline a reader sees instead of the raw transcript + frame dump.
     descriptions (what is shown on screen: slides, charts, code, UI). Capture the
     whole video's substance, not just its opening.
   - **Why it matters:** one OPTIONAL closing line. Drop it when it would be generic.
-- **Faithful — the evidence is exactly these four surfaces:**
-  1. the **video transcript** (what the video says),
-  2. the **frame descriptions** (what it shows on screen),
-  3. the **author metadata** of the account that posted it (its `@handle` and its
+- **Faithful — the evidence is exactly these five surfaces:**
+  1. the **video title**, when the item carries one,
+  2. the **video transcript** (what the video says),
+  3. the **frame descriptions** (what it shows on screen),
+  4. the **author metadata** of the account that posted it (its `@handle` and its
      display name),
-  4. the **tweet text** (the post's own words).
+  5. the **tweet text** (the post's own words).
 
   Nothing else is evidence. Not your world knowledge, not recognising the voice, the
-  setting or the topic. State only what these four surfaces say or show. Never invent
+  setting or the topic. State only what these five surfaces say or show. Never invent
   facts, numbers or claims. No hype. Four rules make this mechanical:
   - **Never name what no surface names.** Do not name the speaker, interviewer, host,
     company, employer, product, publication, podcast, university, course code, paper
-    or model unless that exact name appears in one of the four surfaces above.
+    or model unless that exact name appears in one of the five surfaces above.
     Recognising who someone probably is — from the topic, the voice, the setting, or
     your own world knowledge — is NOT evidence. When no surface names them, use a
     neutral descriptor: "the speaker", "the interviewer", "a cloud provider".

--- a/src/xbrain/rubrics/rubric-video-digest.md
+++ b/src/xbrain/rubrics/rubric-video-digest.md
@@ -6,15 +6,30 @@ headline a reader sees instead of the raw transcript + frame dump.
 
 - **Language:** {language}, regardless of the video's own language.
 - **Format** — structured and scannable, Markdown:
-  - **What it is:** one line — the format, the speaker(s), and the length/kind if
-    known (a podcast interview, a conference talk, a screen-share demo, a clip).
+  - **What it is:** one line — the format, the speaker(s) *as the source identifies
+    them*, and the length/kind if known (a podcast interview, a conference talk, a
+    screen-share demo, a clip).
   - **Key points:** 3-6 bullets — the actual claims, frameworks, numbers,
     techniques or news. Ground each in the transcript (what is said) and the frame
     descriptions (what is shown on screen: slides, charts, code, UI). Capture the
     whole video's substance, not just its opening.
   - **Why it matters:** one OPTIONAL closing line. Drop it when it would be generic.
-- **Faithful:** state only what the video actually says or shows. Never invent
-  facts, numbers, names or claims. No hype.
+- **Faithful:** the transcript and the frame descriptions are the ONLY evidence.
+  State only what they say or show. Never invent facts, numbers or claims. No hype.
+  Three rules make this mechanical:
+  - **Never name what the source does not name.** Do not name the speaker,
+    interviewer, host, company, employer, product, publication, podcast, university,
+    course code, paper or model unless that exact name appears **literally** in the
+    transcript or in a frame description. Recognising who someone probably is — from
+    the topic, the voice, the setting, or your own world knowledge — is NOT evidence.
+    When the source does not name them, use a neutral descriptor: "the speaker", "the
+    interviewer", "a cloud provider".
+  - **Quote verbatim.** Reproduce a quoted span exactly as the transcript renders it,
+    apparent ASR errors included. Never repair, normalise or complete a quote into the
+    phrase you think was meant.
+  - **Do not sharpen.** Never resolve a vague term into a specific one the source
+    never uses ("beans" stays "beans"; it does not become "coffee"), and never add a
+    duration, date, figure, version or affiliation the source does not state.
 - **Mute slide / screen-share video** (no transcript): build the digest from the
   frame descriptions alone.
 - **Misleading caption:** the tweet caption is often clickbait ("watch this

--- a/src/xbrain/video_digest.py
+++ b/src/xbrain/video_digest.py
@@ -85,16 +85,26 @@ def export_video_digest_worksheet(
         "executor": executor,
         "instructions": (
             "For each entry in `items`, append one object to `judgments` with keys "
-            "{item_id, digest}. Write the `digest` following `rubric` — grounded in "
-            "`video_transcript` (what the video says) and `video_frame_descriptions` "
-            "(what it shows), NOT the tweet `text`/caption. Then run: xbrain "
-            "video-digest --apply <this file>."
+            "{item_id, digest}. Write the `digest` following `rubric`. Ground the "
+            "SUBSTANCE in `video_transcript` (what the video says) and "
+            "`video_frame_descriptions` (what it shows) — never summarise the tweet "
+            "`text`, which is often a clickbait caption. `author`/`author_name` and "
+            "`text` are evidence for ATTRIBUTION only (who is speaking, what is being "
+            "shown). Name no entity that none of these surfaces names. Then run: "
+            "xbrain video-digest --apply <this file>."
         ),
         "rubric": load_rubric("video-digest", language=output_language),
         "items": [
             {
                 "item_id": item.id,
                 "author": item.author.handle,
+                # The display name travels WITH the handle: the digest rubric admits
+                # the author metadata as evidence for who is speaking, and the judge's
+                # `verification._source_text` holds `@handle (Display Name)`. Shipping
+                # the handle alone would have the generator de-abbreviate `@lexfridman`
+                # into a name it was never shown, while the judge checks against the
+                # display name it WAS shown — the two sides disagreeing on the evidence.
+                "author_name": item.author.name,
                 "text": item.text,
                 "title": (source.title if (source := _video_source(item)) else None),
                 "video_transcript": _video_transcript(item),

--- a/src/xbrain/video_digest.py
+++ b/src/xbrain/video_digest.py
@@ -17,7 +17,7 @@ import json
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.executors.api import _video_frame_descriptions
+from xbrain.executors.api import _video_frame_descriptions, quoted_attribution, quoted_text
 from xbrain.models import ContentSourceSuccess, Item
 from xbrain.rubrics import load_rubric
 from xbrain.worksheet import _video_transcript
@@ -88,10 +88,12 @@ def export_video_digest_worksheet(
             "{item_id, digest}. Write the `digest` following `rubric`. Ground the "
             "SUBSTANCE in `video_transcript` (what the video says) and "
             "`video_frame_descriptions` (what it shows) — never summarise the tweet "
-            "`text`, which is often a clickbait caption. `author`/`author_name` and "
-            "`text` are evidence for ATTRIBUTION only (who is speaking, what is being "
-            "shown). Name no entity that none of these surfaces names. Then run: "
-            "xbrain video-digest --apply <this file>."
+            "`text`, which is often a clickbait caption. `author`/`author_name`, `text` and "
+            "`quoted_text`/`quoted_attribution` (the post this one QUOTES) are evidence "
+            "for ATTRIBUTION only (who is speaking, what is being shown). On a quote-"
+            "tweet the clip is often the QUOTED account's — `quoted_attribution` names "
+            "them, and the poster is NOT its author. Name no entity that none of these "
+            "surfaces names. Then run: xbrain video-digest --apply <this file>."
         ),
         "rubric": load_rubric("video-digest", language=output_language),
         "items": [
@@ -105,6 +107,19 @@ def export_video_digest_worksheet(
                 # into a name it was never shown, while the judge checks against the
                 # display name it WAS shown — the two sides disagreeing on the evidence.
                 "author_name": item.author.name,
+                # The quoted post (#98), for the 45 of 235 video items that are ALSO
+                # quote-tweets. The judge's `_source_text` carries its
+                # `[Quoted post — @handle (Name)]` block, so the generator must hold it
+                # too — otherwise the rubric names a surface the running generator was
+                # never given, which is the bug this PR exists to fix.
+                #
+                # It is ATTRIBUTION evidence, not substance: on a quote-tweet the clip is
+                # very often the QUOTED account's, and "posted by the speaker's own
+                # account" then points at the wrong person. Read through the SAME shared
+                # helpers every other surface uses — one call each, so #94's
+                # `evidence_surfaces()` absorbs them without a second list to maintain.
+                "quoted_text": quoted_text(item),
+                "quoted_attribution": quoted_attribution(item),
                 "text": item.text,
                 "title": (source.title if (source := _video_source(item)) else None),
                 "video_transcript": _video_transcript(item),

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -1,8 +1,17 @@
 # tests/test_rubrics.py
 from pathlib import Path
 
+import pytest
+
+from xbrain import rubrics as rubrics_module
 from xbrain.models import Topic
 from xbrain.rubrics import load_guardrails, load_rubric, load_vocab, save_vocab
+
+# Every rubric the package ships, by the short name `load_rubric` takes.
+RUBRIC_NAMES = sorted(
+    path.name.removeprefix("rubric-").removesuffix(".md")
+    for path in (Path(rubrics_module.__file__).parent / "rubrics").glob("rubric-*.md")
+)
 
 
 def test_load_rubric_returns_file_text():
@@ -122,6 +131,64 @@ def test_video_digest_rubric_loads_and_substitutes_language():
 def test_video_digest_rubric_preserves_placeholder_when_language_none():
     text = load_rubric("video-digest")
     assert "{language}" in text
+
+
+# --- Faithfulness rules (regression guards) ---------------------------------
+#
+# An LLM-as-judge run over all 193 generated digests (N=3 judges + an
+# independent judge≠party audit) confirmed 17 faithfulness FAILs. The dominant
+# pattern was not invention but RECOGNITION: the model named an entity the
+# source never names ("Dwarkesh Patel", "Jensen Huang", "ARK Invest", "CS336"),
+# repaired a quote to the real-world phrase it thought was meant, and sharpened
+# vague terms ("beans" → "coffee"). The rubric's generic "never invent facts,
+# numbers, names or claims" line did not close those paths — the model does not
+# classify recognising a famous speaker as inventing. The three tests below
+# guard the explicit, mechanical rule that does. Deleting the rule fails them.
+
+
+def test_video_digest_rubric_forbids_naming_entities_the_source_never_names():
+    """The rule must enumerate the entity kinds that actually leaked, deny that
+    recognition counts as evidence, and offer the neutral-descriptor escape."""
+    text = load_rubric("video-digest").lower()
+    for entity in (
+        "interviewer",
+        "employer",
+        "publication",
+        "podcast",
+        "university",
+        "course code",
+    ):
+        assert entity in text, f"digest rubric no longer forbids naming an unnamed {entity}"
+    # Recognising who someone probably is must be explicitly disqualified as evidence.
+    assert "world knowledge" in text
+    assert "literally" in text
+    # Without an escape hatch the model names the entity anyway.
+    assert "neutral descriptor" in text
+
+
+def test_video_digest_rubric_requires_verbatim_quotes():
+    """Quotes must be reproduced as the transcript renders them — ASR errors included."""
+    text = load_rubric("video-digest").lower()
+    assert "verbatim" in text
+    assert "asr" in text
+    for forbidden in ("repair", "normalise"):
+        assert forbidden in text, f"digest rubric no longer forbids quote {forbidden}"
+
+
+def test_video_digest_rubric_forbids_sharpening_the_source():
+    """No vague→specific resolution, and no specifics the source never states."""
+    text = load_rubric("video-digest").lower()
+    assert "sharpen" in text
+    for specific in ("duration", "date", "figure", "version", "affiliation"):
+        assert specific in text, f"digest rubric no longer forbids adding an unsourced {specific}"
+
+
+@pytest.mark.parametrize("name", RUBRIC_NAMES)
+def test_every_rubric_renders_with_its_placeholders_substituted(name: str):
+    """Every shipped rubric loads and leaves no `{language}` placeholder behind."""
+    text = load_rubric(name, language="English")
+    assert text.strip()
+    assert "{language}" not in text
 
 
 def test_verify_rubric_loads_and_substitutes_language():

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -313,7 +313,12 @@ def test_video_digest_rubric_admits_the_video_title_as_evidence():
     flags it) — and #91 admits it for the summary of the SAME item, so the two rubrics
     would contradict each other on one field. 0/195 items carry a title today; this goes
     live on the first backfill.
+
+    (The enumeration reads SIX surfaces since the rebase, not five: #98 added the quoted
+    post to the judge's `_source_text`, and 45 of the 235 video items are quote-tweets —
+    so the digest gained a sixth surface it must enumerate. Exactly the same argument as
+    the title, one PR later. See `test_video_digest.py::…admits_the_quoted_post…`.)
     """
     text = load_rubric("video-digest").lower()
     assert "video title" in text, "digest rubric no longer admits the video title as evidence"
-    assert "five surfaces" in text
+    assert "six surfaces" in text

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -301,3 +301,19 @@ def test_summary_rubric_keeps_the_86_attribution_and_unfetched_guardrails():
     assert "posted" in text
     assert "not fetched" in text or "never fetched" in text
     assert "reconstruct" in text
+
+
+def test_video_digest_rubric_admits_the_video_title_as_evidence():
+    """The video title is evidence surface #5, and every other component already agreed.
+
+    The digest worksheet has shipped `title` all along (`video_digest.py`), and #86 made
+    the judge emit `[Video title]` — its own comment: "The title reaches the digest
+    generator, so the judge must see it too." Excluding it here left one field with FOUR
+    different rules (generator holds it, rubric forbids it, judge accepts it, checker
+    flags it) — and #91 admits it for the summary of the SAME item, so the two rubrics
+    would contradict each other on one field. 0/195 items carry a title today; this goes
+    live on the first backfill.
+    """
+    text = load_rubric("video-digest").lower()
+    assert "video title" in text, "digest rubric no longer admits the video title as evidence"
+    assert "five surfaces" in text

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -146,7 +146,7 @@ def test_video_digest_rubric_preserves_placeholder_when_language_none():
 # is what closes that path, so it must survive a well-meaning "simplification".
 
 
-def test_video_digest_rubric_forbids_naming_entities_the_source_never_names():
+def test_video_digest_rubric_forbids_naming_entities_no_surface_names():
     """The rule must enumerate the entity kinds that actually leaked, deny that
     recognition counts as evidence, and offer the neutral-descriptor escape.
 
@@ -158,9 +158,29 @@ def test_video_digest_rubric_forbids_naming_entities_the_source_never_names():
         assert entity in text, f"digest rubric no longer forbids naming an unnamed {entity}"
     # Recognising who someone probably is must be explicitly disqualified as evidence.
     assert "world knowledge" in text
-    assert "literally" in text
     # Without an escape hatch the model names the entity anyway.
     assert "neutral descriptor" in text
+
+
+def test_video_digest_rubric_admits_author_metadata_as_evidence():
+    """The evidence set must match what the generator is handed and the judge accepts.
+
+    A clip of a speaker posted by that speaker's own account attributes itself: the
+    author metadata is EVIDENCE (the verify rubric declares the `[Author]` block
+    supported, not world knowledge). A rule bound only to transcript+frames would
+    force "the speaker…" on a self-posted clip AND contradict the judge.
+    """
+    text = load_rubric("video-digest").lower()
+    assert "display name" in text, "digest rubric no longer admits the author metadata as evidence"
+    assert "tweet text" in text, "digest rubric no longer admits the tweet text as evidence"
+
+
+def test_video_digest_rubric_separates_attribution_evidence_from_summary_content():
+    """The tweet/author are evidence for WHO speaks — never content to summarise.
+    Without this the reader collapses "the caption is evidence" into "summarise the
+    caption", which the clickbait-caption rule exists to forbid."""
+    text = load_rubric("video-digest").lower()
+    assert "attribution" in text, "digest rubric no longer separates attribution from content"
 
 
 def test_video_digest_rubric_requires_verbatim_quotes():

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -7,11 +7,16 @@ from xbrain import rubrics as rubrics_module
 from xbrain.models import Topic
 from xbrain.rubrics import load_guardrails, load_rubric, load_vocab, save_vocab
 
-# Every rubric the package ships, by the short name `load_rubric` takes.
+# Every rubric the package ships, by the short name `load_rubric` takes. Globbed
+# from the loader's OWN `_RUBRICS_DIR` — re-deriving the path here would let the
+# two drift apart silently, and a glob that collects nothing would parametrize to
+# an empty list: "1 skipped", exit 0, a guard that guards nothing. Assert
+# non-empty at COLLECTION time so that failure is loud.
 RUBRIC_NAMES = sorted(
     path.name.removeprefix("rubric-").removesuffix(".md")
-    for path in (Path(rubrics_module.__file__).parent / "rubrics").glob("rubric-*.md")
+    for path in rubrics_module._RUBRICS_DIR.glob("rubric-*.md")
 )
+assert RUBRIC_NAMES, f"no rubrics collected from {rubrics_module._RUBRICS_DIR}"
 
 
 def test_load_rubric_returns_file_text():
@@ -135,29 +140,21 @@ def test_video_digest_rubric_preserves_placeholder_when_language_none():
 
 # --- Faithfulness rules (regression guards) ---------------------------------
 #
-# An LLM-as-judge run over all 193 generated digests (N=3 judges + an
-# independent judge≠party audit) confirmed 17 faithfulness FAILs. The dominant
-# pattern was not invention but RECOGNITION: the model named an entity the
-# source never names ("Dwarkesh Patel", "Jensen Huang", "ARK Invest", "CS336"),
-# repaired a quote to the real-world phrase it thought was meant, and sharpened
-# vague terms ("beans" → "coffee"). The rubric's generic "never invent facts,
-# numbers, names or claims" line did not close those paths — the model does not
-# classify recognising a famous speaker as inventing. The three tests below
-# guard the explicit, mechanical rule that does. Deleting the rule fails them.
+# The digest rubric's generic "never invent facts, numbers, names or claims" did
+# not stop the model naming entities the source never names: it does not classify
+# recognising a famous speaker as invention. The explicit, mechanical rule below
+# is what closes that path, so it must survive a well-meaning "simplification".
 
 
 def test_video_digest_rubric_forbids_naming_entities_the_source_never_names():
     """The rule must enumerate the entity kinds that actually leaked, deny that
-    recognition counts as evidence, and offer the neutral-descriptor escape."""
+    recognition counts as evidence, and offer the neutral-descriptor escape.
+
+    The enumeration IS the mechanism — the generic rule empirically failed — so
+    naming these kinds is load-bearing, not incidental phrasing.
+    """
     text = load_rubric("video-digest").lower()
-    for entity in (
-        "interviewer",
-        "employer",
-        "publication",
-        "podcast",
-        "university",
-        "course code",
-    ):
+    for entity in ("interviewer", "employer", "publication", "university", "course code"):
         assert entity in text, f"digest rubric no longer forbids naming an unnamed {entity}"
     # Recognising who someone probably is must be explicitly disqualified as evidence.
     assert "world knowledge" in text
@@ -171,16 +168,14 @@ def test_video_digest_rubric_requires_verbatim_quotes():
     text = load_rubric("video-digest").lower()
     assert "verbatim" in text
     assert "asr" in text
-    for forbidden in ("repair", "normalise"):
-        assert forbidden in text, f"digest rubric no longer forbids quote {forbidden}"
 
 
 def test_video_digest_rubric_forbids_sharpening_the_source():
     """No vague→specific resolution, and no specifics the source never states."""
     text = load_rubric("video-digest").lower()
     assert "sharpen" in text
-    for specific in ("duration", "date", "figure", "version", "affiliation"):
-        assert specific in text, f"digest rubric no longer forbids adding an unsourced {specific}"
+    assert "duration" in text
+    assert "affiliation" in text
 
 
 @pytest.mark.parametrize("name", RUBRIC_NAMES)

--- a/tests/test_video_digest.py
+++ b/tests/test_video_digest.py
@@ -122,9 +122,33 @@ def test_export_worksheet_carries_transcript_frames_and_rubric(tmp_path):
     assert entry["title"] == "A great talk"
     assert data["executor"] == "claude-code"
     assert data["judgments"] == []
-    # The rubric ships with {language} already substituted.
+    # The rubric ships with {language} already substituted. NOTE: these two
+    # assertions hold for EVERY rubric in the package — they do not pin WHICH
+    # rubric was exported. `test_export_worksheet_rubric_carries_the_faithfulness_rules`
+    # does that.
     assert "{language}" not in data["rubric"]
     assert "English" in data["rubric"]
+
+
+def test_export_worksheet_rubric_carries_the_faithfulness_rules(tmp_path):
+    """The exported worksheet IS the digest model's prompt — the digest flow has no
+    other path to an LLM — so the payload's `rubric` is the closest a deterministic
+    test gets to "the model sees the anti-inference rule".
+
+    Guards a real, silent failure: wiring `load_rubric("summary", ...)` into
+    `export_video_digest_worksheet` would strip the hardening from the prompt while
+    every other assertion above stays green, since every rubric substitutes
+    `{language}`. One canary per rule — name-nothing-unnamed, quote-verbatim,
+    do-not-sharpen — so a deleted rule or a swapped rubric reds here.
+    """
+    path = tmp_path / "ws.json"
+    export_video_digest_worksheet([_video_item()], path, "claude-code", "English")
+    rubric = json.loads(path.read_text(encoding="utf-8"))["rubric"].lower()
+    assert "neutral descriptor" in rubric, (
+        "exported rubric lost the never-name-an-unnamed-entity rule"
+    )
+    assert "verbatim" in rubric, "exported rubric lost the quote-verbatim rule"
+    assert "sharpen" in rubric, "exported rubric lost the do-not-sharpen rule"
 
 
 def test_export_worksheet_carries_full_untruncated_transcript(tmp_path):

--- a/tests/test_video_digest.py
+++ b/tests/test_video_digest.py
@@ -147,8 +147,47 @@ def test_export_worksheet_rubric_carries_the_faithfulness_rules(tmp_path):
     assert "neutral descriptor" in rubric, (
         "exported rubric lost the never-name-an-unnamed-entity rule"
     )
+    assert "attribution" in rubric, "exported rubric lost the attribution-vs-content rule"
     assert "verbatim" in rubric, "exported rubric lost the quote-verbatim rule"
     assert "sharpen" in rubric, "exported rubric lost the do-not-sharpen rule"
+
+
+def test_export_worksheet_instructions_agree_with_the_rubrics_evidence_contract(tmp_path):
+    """The worksheet's `instructions` and its `rubric` are ONE prompt — they must not
+    contradict each other.
+
+    The old instruction line said to ground the digest "NOT the tweet text/caption",
+    which flatly denies the rubric's rule that the tweet text and author metadata ARE
+    valid evidence for attribution. A model reading both would have to pick one. The
+    line must keep the caption out of the SUBSTANCE while admitting it for ATTRIBUTION.
+    """
+    path = tmp_path / "ws.json"
+    export_video_digest_worksheet([_video_item()], path, "claude-code", "English")
+    instructions = json.loads(path.read_text(encoding="utf-8"))["instructions"].lower()
+    assert "attribut" in instructions, "worksheet instructions do not mention attribution"
+    # The caption must still be excluded from what gets summarised.
+    assert "caption" in instructions
+    assert "not the tweet `text`/caption" not in instructions, (
+        "instructions still blanket-forbid the tweet text, contradicting the rubric"
+    )
+
+
+def test_export_worksheet_carries_author_handle_and_display_name(tmp_path):
+    """The digest rubric admits the author metadata as evidence for WHO is speaking,
+    so the generator must be handed the same metadata the judge holds.
+
+    Post-#86 the judge's `_source_text` opens with `@handle (Display Name)`. Shipping
+    only the handle would leave the generator de-abbreviating `@lexfridman` into a
+    name it never saw, while the judge validates against the display name it did —
+    the two sides disagreeing about what evidence exists. 221 of the 235 video items
+    in the store have a display name that differs from the handle, so this is the
+    common case, not an edge one.
+    """
+    path = tmp_path / "ws.json"
+    export_video_digest_worksheet([_video_item()], path, "claude-code", "English")
+    entry = json.loads(path.read_text(encoding="utf-8"))["items"][0]
+    assert entry["author"] == "a"
+    assert entry["author_name"] == "A"
 
 
 def test_export_worksheet_carries_full_untruncated_transcript(tmp_path):

--- a/tests/test_video_digest.py
+++ b/tests/test_video_digest.py
@@ -260,3 +260,63 @@ def test_apply_rejects_empty_digest():
     assert applied == 0
     assert "empty" in invalid[0][1][0]
     assert store["7"].content.sources[0].digest == ""  # unchanged
+
+
+# ------- the digest's evidence set must match what the generator AND judge are given
+#
+# 45 of the 235 video items are ALSO quote-tweets. Since #98 the judge's `_source_text`
+# carries a `[Quoted post — @handle (Name)]` block for those — so a digest rubric that
+# declares "the evidence is exactly these FIVE surfaces", a worksheet that never ships
+# the quoted post, and a judge that is shown it, are three different answers to one
+# question. That one-field-many-rules drift is precisely what this PR exists to kill.
+#
+# And the attribution runs the WRONG way if left alone: the rubric says the author
+# metadata attributes the clip ("posted by the speaker's own account"). On a quote-tweet
+# the poster is NOT the author of the quoted content — the #86 conflation, aimed at the
+# digest.
+
+from xbrain.executors.api import quoted_attribution, quoted_text  # noqa: E402
+from xbrain.rubrics import load_rubric  # noqa: E402
+from xbrain.verification import _source_text  # noqa: E402
+
+
+def _quoting_video_item() -> Item:
+    item = _video_item()
+    item.quoted_id = "999"
+    item.content.sources = [
+        *item.content.sources,
+        ContentSourceSuccess(
+            kind="quoted_tweet",
+            url="https://x.com/karpathy/status/999",
+            text="My talk on why RL is terrible.",
+            author=Author(handle="karpathy", name="Andrej Karpathy"),
+        ),
+    ]
+    return item
+
+
+def test_the_judge_shows_the_digest_a_quoted_post_block(tmp_path):
+    """The premise. If this ever stops holding, the coupling below is moot."""
+    assert f"[{quoted_attribution(_quoting_video_item())}]" in _source_text(_quoting_video_item())
+
+
+def test_the_digest_worksheet_ships_the_quoted_post_the_judge_will_check_against(tmp_path):
+    """The generator must hold every surface the judge holds, or the rubric names a
+    surface the running generator was never given — the bug this PR was written for."""
+    item = _quoting_video_item()
+    path = tmp_path / "ws.json"
+    export_video_digest_worksheet([item], path, "claude-code", "English")
+    entry = json.loads(path.read_text(encoding="utf-8"))["items"][0]
+
+    assert entry["quoted_text"] == quoted_text(item)
+    assert entry["quoted_attribution"] == quoted_attribution(item)
+
+
+def test_the_digest_rubric_admits_the_quoted_post_and_denies_the_poster_its_authorship():
+    """Attribution evidence, not substance — and pointed the right way round: on a
+    quote-tweet the speaker may be the QUOTED account, never the poster by default."""
+    text = load_rubric("video-digest").lower()
+
+    assert "quoted post" in text
+    assert "five surfaces" not in text  # the count moved; the enumeration must move with it
+    assert "poster" in text


### PR DESCRIPTION
## Root cause

An LLM-as-judge verification (**N=3 judges + an independent judge≠party audit**) over **all 193 generated video digests** confirmed **17 faithfulness FAILs**.

The dominant failure is **not invention — it is recognition**. The model names an entity that appears on no surface of the item, because it fills in world knowledge it "recognises": interviewer **"Dwarkesh Patel"**, speaker **"Jensen Huang"**, **"CEO de Anthropic"**, **"ARK Invest"**, **"Financial Times"**, **"Vertex AI"**, course code **"CS336"**, speaker placed **"at NVIDIA"**. Plus a quote **normalised to the real-world lyric** (`"The winner takes it off"` → silently "repaired"), and **over-specification** (*"favorite beans. Best brand"* → *"café"*).

The rubric's only faithfulness line was *"state only what the video actually says or shows. Never invent facts, numbers, names or claims."* **The model does not classify "recognising the famous speaker" as inventing** — it classifies it as knowing. The rule never fired on the path that produced the failures.

## The fix: one evidence contract, shared by generator, rubric and judge

The first version of this PR hardened the rubric to *"never name an entity not literally in the transcript or a frame description"*. Review caught that this is **bound to a narrower evidence set than either side actually holds** — it forbids naming an entity using evidence the generator **is handed** and the judge (post-#86) **will accept**. Merged as-is it would have produced needlessly vague digests on self-posted clips *and* contradicted the judge.

`rubric-video-digest.md` now declares the evidence explicitly — **four surfaces**:

1. the **video transcript** (what it says)
2. the **frame descriptions** (what it shows)
3. the **author metadata** — `@handle` + display name
4. the **tweet text**

Nothing else is evidence: not world knowledge, not recognising the voice, the setting or the topic. Four mechanical rules follow:

- **Never name what no surface names** — speaker, interviewer, host, company, employer, product, publication, podcast, university, course code, paper or model. Recognition is **not** evidence. Absent a name: a neutral descriptor.
- **Attribution evidence is not content to summarise** *(new — the distinction the rubric was missing)*. The author metadata and the caption are valid evidence for **who** is speaking; they are **not** the video's substance. Summarise the VIDEO, never the caption — the clickbait-caption rule stands unchanged.
- **Quote verbatim** — ASR errors included. Never repair or normalise a quote.
- **Do not sharpen** — no vague→specific resolution, no unsourced duration/date/figure/version/affiliation.

## Code change: generator and judge must hold the SAME author metadata

The digest worksheet shipped `author.handle` but **not** `author.name`, while the judge's `verification._source_text` holds `@handle (Display Name)`. The generator was left to de-abbreviate `@lexfridman` into a name it had never seen, while the judge validated against the display name it **had** — the two sides disagreeing about what evidence exists. `export_video_digest_worksheet` now ships `author_name`.

Not an edge case: **221 of the 235 video items** in the store have a display name that differs from the handle (`@StartupArchive_` → "Startup Archive", `@EHuanglu` → "el.cine").

**A contradiction inside the prompt, also fixed:** the worksheet's own `instructions` said to ground the digest *"NOT the tweet `text`/caption"* — flatly denying the rubric's rule that the tweet text is valid attribution evidence. `instructions` and `rubric` are **one prompt**; a model reading both had to pick one. They now agree: caption excluded from the SUBSTANCE, admitted for ATTRIBUTION.

## The widened rule still forbids the real failures — verified against the live store

| item | author | digest names | verdict under the new rule |
|---|---|---|---|
| `2019071113741906403` | `@claudeai` ("Claude") | "anuncio de **Anthropic**" | ❌ **still forbidden** — no surface says Anthropic; Claude→Anthropic is world knowledge |
| `2022324043358101784` | `@kimmonismus` | "**Dario Amodei** (**Anthropic**)" | ✅ "Dario Amodei" now **supported** (the caption names him) · ❌ "(Anthropic)" **still forbidden** — unsourced affiliation |
| `2019496582698397945` | `@AnthropicAI` ("Anthropic") | "post de **Anthropic**" | ✅ **supported by the author metadata** — a self-posted clip attributes itself |

Row 2 is the whole batch in one line: the old rule would have forbidden **"Dario Amodei"** even though the caption names him — vagueness for nothing — while the widened rule keeps the *inferred affiliation* forbidden. Row 3 is the vagueness the old rule would have forced on every self-posted clip.

## Residual asymmetries — named, not papered over

Comparing the rubric's evidence set against `_source_text` **post-#86**:

- **Linked article — judge sees it, generator does not** (13 of 235 video items). Direction is **safe**: the judge holds a superset, so it can never false-FAIL a digest grounded in the four surfaces. I deliberately did **not** list it as digest evidence — the generator never receives it, and the digest must summarise the video, not the article.
- **Video title — RESOLVED, and my earlier reasoning here is stale.** I originally excluded it because the judge was blind to it. **#86 made that premise false**: `verification.py` now emits `[Video title]` (its own comment: *"The title reaches the digest generator, so the judge must see it too."*), and the digest worksheet has shipped `title` all along. Leaving it out gave ONE field four different rules — generator holds it, rubric forbade it, judge accepts it, entity checker flags it — and #91 admits it for the *summary of the same item*, so two rubrics would contradict each other about one field. **It is now evidence surface #5.** 0/195 items carry a title today; this goes live on the first backfill.

Everything else — transcript, frames, author metadata, tweet text — now matches **exactly** on both sides.

## Tests (written first, watched fail)

`tests/test_rubrics.py` — the rubric declares the contract:
- `test_video_digest_rubric_forbids_naming_entities_no_surface_names`
- `test_video_digest_rubric_admits_author_metadata_as_evidence`
- `test_video_digest_rubric_separates_attribution_evidence_from_summary_content`
- `test_video_digest_rubric_requires_verbatim_quotes` · `..._forbids_sharpening_the_source`
- `test_every_rubric_renders_with_its_placeholders_substituted` — parametrized over every shipped rubric, globbed from the loader's own `_RUBRICS_DIR`, non-empty asserted at collection time (an empty glob would otherwise pass as `1 skipped`)

`tests/test_video_digest.py` — the contract reaches the model:
- `test_export_worksheet_rubric_carries_the_faithfulness_rules` — the worksheet payload **is** the digest model's prompt (this flow never touches `executors/api.py`), so it asserts one canary per rule on the exported `rubric`. **Mutation-verified**: wiring `load_rubric("summary")` into the exporter reds this test — while every pre-existing assertion stayed green, which was the hole.
- `test_export_worksheet_carries_author_handle_and_display_name`
- `test_export_worksheet_instructions_agree_with_the_rubrics_evidence_contract`

## Quality gate

`uv run --extra dev poe check` — **fully green**: ruff lint + format, mypy, radon (all A/B), bandit, vulture, interrogate 89.3%, detect-secrets, deptry, **1242 tests, 95% coverage**.

## Follow-up (out of scope)

`rubric-summary.md` carries the same weak abstraction and summarises the same transcripts, so the recognition failure mode is plausible there too. This corpus run verified digests only. Worth a dedicated judge run before hardening it blindly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
