### PR TITLE
fix(rubrics): bind rubric-summary to its evidence contract (blocks the corpus regeneration)

### DIFF
--- a/src/xbrain/rubrics/rubric-summary.md
+++ b/src/xbrain/rubrics/rubric-summary.md
@@ -4,9 +4,32 @@ Produce a `summary` for one X post (a bookmark or the user's own tweet).
 
 - **Language:** {language}, regardless of the post's language.
 - **Length:** 1-3 sentences. Concise. No preamble ("Este post trata de...").
-- **Faithful:** state only what the post — and its fetched article, video
-  transcript or on-screen frames, if any — actually says. Never invent facts,
-  numbers or claims. No hallucination.
+- **Faithful — the evidence is exactly these surfaces:**
+  1. the **tweet text** (the post's own words),
+  2. the **author metadata** of the account that posted it (its `@handle` and its
+     display name),
+  3. the poster's own **thread**,
+  4. the **fetched article** body and its title,
+  5. the **video** title, transcript and frame descriptions,
+  6. the **image descriptions**.
+
+  Nothing else is evidence. Not your world knowledge, not recognising the topic, the
+  voice or the byline, and **not a link's URL or domain** — a domain is topic signal,
+  never a name and never content. State only what these surfaces say or show. Never
+  invent facts, numbers or claims. No hallucination. Three rules make this mechanical:
+  - **Never name what no surface names.** Do not name the speaker, interviewer, host,
+    author, company, employer, product, publication, podcast, university, course code,
+    paper or model unless that exact name appears in one of the surfaces above.
+    Recognising who someone probably is — from the topic, the writing, the setting or
+    your own world knowledge — is NOT evidence. When no surface names them, use a
+    neutral descriptor ("the speaker", "the author", "a cloud provider"). A link to
+    `nytimes.com` does not license naming the publication.
+  - **Quote verbatim.** Reproduce a quoted span exactly as the source renders it,
+    apparent ASR errors included. Never repair, normalise or complete a quote into the
+    phrase you think was meant.
+  - **Do not sharpen.** Never resolve a vague term into a specific one the evidence
+    never uses ("beans" stays "beans"; it does not become "coffee"), and never add a
+    duration, date, figure, version or affiliation the evidence does not state.
 - **If the post links an article** whose text was fetched: summarise the
   *article's* substance.
 - **If the post has a video** (a `Video transcript:` and/or `Video frames`

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -44,6 +44,22 @@ def _link_content_source(item: Item) -> ContentSourceSuccess | None:
     return None
 
 
+def _video_title(item: Item) -> str | None:
+    """The `x_video` source's title, or None.
+
+    The judge's `_source_text` carries `[Video title]` (#86), and the summary rubric
+    admits it as evidence — so the generator must be handed it too, or the rubric names a
+    surface the generator was never given. Defined locally: importing `video_digest`
+    would be circular (it imports `_video_transcript` from here).
+    """
+    if not item.content:
+        return None
+    for source in item.content.sources:
+        if isinstance(source, ContentSourceSuccess) and source.kind == "x_video":
+            return source.title
+    return None
+
+
 def _article_text(item: Item) -> str | None:
     """First successfully-fetched LINKED article body, truncated, or None."""
     return first_source_text(item, LINK_CONTENT_KINDS)
@@ -97,6 +113,8 @@ def export_worksheet(
             "(content-bearing photos) — weigh them all as topic signal, not just "
             "`text`. `unfetched_links_note` / `quoted_content_note` mark content "
             "that was NEVER downloaded: obey them — never describe or guess it. "
+            "Name no entity that none of these surfaces names: `links` carry a URL "
+            "and a domain, which are topic signal only — never a name, never content. "
             "Then run: xbrain enrich --apply <this file>."
         ),
         "rubrics": {
@@ -108,6 +126,12 @@ def export_worksheet(
             {
                 "item_id": it.id,
                 "author": it.author.handle,
+                # The display name travels WITH the handle: the summary rubric admits the
+                # author metadata as evidence for WHO POSTED, and the judge's
+                # `_source_text` holds `@handle (Display Name)` since #86. Handle-only
+                # would have the generator de-abbreviating `@lexfridman` into a name it
+                # was never shown, while the judge checks the name it WAS shown.
+                "author_name": it.author.name,
                 "text": it.text,
                 "bookmark_folder": it.bookmark_folder,
                 "links": [{"url": ln.url, "domain": ln.domain} for ln in it.links],
@@ -128,6 +152,9 @@ def export_worksheet(
                 "quoted_content_note": (
                     QUOTED_CONTENT_UNFETCHED_NOTE if quoted_content_unfetched(it) else None
                 ),
+                # The judge sees `[Video title]` (#86); the generator must hold the same
+                # surface, or the rubric's evidence set is a promise we do not keep.
+                "video_title": _video_title(it),
                 "video_transcript": _video_transcript(it),
                 # Content-bearing photo descriptions (#34): the same non-decorative
                 # selection the `api` executor injects as its `Images in this post:`

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -44,6 +44,23 @@ def _link_content_source(item: Item) -> ContentSourceSuccess | None:
     return None
 
 
+def _article_title(item: Item) -> str | None:
+    """The FETCHED linked article's title, or None.
+
+    The summary rubric declares "the fetched article body and its title" as evidence, the
+    api prompt ships it and the judge's `_source_text` ships it — but the worksheet track,
+    the one that actually runs, shipped the body alone. The rubric was naming a surface the
+    running generator never received. Cost, measured: 8 summaries flagged ungrounded for a
+    name that sits in the article's TITLE.
+    """
+    if not item.content:
+        return None
+    for source in item.content.sources:
+        if isinstance(source, ContentSourceSuccess) and source.kind in LINK_CONTENT_KINDS:
+            return source.title
+    return None
+
+
 def _video_title(item: Item) -> str | None:
     """The `x_video` source's title, or None.
 
@@ -136,6 +153,7 @@ def export_worksheet(
                 "bookmark_folder": it.bookmark_folder,
                 "links": [{"url": ln.url, "domain": ln.domain} for ln in it.links],
                 "article": _article_text(it),
+                "article_title": _article_title(it),
                 # The poster's OWN expanded thread — real signal, but NOT a fetched
                 # linked page. It ships in its own field so the agent never reads the
                 # author's own words as the body of an article nobody downloaded.

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -167,3 +167,55 @@ def test_summary_rubric_only_summarises_shared_content_when_present():
     assert "summarise the substantive content being shared." not in text
     assert "when it is present" in text or "when its content is present" in text
     assert "post's own text" in text
+
+
+# --- Summary faithfulness: the evidence contract (PR-E) ----------------------
+#
+# The summary rubric carried only "never invent facts, numbers or claims" — the same
+# abstraction that failed on digests, because the model does not classify recognising a
+# famous name as inventing. It produced 307 ungrounded names across 2,168 summaries.
+# These guards pin the mechanical rule that replaces it.
+
+
+def test_summary_rubric_declares_its_evidence_surfaces():
+    """The summary's evidence set is WIDER than the digest's: the enrich worksheet ships
+    the fetched article, the poster's own thread and the image descriptions. The rule must
+    ADMIT them — forbidding evidence the generator was correctly given would flag it for
+    doing its job (the exact bug found in the entity checker itself)."""
+    text = load_rubric("summary").lower()
+    for surface in ("display name", "tweet text", "thread", "article", "image descriptions"):
+        assert surface in text, f"summary rubric no longer admits {surface!r} as evidence"
+
+
+def test_summary_rubric_forbids_naming_entities_no_surface_names():
+    """Same mechanism as the digest rubric: the entity enumeration IS the mechanism,
+    since the generic rule empirically failed across 2,168 summaries."""
+    text = load_rubric("summary").lower()
+    for entity in ("interviewer", "employer", "publication", "university", "author"):
+        assert entity in text, f"summary rubric no longer forbids naming an unnamed {entity}"
+    assert "world knowledge" in text
+    assert "neutral descriptor" in text
+
+
+def test_summary_rubric_refuses_the_url_and_domain_as_a_source_of_names():
+    """A link to nytimes.com does not license naming "The New York Times". The generator
+    sees every link's URL+domain; the judge only sees them when the fetch FAILED. Reading a
+    publication's name off a domain is the "Financial Times" failure with extra steps."""
+    text = load_rubric("summary").lower()
+    assert "domain" in text
+    assert "topic signal" in text
+
+
+def test_summary_rubric_keeps_quote_verbatim_and_do_not_sharpen():
+    text = load_rubric("summary").lower()
+    assert "verbatim" in text
+    assert "sharpen" in text
+
+
+def test_summary_rubric_keeps_the_86_attribution_and_unfetched_guardrails():
+    """#86's constraints must survive intact and stay coherent with the new rule: the
+    author block licenses WHO POSTED only, and unfetched content is never reconstructed."""
+    text = load_rubric("summary").lower()
+    assert "posted" in text
+    assert "not fetched" in text or "never fetched" in text
+    assert "reconstruct" in text

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -445,3 +445,34 @@ def test_export_worksheet_summary_rubric_carries_the_evidence_contract(tmp_path)
     assert "verbatim" in rubric, "lost the quote-verbatim rule"
     assert "sharpen" in rubric, "lost the do-not-sharpen rule"
     assert "domain" in rubric, "lost the URL/domain-is-not-a-name rule"
+
+
+def test_export_worksheet_carries_the_fetched_article_title(tmp_path):
+    """The summary rubric declares "the fetched article body AND ITS TITLE" as evidence.
+
+    The api prompt ships the title (`Linked article ({src.title …})`) and the judge's
+    `_source_text` ships it — but the worksheet track, the one that actually runs, shipped
+    the body only. So the rubric named a surface the running generator was never handed:
+    a promise the code did not keep. Measured cost: 8 summaries were flagged as ungrounded
+    for names that appear in the article's title — one of them "Financial Times", the case
+    we had both been citing as the canonical hallucination. It was grounded all along.
+    """
+    from xbrain.models import Content, ContentSourceSuccess
+
+    item = _item("1")
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        sources=[
+            ContentSourceSuccess(
+                kind="external_article",
+                url="https://ft.com/x",
+                title="Financial Times: the compute race",
+                text="A long article body.",
+            )
+        ],
+    )
+    path = tmp_path / "ws.json"
+    export_worksheet([item], VOCAB, path, "claude-code", "English")
+    entry = json.loads(path.read_text(encoding="utf-8"))["items"][0]
+    assert entry["article_title"] == "Financial Times: the compute race"
+    assert entry["article"] == "A long article body."

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -417,3 +417,31 @@ def test_export_worksheet_marks_an_unfetched_quoted_post(tmp_path):
 
 def test_export_worksheet_no_quoted_note_without_a_quote(tmp_path):
     assert _exported(_item("1"), tmp_path)["quoted_content_note"] is None
+
+
+def test_export_worksheet_carries_author_display_name(tmp_path):
+    """The summary rubric admits the author metadata as evidence for WHO POSTED, and the
+    judge's `_source_text` holds `@handle (Display Name)` since #86. Shipping the handle
+    alone leaves the generator de-abbreviating `@lexfridman` into a name it never saw while
+    the judge validates against the display name it DID see — the two sides disagreeing
+    about what evidence exists. 221 of 235 video authors have a name that differs from the
+    handle, so this is the common case.
+    """
+    path = tmp_path / "ws.json"
+    export_worksheet([_item("1")], VOCAB, path, "claude-code", "English")
+    entry = json.loads(path.read_text(encoding="utf-8"))["items"][0]
+    assert entry["author"] == "a"
+    assert entry["author_name"] == "A"
+
+
+def test_export_worksheet_summary_rubric_carries_the_evidence_contract(tmp_path):
+    """The exported worksheet IS the enrich model's prompt. Assert one canary per rule, so
+    a swapped or gutted rubric reds here instead of silently shipping the OLD rule that
+    produced 307 ungrounded names."""
+    path = tmp_path / "ws.json"
+    export_worksheet([_item("1")], VOCAB, path, "claude-code", "English")
+    rubric = json.loads(path.read_text(encoding="utf-8"))["rubrics"]["summary"].lower()
+    assert "neutral descriptor" in rubric, "lost the never-name-an-unnamed-entity rule"
+    assert "verbatim" in rubric, "lost the quote-verbatim rule"
+    assert "sharpen" in rubric, "lost the do-not-sharpen rule"
+    assert "domain" in rubric, "lost the URL/domain-is-not-a-name rule"


### PR DESCRIPTION
## Why this blocks the regeneration

#87 bound the **digest** rubric to an explicit evidence contract. `rubric-summary.md` still carried the abstraction that #87 proved useless — *"never invent facts, numbers or claims"*. **The model does not classify recognising a famous name as inventing**, so the rule never fired.

The entity sweep (#89) measured the result: **307 of 2,168 summaries name entities no evidence surface carries** — `Sam Altman`, `Andrej Karpathy`, `Dario Amodei`, `GPT-5`, `Y Combinator`, `Garry Tan`, `Boris Cherny`. And **zero summaries were ever judged** — the archived report holds 193 digest records and no summary records. Not 28% recall: **0% coverage**.

Regenerating 2,168 summaries under the rule that produced them reproduces them at cost. Hence: blocking.

## The contract

Built on the post-#86 text (its attribution + unfetched/quoted guardrails are kept intact and made coherent, not reverted). The summary's evidence set is **wider than the digest's**, because the enrich worksheet genuinely ships more:

1. the **tweet text** · 2. the **author metadata** (`@handle` + display name) · 3. the poster's own **thread** · 4. the **fetched article** + title · 5. the **video** title, transcript, frames · 6. the **image descriptions**

Nothing else is evidence — not world knowledge, not recognising the byline, and **not a link's URL or domain**.

> **The asymmetry that must not recur:** the summary generator *is* handed the article and the images, so the rule **admits** them. Forbidding evidence the generator was correctly given would flag it for doing its job — which is exactly the bug I found in my own entity checker (it was digest-shaped for every target, and 222 of its summary flags were its own fault).

Three mechanical rules, carried over from #87:

- **Never name what no surface names** — speaker, interviewer, host, author, company, employer, product, publication, podcast, university, course code, paper, model. Recognition is **not** evidence. Absent a name: a neutral descriptor. *A link to `nytimes.com` does not license naming the publication.*
- **Quote verbatim** — ASR errors included; never repair or normalise.
- **Do not sharpen** — no vague→specific resolution, no unsourced duration/date/figure/version/affiliation.

The entity enumeration is **the mechanism, not decoration**: the generic rule failed empirically across 2,168 summaries.

## Symmetry fix (code, test-first)

The enrich worksheet shipped `author.handle` but **not** `author.name`, and **no video title** — while the judge's `_source_text` has carried `@handle (Display Name)` and `[Video title]` since #86. The generator was left de-abbreviating `@lexfridman` into a name it had never seen, while the judge validated against the name it **had**.

Now ships `author_name` + `video_title`, so **the rubric's evidence set is a promise we keep** rather than a surface the generator was never given. The worksheet's own `instructions` are aligned to the same contract (URL/domain is topic signal, never a name) — `instructions` and `rubric` are one prompt and must not contradict.

## Ground truth — validated against the live corpus

**Must be forbidden** (from the 307, each named on no surface):

| entity | item | author | verdict |
|---|---|---|---|
| `Y Combinator` | `1897303270311489931` | @garrytan | ❌ forbidden |
| `Sam Altman` | `1904872448324939966` | @vgonpa | ❌ forbidden |
| `Andrej Karpathy` | `1935512056427344357` | @garrytan | ❌ forbidden |
| `Dario Amodei` | `1938058294439924059` | @ns123abc | ❌ forbidden |
| `GPT-5` | `1953509618493403404` | @elonmusk | ❌ forbidden |

**Must stay allowed** (the rule must not force vagueness):

| entity | grounded in |
|---|---|
| `Bryan Johnson`, `Netflix`, `Don't Die` | the **tweet text** |
| `Elon Musk`, `Tesla` | the **tweet text** |
| **`Satya Nadella`** on **@satyanadella** | the **author metadata** — a self-post attributes itself |

That last row is the point: the rule kills invention **without** making a self-posted item say "the speaker".

## Residual asymmetry — named, not papered over

After shipping `author_name` + `video_title`, the rubric's evidence set matches `_source_text` post-#86 for every **content** surface. What remains:

- **`bookmark_folder` and `links` (URL + domain) are generator-only** — the judge sees links only when the fetch failed. This is **not** a false-FAIL risk, because the rubric explicitly **excludes** both from being a source of names: a domain is topic signal, never a name and never content. The two sides therefore agree on what may be *named*, which is the property that matters. If a future rule ever wants to name something from a domain, the judge must gain the surface first.

## Tests (written first, watched fail)

`tests/test_rubrics.py` — the rubric declares the contract: evidence surfaces · never-name-what-no-surface-names (entity enumeration) · URL/domain is not a name · quote verbatim + do not sharpen · **#86's attribution and unfetched guardrails survive**.

`tests/test_worksheet.py` — the contract reaches the model: `author_name` is shipped, and the exported worksheet's `rubrics.summary` carries one canary per rule (a swapped or gutted rubric reds here instead of silently shipping the OLD rule).

## Gate

`uv run --extra dev poe check` — **fully green**: ruff lint + format, mypy, radon all A/B, bandit, vulture, interrogate 89.5%, detect-secrets, deptry, **1268 tests, 95% coverage**.

## Acceptance test for the regeneration

`xbrain verify-entities --target summary` (#89) is the acceptance test: **343 flagged / 307 real** today. After regeneration under this rubric it should collapse toward zero. That delta is the honest proof the rule works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)