### PR TITLE
test(verify): pin the guardrail CONTRACT, not just its wiring (+ drop empty [Author] block)

### DIFF
--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -173,7 +173,13 @@ def _source_text(item: Item) -> str:
     content — turning an unsupported claim about the linked piece into a PASS. Content
     the pipeline never downloaded (a link's body, a quoted post) is marked as such.
     """
-    parts: list[str] = ["[Author]", f"@{item.author.handle} ({item.author.name})"]
+    parts: list[str] = []
+    # No handle, no block. The rubric tells the judge the `[Author]` block is TRUSTED
+    # metadata, so an empty one (`[Author]\n@ ()`) would present a garbage anchor as
+    # trustworthy. Omitting it is the strict direction: with no author in the source,
+    # the judge has nobody to attribute anything to.
+    if item.author.handle:
+        parts += ["[Author]", f"@{item.author.handle} ({item.author.name})"]
     parts += _video_parts(item)
     images = _content_image_descriptions(item)
     if images:

--- a/tests/test_executors_api.py
+++ b/tests/test_executors_api.py
@@ -3,7 +3,13 @@ from datetime import datetime, timezone
 
 import pytest
 
-from xbrain.executors.api import ApiExecutor, _user_prompt, links_content_unfetched
+from xbrain.executors.api import (
+    QUOTED_CONTENT_UNFETCHED_NOTE,
+    ApiExecutor,
+    _user_prompt,
+    links_content_unfetched,
+    unfetched_links_note,
+)
 from xbrain.models import Author, Content, ContentSourceSuccess, Item, Link, Topic
 
 from tests.conftest import FakeAnthropic
@@ -538,9 +544,11 @@ def test_links_content_unfetched_ignores_a_textless_source():
 def test_user_prompt_flags_unfetched_links():
     """When the linked content was never fetched, the prompt carries the guardrail
     note — the model must not reconstruct the linked content from the URL/domain."""
-    prompt = _user_prompt(_linked_item(), VOCAB)
-    assert "NOT fetched" in prompt
-    assert "never describe, reconstruct or guess" in prompt
+    item = _linked_item()
+    prompt = _user_prompt(item, VOCAB)
+    # Identity, not a substring: the prompt must carry the SHARED note verbatim, so the
+    # judge can hold the generator to exactly what it was told.
+    assert unfetched_links_note(item) in prompt
 
 
 def test_user_prompt_does_not_flag_links_when_article_fetched():
@@ -560,7 +568,7 @@ def test_user_prompt_labels_thread_text_as_thread_not_article():
     thread_idx = prompt.index("Thread (full text by the same author):")
     assert thread_idx < prompt.index("1/ my thread")
     assert "Linked article" not in prompt  # …but it is not served as a fetched article
-    assert "NOT fetched" in prompt  # …and the unfetched link is still flagged
+    assert unfetched_links_note(item) in prompt  # …and the unfetched link is still flagged
 
 
 def test_user_prompt_partial_fetch_flags_the_missing_link_with_counts():
@@ -569,8 +577,9 @@ def test_user_prompt_partial_fetch_flags_the_missing_link_with_counts():
     item = _linked_item(links=2, sources=[_source("external_article", "the fetched body")])
     prompt = _user_prompt(item, VOCAB)
     assert "the fetched body" in prompt
-    assert "1 of 2" in prompt
-    assert "NOT fetched" in prompt
+    note = unfetched_links_note(item)
+    assert note is not None and "1 of 2" in note
+    assert note in prompt
 
 
 def test_user_prompt_marks_an_unfetched_quoted_post():
@@ -579,7 +588,7 @@ def test_user_prompt_marks_an_unfetched_quoted_post():
     item = _item("1", quoted_id="123")
     prompt = _user_prompt(item, VOCAB)
     assert "Quoted post" in prompt
-    assert "NOT fetched" in prompt
+    assert QUOTED_CONTENT_UNFETCHED_NOTE in prompt
 
 
 def test_user_prompt_has_no_quoted_marker_without_a_quote():

--- a/tests/test_guardrail_contract.py
+++ b/tests/test_guardrail_contract.py
@@ -1,0 +1,147 @@
+# tests/test_guardrail_contract.py
+"""The unfetched-content guardrails are ONE contract, read by every LLM surface.
+
+The generator (the `api` prompt, the enrich worksheet) and the judge (the verify
+source) must receive the note VERBATIM and IDENTICAL. If any surface drifts to its own
+wording, the judge can no longer hold the generator to what it was told — which is the
+entire premise of the guardrail.
+
+These tests assert IDENTITY against the shared note, and pin the note's semantic core.
+They never assert a bare `"NOT fetched"` substring: that substring is already satisfied
+by the section HEADER (`[Links — content NOT fetched]`), so a test written that way
+passes even when the instruction itself has been deleted — an accidental tautology that
+let a gutted guardrail through review once already.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from xbrain.executors.api import (
+    QUOTED_CONTENT_UNFETCHED_NOTE,
+    _user_prompt,
+    unfetched_links_note,
+)
+from xbrain.models import Author, Content, ContentSourceSuccess, Item, Link, Topic
+from xbrain.verification import _source_text
+from xbrain.worksheet import export_worksheet
+
+VOCAB = [Topic(slug="misc", description="Noise.")]
+
+
+def _item(*, links: int = 0, quoted: bool = False, article: bool = False) -> Item:
+    sources = (
+        [
+            ContentSourceSuccess(
+                kind="external_article",
+                url="https://example.com/0",
+                title="The piece",
+                text="the fetched article body",
+            )
+        ]
+        if article
+        else []
+    )
+    return Item(
+        id="1",
+        source="bookmark",
+        url="https://x.com/a/status/1",
+        author=Author(handle="a", name="A"),
+        text="a post",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url=f"https://example.com/{i}", domain="example.com") for i in range(links)],
+        quoted_id="999" if quoted else None,
+        content=(
+            Content(fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc), sources=sources)
+            if sources
+            else None
+        ),
+    )
+
+
+def _worksheet_entry(item: Item, tmp_path) -> dict:
+    path = tmp_path / "ws.json"
+    export_worksheet([item], VOCAB, path, "claude-code", "English")
+    return json.loads(path.read_text(encoding="utf-8"))["items"][0]
+
+
+# ------------------------------------------------- one contract, every surface
+
+
+@pytest.mark.parametrize(
+    ("links", "article"),
+    [
+        (1, False),  # nothing fetched
+        (2, True),  # PARTIAL fetch — the note states the counts
+    ],
+)
+def test_every_surface_carries_the_identical_unfetched_links_note(links, article, tmp_path):
+    """The generator's two surfaces and the judge's source must carry the SAME note,
+    verbatim. Any surface drifting to its own wording breaks the contract silently."""
+    item = _item(links=links, article=article)
+    note = unfetched_links_note(item)
+    assert note is not None
+    assert note in _user_prompt(item, VOCAB)  # generator: api prompt
+    assert _worksheet_entry(item, tmp_path)["unfetched_links_note"] == note  # generator: worksheet
+    assert note in _source_text(item)  # judge: verify source
+
+
+def test_every_surface_carries_the_identical_quoted_note(tmp_path):
+    """Same contract for the quoted post nobody fetches."""
+    item = _item(quoted=True)
+    assert QUOTED_CONTENT_UNFETCHED_NOTE in _user_prompt(item, VOCAB)
+    assert _worksheet_entry(item, tmp_path)["quoted_content_note"] == QUOTED_CONTENT_UNFETCHED_NOTE
+    assert QUOTED_CONTENT_UNFETCHED_NOTE in _source_text(item)
+
+
+def test_the_judge_source_carries_the_note_not_merely_the_header():
+    """The judge's source must carry the INSTRUCTION, not just the `[Links — content
+    NOT fetched]` heading. Deleting the note while keeping the header is the mutation
+    that survived review: the header alone satisfies a `"NOT fetched"` substring."""
+    item = _item(links=1)
+    text = _source_text(item)
+    header = "[Links — content NOT fetched]"
+    assert header in text
+    assert text.replace(header, "").count("NOT fetched") >= 1  # the note survives header removal
+    assert unfetched_links_note(item) in text
+
+
+def test_the_judge_source_carries_the_quoted_note_not_merely_the_header():
+    item = _item(quoted=True)
+    text = _source_text(item)
+    header = "[Quoted post — content NOT fetched]"
+    assert header in text
+    assert QUOTED_CONTENT_UNFETCHED_NOTE in text.replace(header, "")
+
+
+# ------------------------------------------------- the note's semantic core
+
+
+@pytest.mark.parametrize(
+    "note_of",
+    [
+        lambda: unfetched_links_note(_item(links=1)),
+        lambda: unfetched_links_note(_item(links=2, article=True)),
+        lambda: QUOTED_CONTENT_UNFETCHED_NOTE,
+    ],
+)
+def test_the_note_forbids_reconstructing_content_that_was_never_downloaded(note_of):
+    """The note IS the guardrail. Gutting its instruction to a bare "NOT fetched." must
+    not stay green — that empties the PR of its content while CI applauds."""
+    note = note_of()
+    assert note is not None
+    assert "NOT fetched" in note  # the state
+    for forbidden in ("describe", "reconstruct", "guess"):  # the instruction
+        assert forbidden in note
+    for basis in ("URL", "domain", "world knowledge"):  # …and what it may not be guessed from
+        assert basis in note
+
+
+def test_the_partial_fetch_note_states_the_counts():
+    """A partial fetch has a `[Linked article]` block sitting right there; the note must
+    say how many links it does NOT cover, or that block lends it false credibility."""
+    note = unfetched_links_note(_item(links=2, article=True))
+    assert note is not None
+    assert "1 of 2" in note

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -441,11 +441,15 @@ def test_source_text_marks_unfetched_links():
     from xbrain.models import Link
     from xbrain.verification import _source_text
 
+    from xbrain.executors.api import unfetched_links_note
+
     item = _item()
     item.links = [Link(url="https://t.co/x", domain="time.com")]
     # the only content source is the x_video transcript — no fetched article
     text = _source_text(item)
-    assert "NOT fetched" in text
+    # Identity, not a substring: `"NOT fetched" in text` is already satisfied by the
+    # `[Links — content NOT fetched]` HEADER, so it would pass with the instruction gone.
+    assert unfetched_links_note(item) in text
     assert "time.com" in text
 
 
@@ -584,3 +588,18 @@ def test_source_text_omits_decorative_image_descriptions():
     from xbrain.verification import _source_text
 
     assert "[Images in the post]" not in _source_text(_item())
+
+
+def test_source_text_omits_the_author_block_without_a_handle():
+    """G4: the rubric tells the judge the `[Author]` block is TRUSTED metadata, so an
+    empty one (`[Author]\\n@ ()`) would present a garbage anchor as trustworthy. No
+    handle, no block — the judge then has no author to attribute anything to, which is
+    the strict direction."""
+    from xbrain.verification import _source_text
+
+    item = _item()
+    item.author = Author(handle="", name="")
+    text = _source_text(item)
+    assert "[Author]" not in text
+    assert "@ ()" not in text
+    assert "[Video transcript]" in text  # the rest of the source is unaffected

--- a/tests/test_worksheet.py
+++ b/tests/test_worksheet.py
@@ -322,9 +322,11 @@ def test_export_worksheet_notes_unfetched_links(tmp_path):
     path = tmp_path / "ws.json"
     export_worksheet([_item("1")], VOCAB, path, "claude-code", "English")
     data = json.loads(path.read_text(encoding="utf-8"))
+    from xbrain.executors.api import unfetched_links_note
+
     note = data["items"][0]["unfetched_links_note"]
     assert note is not None
-    assert "NOT fetched" in note
+    assert note == unfetched_links_note(_item("1"))  # the SHARED note, verbatim
 
 
 def test_export_worksheet_no_unfetched_note_when_article_fetched(tmp_path):
@@ -410,9 +412,10 @@ def test_export_worksheet_marks_an_unfetched_quoted_post(tmp_path):
     does not invent the shared content the summary rubric asks it to describe."""
     item = _item("1")
     item.quoted_id = "999"
+    from xbrain.executors.api import QUOTED_CONTENT_UNFETCHED_NOTE
+
     entry = _exported(item, tmp_path)
-    assert entry["quoted_content_note"] is not None
-    assert "NOT fetched" in entry["quoted_content_note"]
+    assert entry["quoted_content_note"] == QUOTED_CONTENT_UNFETCHED_NOTE
 
 
 def test_export_worksheet_no_quoted_note_without_a_quote(tmp_path):


### PR DESCRIPTION
Seguimiento de #86 (ya mergeado). Un segundo revisor hizo **mutation testing** sobre los guardarraíles de contenido-no-descargado y encontró que el **cableado** estaba bien cubierto, pero **el contrato en sí** no — justo en un PR cuya premisa es *"el generador y el juez leen el MISMO contrato"*.

Pasado ese lente sobre el código ya mergeado, **2 mutaciones sobrevivían en VERDE**, las dos en la nota de quote añadida en #86:

| Mutación | Antes | Ahora |
|---|---|---|
| `M2` — vaciar `QUOTED_CONTENT_UNFETCHED_NOTE` a la cadena pelada `"NOT fetched."`, borrando *"never describe, reconstruct or guess…"* | 🟢 **sobrevivía (1261 passed)** | 🔴 cazada |
| `M7` — quitar la nota de `_source_text` **manteniendo la cabecera** `[Quoted post — content NOT fetched]` | 🟢 **sobrevivía** | 🔴 cazada |
| `M1` vaciar la regla de links · `M3` idem en el source del juez · `M4`/`M5`/`M6` cada superficie deriva a su propia redacción · `C1` predicado siempre False · `C2` borrar el bloque `[Author]` | 🔴 | 🔴 |

**10/10 mutaciones cazadas · 0 supervivientes.**

`M7` es una **tautología accidental**: `assert "NOT fetched" in text` **ya lo satisface la CABECERA de sección**, así que la aserción parecía cubrir la instrucción cuando solo cubría el título. Por eso una guardarraíl vaciado pasaba CI aplaudiendo.

## Qué hace este PR

**`tests/test_guardrail_contract.py`** fija el invariante que el docstring de la constante ya afirmaba y nadie comprobaba: el prompt del `api`, el worksheet de `enrich` y el source de `verify` llevan la nota **IDÉNTICA y literal** — identidad contra la constante compartida, **nunca un substring** — para la nota de links y la de quote, en fetch total y en fetch parcial. Más el **núcleo semántico** de la nota: debe prohibir *describir / reconstruir / adivinar* el contenido a partir de la URL, el dominio o conocimiento del mundo. Las aserciones por substring de los tests de #86 se re-apuntan a las constantes compartidas por el mismo motivo.

**G4 (`verification.py`):** `_source_text` emitía `[Author]\n@ ()` con un handle vacío. No es alcanzable hoy (la extracción descarta ítems sin handle), pero la rúbrica de #86 le dice al juez que el bloque `[Author]` es metadato **de confianza** — un ancla basura no puede presentarse como fiable. Sin handle, sin bloque: el juez se queda sin nadie a quien atribuir nada, que es la dirección estricta.

## ⚠️ Precondición que sigue abierta (no se arregla aquí)

#86 **cambió el contrato de juicio** (source + rúbricas), pero `fingerprint_output` hashea **solo el OUTPUT**, no el contrato que el juez leyó. Todo verdict almacenado **antes** de #86 sigue haciendo fingerprint-match y se muestra como FRESCO, aunque se emitió bajo el contrato viejo — el que (medido con jueces reales, N=8) dejaba pasar **8/8** la atribución falsa del ponente.

**Todo verdict existente es obsoleto en sustancia aunque no en fingerprint. Un re-verify de todo el corpus es precondición para confiar en cualquier badge.** Va en su propio PR.

## Estado
1271 tests verdes · `poe check` completo en verde (ruff, format, mypy, radon A/B, bandit, vulture, interrogate, detect-secrets, deptry, cobertura 95%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)