### PR TITLE
fix(extract): read the long-form tweet body, not the 280-char truncation

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -29,7 +29,12 @@ from xbrain.extract.browser import x_context
 from xbrain.extract.extractor import RateLimitTruncated, extract_source
 from xbrain.extract.threads import expand_threads
 from xbrain.fetch import fetch_pending
-from xbrain.fetch_x import fetch_x_articles
+from xbrain.extract.graphql import items_needing_refetch
+from xbrain.fetch_x import (
+    browser_text_fetcher,
+    fetch_x_articles,
+    refetch_full_texts,
+)
 from xbrain.generate import generate as run_generate
 from xbrain.media import download_all as run_media_download
 from xbrain.media import emit_summary_line as media_emit_summary_line
@@ -2154,6 +2159,38 @@ def reextract_command(
         typer.echo(f"{len(report.changed)} campo(s) actualizados → {cfg.items_path}")
     else:
         typer.echo("Dry run. Pass --apply to write.")
+@app.command(name="refetch-truncated")
+@_handle_cli_errors
+def refetch_truncated_command(
+    apply: bool = typer.Option(False, "--apply", help="Actually re-fetch from X (network)"),
+) -> None:
+    """List (or re-fetch) items whose tweet text was TRUNCATED at ingest.
+
+    `legacy.full_text` is capped at 280 chars: X cuts a long post mid-word and appends a
+    t.co self-link. Items ingested before the `note_tweet` fix carry half a sentence, and
+    the generator — told to summarise it — finishes the sentence itself.
+
+    The raw GraphQL payloads are NOT on disk (they are captured in-flight), so this is NOT
+    a free re-parse: `--apply` re-fetches each affected tweet from X. It snapshots `data/`
+    first. Without `--apply` it only reports, and writes the id list.
+    """
+    cfg = _config()
+    store = load_store(cfg.items_path)
+    targets = items_needing_refetch(store)
+    path = cfg.data_dir / "truncated-items.json"
+    path.write_text(
+        json.dumps([{"id": i.id, "url": i.url, "text": i.text} for i in targets], indent=2),
+        encoding="utf-8",
+    )
+    typer.echo(f"{len(targets)}/{len(store)} items truncated at ingest → {path}")
+    if not apply:
+        typer.echo("Dry run. Re-fetching requires the network: pass --apply.")
+        return
+    _auto_snapshot(cfg, "refetch-truncated")
+    with x_context(cfg.storage_state_path, headless=False) as context:
+        repaired = refetch_full_texts(store, targets, browser_text_fetcher(context))
+    save_store(store, cfg.items_path)
+    typer.echo(f"{repaired}/{len(targets)} textos completos recuperados → {cfg.items_path}")
 
 
 if __name__ == "__main__":

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -2159,6 +2159,8 @@ def reextract_command(
         typer.echo(f"{len(report.changed)} campo(s) actualizados → {cfg.items_path}")
     else:
         typer.echo("Dry run. Pass --apply to write.")
+
+
 @app.command(name="refetch-truncated")
 @_handle_cli_errors
 def refetch_truncated_command(
@@ -2187,10 +2189,21 @@ def refetch_truncated_command(
         typer.echo("Dry run. Re-fetching requires the network: pass --apply.")
         return
     _auto_snapshot(cfg, "refetch-truncated")
+
+    # Checkpoint as we go: a session expiry on item 400 of 535 must not discard the first
+    # 400 repairs. This is deliberately human-paced browser work — hours of it.
+    def _checkpoint() -> None:
+        save_store(store, cfg.items_path)
+
     with x_context(cfg.storage_state_path, headless=False) as context:
-        repaired = refetch_full_texts(store, targets, browser_text_fetcher(context))
+        repaired = refetch_full_texts(
+            store, targets, browser_text_fetcher(context), checkpoint=_checkpoint
+        )
     save_store(store, cfg.items_path)
-    typer.echo(f"{repaired}/{len(targets)} textos completos recuperados → {cfg.items_path}")
+    typer.echo(
+        f"{repaired}/{len(targets)} textos completos recuperados → {cfg.items_path}\n"
+        f"{repaired} resúmenes invalidados: vuelve a ejecutar `xbrain enrich`."
+    )
 
 
 if __name__ == "__main__":

--- a/src/xbrain/extract/graphql.py
+++ b/src/xbrain/extract/graphql.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime, timezone
 from typing import Any, Iterator
 from urllib.parse import urlparse
@@ -109,6 +110,67 @@ def _unwrap(result: dict[str, Any]) -> dict[str, Any] | None:
     return result if "legacy" in result else None
 
 
+# X truncates a long post at 280 characters of prose and appends a t.co self-link.
+_TRAILING_TCO = re.compile(r"https://t\.co/\w+\s*$")
+# A sentence that really ended does so on punctuation. Anything else at the cap is a cut.
+_TERMINAL = (".", "!", "?", "…", '"', "”", ")", ":", ";", "»")
+# The observed cut lands at 270–290 chars of body (the store's median body is 279).
+_TRUNCATION_FLOOR = 265
+
+
+def looks_truncated(text: str, links: list[str]) -> bool:
+    """True when `text` bears X's 280-character truncation signature.
+
+    The mechanical marks: ~280 characters of prose, ending mid-word with no terminal
+    punctuation, optionally followed by an appended `t.co` self-link that is NOT among the
+    tweet's own `links` (X adds it; the tweet never contained it).
+
+    Deliberately biased towards FLAGGING: a detector that silently passes a genuinely
+    truncated tweet reproduces the very bug it exists to catch — the generator gets half a
+    sentence and finishes it. A false flag costs a re-fetch; a missed one costs a
+    fabrication in the knowledge base.
+    """
+    body = text.rstrip()
+    match = _TRAILING_TCO.search(body)
+    if match and match.group().strip() not in links:
+        body = body[: match.start()].rstrip()
+    return len(body) >= _TRUNCATION_FLOOR and not body.endswith(_TERMINAL)
+
+
+def items_needing_refetch(store: dict[str, Item]) -> list[Item]:
+    """Every stored item whose text was truncated at ingest.
+
+    These were extracted before the `note_tweet` fix, so their long-form body was never
+    read. The raw GraphQL payloads are NOT persisted (they are captured in-flight during
+    the browser session), so repairing them REQUIRES a re-fetch from X — this is not a
+    free re-parse of data we already hold.
+    """
+    return [
+        item
+        for item in store.values()
+        if looks_truncated(item.text, [link.url for link in item.links])
+    ]
+
+
+def _tweet_text(tweet: dict[str, Any], legacy: dict[str, Any]) -> str:
+    """The tweet's FULL text — the long-form body when X provides one.
+
+    `legacy.full_text` is capped at 280 characters: X truncates a long post there and
+    appends a t.co self-link, so the stored text ends mid-word ("…solve literally any").
+    The generator is then handed half a sentence and told to summarise it, and it completes
+    the sentence itself — a fabrication WE cause, at ingest. The real body lives in
+    `note_tweet.note_tweet_results.result.text`.
+
+    An empty long-form body falls back to `full_text`: shipping a truncated tweet is bad,
+    shipping an EMPTY one is worse.
+    """
+    # `_dig` coerces a non-dict leaf to {}, so walk to the parent and read the leaf here.
+    note = _dig(tweet, "note_tweet", "note_tweet_results", "result").get("text")
+    if isinstance(note, str) and note.strip():
+        return note
+    return legacy.get("full_text", "")
+
+
 def _tweet_to_item(tweet: dict[str, Any], source: SourceName) -> Item | None:
     legacy = tweet.get("legacy")
     rest_id = tweet.get("rest_id")
@@ -123,7 +185,7 @@ def _tweet_to_item(tweet: dict[str, Any], source: SourceName) -> Item | None:
         source=source,
         url=f"https://x.com/{author.handle}/status/{rest_id}",
         author=author,
-        text=legacy.get("full_text", ""),
+        text=_tweet_text(tweet, legacy),
         created_at=_parse_x_date(legacy.get("created_at")),
         captured_at=datetime.now(timezone.utc),
         media=_extract_media(legacy),

--- a/src/xbrain/extract/graphql.py
+++ b/src/xbrain/extract/graphql.py
@@ -112,28 +112,47 @@ def _unwrap(result: dict[str, Any]) -> dict[str, Any] | None:
 
 # X truncates a long post at 280 characters of prose and appends a t.co self-link.
 _TRAILING_TCO = re.compile(r"https://t\.co/\w+\s*$")
-# A sentence that really ended does so on punctuation. Anything else at the cap is a cut.
-_TERMINAL = (".", "!", "?", "…", '"', "”", ")", ":", ";", "»")
-# The observed cut lands at 270–290 chars of body (the store's median body is 279).
+# A sentence that really ended does so on one of these.
+#
+# `:` and `;` are DELIBERATELY ABSENT. A colon is a CONTINUATION marker — the literal
+# opposite of a terminator — and X's cut lands on one constantly: "Here's how to write
+# headers that convert like crazy:" with nothing after it, a numbered list severed at "4.".
+# Those were the worst-mutilated items in the corpus and the detector waved all 72 through.
+_TERMINAL = (".", "!", "?", "…", '"', "”", ")", "»")
+# The cut lands at 274–282 chars of prose (the store's median body is 279).
 _TRUNCATION_FLOOR = 265
+# Above this, prose length ALONE is the signal: X's cut is DEFINED by length, so no final
+# character may override it. A tweet this long that ends on a terminator is one X trimmed to
+# fit exactly — still a cut.
+_TRUNCATION_CERTAIN = 274
 
 
 def looks_truncated(text: str, links: list[str]) -> bool:
     """True when `text` bears X's 280-character truncation signature.
 
-    The mechanical marks: ~280 characters of prose, ending mid-word with no terminal
-    punctuation, optionally followed by an appended `t.co` self-link that is NOT among the
-    tweet's own `links` (X adds it; the tweet never contained it).
+    LENGTH is the signal, because X's cut is defined by length. Two bands:
 
-    Deliberately biased towards FLAGGING: a detector that silently passes a genuinely
-    truncated tweet reproduces the very bug it exists to catch — the generator gets half a
-    sentence and finishes it. A false flag costs a re-fetch; a missed one costs a
-    fabrication in the knowledge base.
+    * `>= 274` chars of prose — truncated regardless of the final character. Letting
+      punctuation override the length signal is what hid the 72 worst items in the corpus.
+    * `265–273` — truncated when it does not end on a real terminator (`:` and `;` are not
+      terminators; see `_TERMINAL`).
+
+    Biased towards FLAGGING: a detector that silently passes a genuine truncation reproduces
+    the very bug it exists to catch. A false flag costs a re-fetch; a missed one costs a
+    fabrication in the knowledge base — and after this PR, `refetch-truncated` is the ONLY
+    repair path for old items, so a miss keeps its half-sentence forever.
+
+    `links` is accepted but no longer consulted: `_extract_links` stores the RESOLVED
+    `expanded_url`, so a `t.co` can never appear there (measured: 0 of 2,168 items). The
+    condition could never be False — dead code, load-bearing in a docstring. The trailing
+    t.co is now stripped unconditionally, and the length does the work.
     """
     body = text.rstrip()
     match = _TRAILING_TCO.search(body)
-    if match and match.group().strip() not in links:
+    if match:
         body = body[: match.start()].rstrip()
+    if len(body) >= _TRUNCATION_CERTAIN:
+        return True
     return len(body) >= _TRUNCATION_FLOOR and not body.endswith(_TERMINAL)
 
 
@@ -166,9 +185,16 @@ def _tweet_text(tweet: dict[str, Any], legacy: dict[str, Any]) -> str:
     """
     # `_dig` coerces a non-dict leaf to {}, so walk to the parent and read the leaf here.
     note = _dig(tweet, "note_tweet", "note_tweet_results", "result").get("text")
-    if isinstance(note, str) and note.strip():
-        return note
-    return legacy.get("full_text", "")
+    full = legacy.get("full_text", "")
+    if not isinstance(note, str) or not note.strip():
+        return full
+    # A long-form body is by definition NOT SHORTER than the truncation of itself. Compare
+    # against the PROSE of `full_text` — the truncation carries an appended t.co that is not
+    # part of the post, so comparing raw lengths would reject a genuine 285-char body against
+    # a 303-char "280 + link". Unreachable in X's real schema, and this module's whole thesis
+    # is that the unreachable shape is what bites you six months later.
+    prose = _TRAILING_TCO.sub("", full).rstrip()
+    return note if len(note) >= len(prose) else full
 
 
 def _tweet_to_item(tweet: dict[str, Any], source: SourceName) -> Item | None:
@@ -180,12 +206,23 @@ def _tweet_to_item(tweet: dict[str, Any], source: SourceName) -> Item | None:
     if author is None:
         return None
     quoted_id = legacy.get("quoted_status_id_str") or _quoted_id(tweet)
+    text = _tweet_text(tweet, legacy)
+    if looks_truncated(text, []):
+        # N7: the guard is CALLED, not merely defined. A tweet that still arrives truncated
+        # means `note_tweet` was absent (X did not give us the body) or the read regressed —
+        # and a silent regression here is exactly how 432 items got half a sentence.
+        logger.warning(
+            "tweet %s arrives TRUNCATED (%d chars, cut mid-word) — the long-form body was "
+            "not available; the generator will be handed half a sentence.",
+            rest_id,
+            len(text),
+        )
     return Item(
         id=str(rest_id),
         source=source,
         url=f"https://x.com/{author.handle}/status/{rest_id}",
         author=author,
-        text=_tweet_text(tweet, legacy),
+        text=text,
         created_at=_parse_x_date(legacy.get("created_at")),
         captured_at=datetime.now(timezone.utc),
         media=_extract_media(legacy),
@@ -355,7 +392,10 @@ def _quoted_content(tweet: dict[str, Any], quoted_id: str | None) -> Content | N
         # us the body too: dropping the cure because one field is missing would be the
         # bug wearing a different hat.
         author = _extract_author(quoted)
-        text = _dig(quoted, "legacy").get("full_text") or ""
+        # THROUGH `_tweet_text`, never around it: reading `legacy.full_text` directly here
+        # re-introduced the 280-char truncation into the very evidence #98 exists to ship —
+        # a long quoted post reached the generator cut mid-word. One helper, one truth.
+        text = _tweet_text(quoted, _dig(quoted, "legacy"))
         rest_id = quoted.get("rest_id") or quoted_id
         handle = author.handle if author else "i"
         if text:

--- a/src/xbrain/fetch_x.py
+++ b/src/xbrain/fetch_x.py
@@ -395,13 +395,53 @@ def _attach_x_sources(
         item.content.fetched_at = now()
 
 
+def tweet_text_from_payloads(responses: list[dict], url: str) -> str | None:
+    """THIS tweet's body from captured TweetDetail payloads — never the thread's.
+
+    Pure, and separated precisely so it can be tested: the previous version delegated to
+    `_fetch_tweet`, which was never a "get this tweet's text" function. It fetches a LINKED
+    tweet as an `x_article` source via `assemble_linked_thread`, which joins EVERY tweet by
+    the anchor's author with "\n\n". So a re-fetch would have written a three-tweet blob into
+    `item.text` — and a post long enough to hit the 280-cap is exactly the kind that gets
+    self-replies, so this fired constantly, not rarely.
+
+    We parse the payload and select the item whose id matches the STATUS ID IN THE URL. No
+    match → None: a tombstoned or protected tweet must yield nothing, never a neighbouring
+    tweet's body, which would silently write someone else's words into this item.
+    """
+    status_id = _x_status_id(url)
+    if not status_id:
+        return None
+    for response in responses:
+        for item in parse_tweets(response, "bookmark"):
+            if item.id == status_id:
+                return item.text or None
+    return None
+
+
 def browser_text_fetcher(context: BrowserContext) -> Callable[[str], str | None]:
     """Bind a full-text fetcher to a live X session: visit the status page, intercept the
-    TweetDetail payload, and re-parse it with the (now note_tweet-aware) extractor."""
+    TweetDetail payloads, and re-parse THIS tweet with the (now note_tweet-aware) extractor.
+    """
 
     def fetch(url: str) -> str | None:
-        source = _fetch_tweet(context, url)
-        return getattr(source, "text", None)
+        captured: list[dict] = []
+        page = context.new_page()
+
+        def on_response(response: Response) -> None:
+            if "/graphql/" in response.url and "TweetDetail" in response.url:
+                try:
+                    captured.append(response.json())
+                except Exception:  # noqa: BLE001 - ignore non-JSON / partial bodies
+                    logger.debug("refetch: undecodable GraphQL response: %s", response.url)
+
+        page.on("response", on_response)
+        try:
+            page.goto(url, wait_until="domcontentloaded")
+            page.wait_for_timeout(_SETTLE_MS)
+        finally:
+            page.close()
+        return tweet_text_from_payloads(captured, url)
 
     return fetch
 
@@ -410,22 +450,44 @@ def refetch_full_texts(
     store: dict[str, Item],
     targets: list[Item],
     text_fetcher: Callable[[str], str | None],
+    *,
+    checkpoint: Callable[[], None] | None = None,
+    every: int = 25,
 ) -> int:
     """Replace each truncated item's text with the full post re-fetched from X.
 
     `text_fetcher` is injected (tests pass a fake; production binds it to a Playwright
     TweetDetail capture) — the same seam `fetch_x_articles` uses for `link_fetcher`.
 
-    A failed or empty re-fetch leaves the truncated text ALONE. Half a tweet is bad;
-    blanking the item is worse, and it would be a silent data loss on the one surface that
-    is the only evidence 432 items have.
+    A failed or empty re-fetch leaves the truncated text ALONE. Half a tweet is bad; blanking
+    the item is worse, and it would be silent data loss on the one surface that is the only
+    evidence 432 items have.
+
+    A repaired text NULLS `enriched`: the summary was written from half a sentence and must
+    be regenerated. `_needs_reenrichment` cannot do this job — it requires
+    `item.content is not None`, and the population this repairs is precisely the one with no
+    content block at all. The standard lever does not reach them.
+
+    `checkpoint` is called every `every` items and re-raised through: a session expiry on
+    item 400 of 535 must not discard the first 400 repairs — that is hours of deliberately
+    human-paced browser work.
     """
     repaired = 0
-    for item in targets:
-        fresh = text_fetcher(item.url)
-        if fresh and fresh.strip() and fresh != item.text:
-            item.text = fresh
-            repaired += 1
+    try:
+        for index, item in enumerate(targets, start=1):
+            fresh = text_fetcher(item.url)
+            if fresh and fresh.strip() and fresh != item.text:
+                item.text = fresh
+                # The summary was written from the truncation. It is stale by construction,
+                # and its persisted verdict still reads PASS because verification fingerprints
+                # the OUTPUT, not the source it was built from.
+                item.enriched = None
+                repaired += 1
+            if checkpoint and index % every == 0:
+                checkpoint()
+    finally:
+        if checkpoint:
+            checkpoint()
     return repaired
 
 

--- a/src/xbrain/fetch_x.py
+++ b/src/xbrain/fetch_x.py
@@ -395,6 +395,40 @@ def _attach_x_sources(
         item.content.fetched_at = now()
 
 
+def browser_text_fetcher(context: BrowserContext) -> Callable[[str], str | None]:
+    """Bind a full-text fetcher to a live X session: visit the status page, intercept the
+    TweetDetail payload, and re-parse it with the (now note_tweet-aware) extractor."""
+
+    def fetch(url: str) -> str | None:
+        source = _fetch_tweet(context, url)
+        return getattr(source, "text", None)
+
+    return fetch
+
+
+def refetch_full_texts(
+    store: dict[str, Item],
+    targets: list[Item],
+    text_fetcher: Callable[[str], str | None],
+) -> int:
+    """Replace each truncated item's text with the full post re-fetched from X.
+
+    `text_fetcher` is injected (tests pass a fake; production binds it to a Playwright
+    TweetDetail capture) — the same seam `fetch_x_articles` uses for `link_fetcher`.
+
+    A failed or empty re-fetch leaves the truncated text ALONE. Half a tweet is bad;
+    blanking the item is worse, and it would be a silent data loss on the one surface that
+    is the only evidence 432 items have.
+    """
+    repaired = 0
+    for item in targets:
+        fresh = text_fetcher(item.url)
+        if fresh and fresh.strip() and fresh != item.text:
+            item.text = fresh
+            repaired += 1
+    return repaired
+
+
 def fetch_x_articles(
     store: dict[str, Item],
     storage_state_path: Path | None,

--- a/tests/test_fetch_x.py
+++ b/tests/test_fetch_x.py
@@ -1,5 +1,6 @@
 # tests/test_fetch_x.py
 import json
+import pytest
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -671,3 +672,145 @@ def test_refetch_full_texts_never_blanks_an_item_when_the_refetch_fails():
     assert item.text == "cut off mid"
     assert refetch_full_texts(store, [item], lambda url: "   ") == 0
     assert item.text == "cut off mid"
+
+
+# --- N1: the re-fetch was writing whole THREADS into item.text -------------------------
+
+
+def _tweet_detail_payload() -> dict:
+    """A TweetDetail response shaped like the real one: the anchor post, TWO self-replies by
+    the same author, and a third-party reply — i.e. the normal shape of the exact population
+    `refetch-truncated` targets, because a post long enough to hit the 280-cap is precisely
+    the kind that gets self-replies."""
+    from tests.test_graphql import _tweet_result
+
+    def entry(tweet):
+        return {
+            "entryId": f"tweet-{tweet['rest_id']}",
+            "content": {
+                "itemContent": {"itemType": "TimelineTweet", "tweet_results": {"result": tweet}}
+            },
+        }
+
+    anchor = _tweet_result("100", "bob", "The truncated post, now complete.")
+    reply1 = _tweet_result("101", "bob", "A follow-up reply I also wrote.")
+    reply2 = _tweet_result("102", "bob", "And one more thought.")
+    other = _tweet_result("103", "stranger", "Someone else's reply entirely.")
+    return {
+        "data": {
+            "threaded_conversation_with_injections_v2": {
+                "instructions": [
+                    {
+                        "type": "TimelineAddEntries",
+                        "entries": [entry(anchor), entry(reply1), entry(reply2), entry(other)],
+                    }
+                ]
+            }
+        }
+    }
+
+
+def test_the_refetch_returns_ONE_tweet_body_not_the_whole_thread():
+    """N1, CRITICAL. `browser_text_fetcher` called `_fetch_tweet`, which was never a
+    "get this tweet's text" function: it fetches a LINKED tweet as an `x_article` source via
+    `assemble_linked_thread`, which joins EVERY tweet by the anchor's author with "\\n\\n".
+
+    So `item.text` — one tweet's body — would have become a three-tweet blob. The existing
+    guard (`fresh != item.text`) waves that through happily. Blast radius: the judge's
+    `[Tweet]` block, the worksheet text, the note body, and `title_of()` — so note FILENAMES
+    change too. And if the item also has `item.thread`, the judge sees the same content twice
+    and can only conclude the poster wrote it twice.
+
+    It was the one code path with no test — both existing tests inject a fake fetcher — which
+    is exactly why CI was green.
+    """
+    from xbrain.fetch_x import tweet_text_from_payloads
+
+    text = tweet_text_from_payloads([_tweet_detail_payload()], "https://x.com/bob/status/100")
+
+    assert text == "The truncated post, now complete."
+    assert "follow-up" not in text, "a self-reply is NOT part of this tweet's body"
+    assert "one more thought" not in text
+    assert "Someone else" not in text
+
+
+def test_the_refetch_returns_None_when_the_anchor_is_not_in_the_payload():
+    """A tombstoned or protected tweet must yield nothing — never a neighbouring tweet's
+    body, which would silently write someone else's words into this item."""
+    from xbrain.fetch_x import tweet_text_from_payloads
+
+    assert tweet_text_from_payloads([_tweet_detail_payload()], "https://x.com/x/status/999") is None
+
+
+def test_a_repaired_text_invalidates_the_stale_summary(tmp_path):
+    """N3. After repair: the FULL tweet in the note, and a summary still written from half a
+    sentence — with its PASS badge intact, because verification fingerprints the OUTPUT.
+
+    And the sharp edge specific to this PR: `_needs_reenrichment` requires
+    `item.content is not None`, and for the 432 items where the tweet is the ONLY evidence,
+    `content` is exactly what they do NOT have. **The standard lever cannot reach the
+    population this command exists to repair.** So we null `enriched` directly.
+    """
+    from datetime import datetime, timezone
+
+    from xbrain.fetch_x import refetch_full_texts
+    from xbrain.models import Author, Enrichment, Item
+
+    item = Item(
+        id="1",
+        source="bookmark",
+        url="https://x.com/a/status/1",
+        author=Author(handle="a", name="A"),
+        text="cut off mid",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    item.enriched = Enrichment(
+        enriched_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        executor="api",
+        summary="a summary written from HALF a sentence",
+    )
+    assert item.content is None, "the population this repairs has no content block at all"
+
+    store = {"1": item}
+    repaired = refetch_full_texts(store, [item], lambda url: "The whole post, complete.")
+
+    assert repaired == 1
+    assert item.text == "The whole post, complete."
+    assert item.enriched is None, "the summary built on the truncated text must not survive"
+
+
+def test_refetch_checkpoints_so_a_mid_run_failure_keeps_its_repairs():
+    """N6. `save_store` fired once, after the browser context closed. A session expiry on
+    item 400 of 535 lost all 400 — hours of deliberately human-paced scrolling, gone."""
+    from datetime import datetime, timezone
+
+    from xbrain.fetch_x import refetch_full_texts
+    from xbrain.models import Author, Item
+
+    def mk(i: str) -> Item:
+        return Item(
+            id=i,
+            source="bookmark",
+            url=f"https://x.com/a/status/{i}",
+            author=Author(handle="a", name="A"),
+            text="cut off mid",
+            created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            captured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+
+    items = [mk("1"), mk("2"), mk("3")]
+    store = {i.id: i for i in items}
+    saved: list[int] = []
+
+    def explode(url: str) -> str:
+        if url.endswith("3"):
+            raise RuntimeError("Sesión de X caducada")
+        return "repaired"
+
+    with pytest.raises(RuntimeError):
+        refetch_full_texts(store, items, explode, checkpoint=lambda: saved.append(1), every=1)
+
+    assert store["1"].text == "repaired"
+    assert store["2"].text == "repaired"
+    assert saved, "the repairs made before the failure must be checkpointed, not discarded"

--- a/tests/test_fetch_x.py
+++ b/tests/test_fetch_x.py
@@ -618,3 +618,56 @@ def test_structured_article_selects_richest_of_multiple_payloads(caplog):
     assert source.title == _OPENWIKI_TITLE
     assert len(source.blocks) > 5
     assert any("selecting the" in r.message for r in caplog.records)
+
+
+def test_refetch_full_texts_replaces_only_the_truncated_text():
+    """The backfill's core is pure and injected, exactly like `fetch_x_articles`'s
+    `link_fetcher`: the browser hop is the only untested surface."""
+    from datetime import datetime, timezone
+
+    from xbrain.fetch_x import refetch_full_texts
+    from xbrain.models import Author, Item
+
+    def mk(item_id: str, text: str) -> Item:
+        return Item(
+            id=item_id,
+            source="bookmark",
+            url=f"https://x.com/a/status/{item_id}",
+            author=Author(handle="a", name="A"),
+            text=text,
+            created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            captured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        )
+
+    cut, whole = "cut off mid", "The whole post, complete."
+    store = {"1": mk("1", cut), "2": mk("2", "untouched")}
+    fetched = {"https://x.com/a/status/1": whole}
+
+    repaired = refetch_full_texts(store, [store["1"]], lambda url: fetched.get(url))
+    assert repaired == 1
+    assert store["1"].text == whole
+    assert store["2"].text == "untouched"
+
+
+def test_refetch_full_texts_never_blanks_an_item_when_the_refetch_fails():
+    """A failed re-fetch (None/empty) must leave the truncated text in place. Half a tweet
+    is bad; no tweet at all is worse, and it would be a silent data loss."""
+    from datetime import datetime, timezone
+
+    from xbrain.fetch_x import refetch_full_texts
+    from xbrain.models import Author, Item
+
+    item = Item(
+        id="1",
+        source="bookmark",
+        url="https://x.com/a/status/1",
+        author=Author(handle="a", name="A"),
+        text="cut off mid",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+    )
+    store = {"1": item}
+    assert refetch_full_texts(store, [item], lambda url: None) == 0
+    assert item.text == "cut off mid"
+    assert refetch_full_texts(store, [item], lambda url: "   ") == 0
+    assert item.text == "cut off mid"

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -582,6 +582,7 @@ def test_iter_tweet_payloads_yields_the_full_subtree_per_tweet():
     assert pairs["111"]["legacy"]["full_text"]  # the whole subtree, not a summary
     assert pairs["111"]["rest_id"] == "111"
 
+
 def _quoted_author_block(handle: str, name: str) -> dict:
     return {"user_results": {"result": {"legacy": {"screen_name": handle, "name": name}}}}
 
@@ -782,10 +783,14 @@ def test_a_quoted_post_with_a_body_but_no_author_still_ships_its_body():
     assert isinstance(source, ContentSourceSuccess)
     assert source.text == "I am leaving OpenAI."
     assert source.author is None
+
+
 def test_long_post_uses_the_note_tweet_body_not_the_truncated_full_text():
     """The whole bug in one assertion: when X provides the long-form body, take it."""
-    truncated = "a" * 277 + " https://t.co/abc123"
-    full = "The complete thought, all of it, ending in a real sentence."
+    # A real long-form body is LONGER than the 280-char cut of itself — the fixture that
+    # said otherwise described a shape X cannot produce.
+    truncated = "The complete thought, " + "a" * 250 + " https://t.co/abc123"
+    full = "The complete thought, " + "a" * 250 + " and the rest of it, ending properly."
     items = parse_tweets([_long_post_response(truncated, full)], "bookmark")
     assert len(items) == 1
     assert items[0].text == full  # identity, not a substring check
@@ -863,3 +868,83 @@ def test_items_needing_refetch_selects_exactly_the_truncated_ones():
         "3": mk("3", "x" * 300 + " https://t.co/aaa"),  # truncated + appended self-link
     }
     assert [i.id for i in items_needing_refetch(store)] == ["1", "3"]
+
+
+def test_a_long_QUOTED_post_uses_its_note_tweet_body_too():
+    """N9, and it is live on `develop` right now.
+
+    #98 ships the quoted post's body to fix 46% of all defects — and reads
+    `legacy.full_text` DIRECTLY, so a long quoted post reaches the generator truncated at
+    280 chars, mid-word. The exact failure #98 exists to fix, reintroduced through the back
+    door. The quoted parse must go THROUGH the shared helper, not around it.
+    """
+    quoted = _tweet_result("222", "karpathy", "I am leaving " + "x" * 270 + " https://t.co/abc")
+    quoted["note_tweet"] = {
+        "note_tweet_results": {
+            "result": {"text": "I am leaving " + "x" * 270 + " — and here is the whole reason."}
+        }
+    }
+    quoted["core"] = _quoted_author_block("karpathy", "Andrej Karpathy")
+    tweet = _tweet_result("111", "bob", "read this")
+    tweet["quoted_status_result"] = {"result": quoted}
+    tweet["legacy"]["quoted_status_id_str"] = "222"
+
+    _item, source = _only_source(tweet)
+
+    assert source.text.endswith("— and here is the whole reason.")
+    assert "t.co" not in source.text
+
+
+def test_a_note_tweet_shorter_than_full_text_never_wins():
+    """N8. Unreachable in X's real schema — and this PR's entire thesis is that the
+    unreachable shape is what bites you six months later."""
+    from xbrain.extract.graphql import _tweet_text
+
+    legacy = {"full_text": "the longer, real body of the post"}
+    tweet = {"note_tweet": {"note_tweet_results": {"result": {"text": "short"}}}}
+    assert _tweet_text(tweet, legacy) == "the longer, real body of the post"
+
+
+# --- N2: the detector misses 72 of the worst-mutilated items --------------------------
+
+
+def test_truncation_detector_flags_a_cut_that_ends_on_a_colon():
+    """N2. `:` and `;` were in `_TERMINAL` — but **a colon is a CONTINUATION marker, the
+    literal opposite of a sentence terminator.** And the punctuation escape overrode the
+    LENGTH signal entirely, when X's cut is *defined* by prose length.
+
+    These are the worst-mutilated items in the corpus: a numbered list cut at item 4, a
+    promise of "the breakdown" with no breakdown. And after this PR lands,
+    `refetch-truncated` is the ONLY repair path — so a miss here keeps its half-sentence
+    forever.
+    """
+    from xbrain.extract.graphql import looks_truncated
+
+    colon = "x" * 224 + " Here's how to write headers that convert like crazy:"
+    assert len(colon) >= 274
+    assert looks_truncated(colon, links=[])
+
+    numbered = "y" * 250 + " how to select the best set of tools for your agent\n\n4."
+    assert looks_truncated(numbered, links=[])
+
+
+def test_truncation_detector_still_spares_a_short_post_that_ends_on_a_colon():
+    """Length is the signal. A colon in a SHORT post is just a colon."""
+    from xbrain.extract.graphql import looks_truncated
+
+    assert not looks_truncated("Here is the list:", links=[])
+
+
+def test_ingest_warns_when_a_tweet_arrives_truncated(caplog):
+    """N7. I called `looks_truncated` "the ingest guard that would have caught this" — and
+    never wired it into the extract path. Nothing warned at ingest, so if the `note_tweet`
+    read ever regresses it goes silent again, exactly as before. A guard that is not called
+    is a comment."""
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        parse_tweets(_long_post_response("x" * 279 + " https://t.co/abc", None), "bookmark")
+
+    assert any(
+        "truncad" in r.message.lower() or "truncat" in r.message.lower() for r in caplog.records
+    )

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -581,3 +581,285 @@ def test_iter_tweet_payloads_yields_the_full_subtree_per_tweet():
     assert set(pairs) == {"111"}
     assert pairs["111"]["legacy"]["full_text"]  # the whole subtree, not a summary
     assert pairs["111"]["rest_id"] == "111"
+
+def _quoted_author_block(handle: str, name: str) -> dict:
+    return {"user_results": {"result": {"legacy": {"screen_name": handle, "name": name}}}}
+
+
+def _quoting_tweet(quoted_result: dict | None, *, quoted_id: str | None = "222") -> dict:
+    """Tweet 111 quoting tweet `quoted_id`; `quoted_result` is what X hydrated
+    (None = X sent the id but embedded no post)."""
+    tweet = _tweet_result("111", "alice", "Read this and you'll understand better this career move")
+    if quoted_id is not None:
+        tweet["legacy"]["quoted_status_id_str"] = quoted_id
+    if quoted_result is not None:
+        tweet["quoted_status_result"] = {"result": quoted_result}
+    return tweet
+
+
+def _quoted_post(**over) -> dict:
+    quoted = _tweet_result("222", "karpathy", "I am leaving OpenAI.")
+    quoted["core"] = _quoted_author_block("karpathy", "Andrej Karpathy")
+    quoted.update(over)
+    return quoted
+
+
+def _timeline(tweet: dict) -> dict:
+    """Wrap one tweet result in a bookmark-timeline envelope."""
+    return {
+        "data": {
+            "bookmark_timeline_v2": {
+                "timeline": {
+                    "instructions": [
+                        {
+                            "type": "TimelineAddEntries",
+                            "entries": [
+                                {
+                                    "entryId": f"tweet-{tweet['rest_id']}",
+                                    "content": {
+                                        "itemContent": {
+                                            "itemType": "TimelineTweet",
+                                            "tweet_results": {"result": tweet},
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+
+# --- Long-form posts: `legacy.full_text` is a 280-char TRUNCATION -------------------
+#
+# X caps `legacy.full_text` at 280 characters and appends a t.co self-link. For a long
+# post the real body lives in `note_tweet.note_tweet_results.result.text`. Reading
+# `full_text` hands the generator half a sentence — ending mid-word, mid-clause — and the
+# rubric then tells it to summarise. It completes the sentence itself. That is a
+# fabrication WE cause, at ingest, and it affects ~18% of the store (382 items); for 281
+# of them the truncated tweet is the only evidence there is.
+
+
+def _long_post_response(full_text: str, note_text: str | None) -> dict:
+    """A bookmark payload whose tweet may carry a `note_tweet` long-form body.
+
+    Built on the SHARED `_tweet_result` / `_timeline` helpers rather than a private copy of
+    the envelope — two fixtures for one payload shape is how the two sides drift apart.
+    """
+    tweet = _tweet_result("999", "bob", full_text)
+    if note_text is not None:
+        tweet["note_tweet"] = {"note_tweet_results": {"result": {"id": "N1", "text": note_text}}}
+    return _timeline(tweet)
+
+
+def _only_source(tweet: dict):
+    items = parse_tweets(_timeline(tweet), "bookmark")
+    assert len(items) == 1
+    item = items[0]
+    assert item.content is not None, "the quoting item must carry a Content block"
+    assert len(item.content.sources) == 1
+    return item, item.content.sources[0]
+
+
+def test_quoted_post_body_and_author_land_as_a_content_source():
+    """The quoted post's TEXT and its AUTHOR are the evidence that was missing.
+
+    The author matters as much as the body: the quoted post is a third party's,
+    and naming the poster as its author is the attribution bug #86 guards against.
+    """
+    from xbrain.models import Author, ContentSourceSuccess
+
+    item, source = _only_source(_quoting_tweet(_quoted_post()))
+
+    assert isinstance(source, ContentSourceSuccess)
+    assert source.kind == "quoted_tweet"
+    assert source.text == "I am leaving OpenAI."
+    assert source.author == Author(handle="karpathy", name="Andrej Karpathy")
+    assert source.url == "https://x.com/karpathy/status/222"
+    assert item.quoted_id == "222"
+
+
+def test_the_quoted_source_carries_no_title():
+    """`notes_io.note_title` takes the first source with a `title` — a quoted post
+    has no title, and borrowing that field for the author would hijack note titles."""
+    _, source = _only_source(_quoting_tweet(_quoted_post()))
+    assert source.title is None
+
+
+def test_the_quoted_source_is_not_a_link_content_kind():
+    """It must never be mistaken for a fetched LINK body: a quoted post is not the
+    content of any link the post points at."""
+    from xbrain.executors.api import fetched_link_sources
+    from xbrain.models import LINK_CONTENT_KINDS
+
+    item, source = _only_source(_quoting_tweet(_quoted_post()))
+
+    assert source.kind not in LINK_CONTENT_KINDS
+    assert fetched_link_sources(item) == 0
+
+
+def test_a_deleted_quoted_post_lands_as_a_not_found_failure():
+    from xbrain.models import ContentSourceFailure
+
+    tombstone = {"__typename": "TweetTombstone", "tombstone": {"text": {"text": "unavailable"}}}
+    _, source = _only_source(_quoting_tweet(tombstone))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.kind == "quoted_tweet"
+    assert source.failure_reason == "not_found"
+    assert source.url == "https://x.com/i/status/222"
+
+
+def test_a_protected_quoted_post_lands_as_a_forbidden_failure():
+    from xbrain.models import ContentSourceFailure
+
+    unavailable = {"__typename": "TweetUnavailable", "reason": "Protected"}
+    _, source = _only_source(_quoting_tweet(unavailable))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "forbidden"
+
+
+def test_an_unhydrated_quoted_post_lands_as_an_empty_content_failure():
+    """X sent the id but embedded no post — we know a quote exists and hold none
+    of it. That is a FAILURE state, not the absence of a quote."""
+    from xbrain.models import ContentSourceFailure
+
+    _, source = _only_source(_quoting_tweet(None))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "empty_content"
+    assert source.url == "https://x.com/i/status/222"
+
+
+def test_a_quoted_post_with_no_body_and_no_author_is_an_empty_content_failure():
+    from xbrain.models import ContentSourceFailure
+
+    _, source = _only_source(_quoting_tweet({"__typename": "Tweet", "rest_id": "222"}))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "empty_content"
+
+
+def test_a_tweet_that_quotes_nothing_gets_no_content_block():
+    """No quote → no source, and crucially no EMPTY `Content` that would later read
+    as "already fetched" to the link fetcher."""
+    items = parse_tweets(_timeline(_tweet_result("111", "alice", "just a post")), "bookmark")
+    assert items[0].quoted_id is None
+    assert items[0].content is None
+
+
+# ------------------------------------------- L6/M5: an honest record of what X did
+
+
+def test_a_media_only_quoted_post_is_not_recorded_as_X_refusing_it():
+    """X DID serve the post — it simply carries no text (a photo/video quote). Recording
+    "X did not serve the quoted post" is a false statement about the world, in the very
+    evidence store whose whole purpose is to stop us inventing facts."""
+    from xbrain.models import ContentSourceFailure
+
+    media_only = _quoted_post()
+    media_only["legacy"]["full_text"] = ""
+    _, source = _only_source(_quoting_tweet(media_only))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "empty_content"
+    assert "no text" in (source.error or "")
+    assert "did not serve" not in (source.error or "")
+
+
+def test_a_quoted_post_with_a_body_but_no_author_still_ships_its_body():
+    """The body is evidence even when X hydrates no author. Dropping it would throw away
+    the cure because one field is missing; the attribution simply names nobody."""
+    from xbrain.models import ContentSourceSuccess
+
+    anonymous = _quoted_post()
+    del anonymous["core"]
+    _, source = _only_source(_quoting_tweet(anonymous))
+
+    assert isinstance(source, ContentSourceSuccess)
+    assert source.text == "I am leaving OpenAI."
+    assert source.author is None
+def test_long_post_uses_the_note_tweet_body_not_the_truncated_full_text():
+    """The whole bug in one assertion: when X provides the long-form body, take it."""
+    truncated = "a" * 277 + " https://t.co/abc123"
+    full = "The complete thought, all of it, ending in a real sentence."
+    items = parse_tweets([_long_post_response(truncated, full)], "bookmark")
+    assert len(items) == 1
+    assert items[0].text == full  # identity, not a substring check
+    assert "t.co" not in items[0].text
+
+
+def test_a_short_post_still_uses_full_text():
+    """No `note_tweet` → `full_text` IS the whole post. The fix must not disturb the 82%."""
+    items = parse_tweets([_long_post_response("A short thought.", None)], "bookmark")
+    assert items[0].text == "A short thought."
+
+
+def test_an_empty_note_tweet_body_never_silently_replaces_the_tweet():
+    """A present-but-empty long-form body must not blank the item: falling back to the
+    truncated text is bad, but shipping an EMPTY tweet to the generator is worse."""
+    items = parse_tweets([_long_post_response("Real text here.", "")], "bookmark")
+    assert items[0].text == "Real text here."
+
+
+# --- The ingest guard that would have caught this ------------------------------------
+
+
+def test_truncation_detector_flags_x_s_long_post_signature():
+    """X's signature is unmistakable and mechanical: ~280 characters of prose, cut
+    mid-word, followed by an appended t.co self-link that is NOT among the tweet's own
+    links. 382 items in the store carry it; 281 of them have no other evidence at all."""
+    from xbrain.extract.graphql import looks_truncated
+
+    body = "En este hilo explico por qué el modelo " * 7  # ~270 chars, cut mid-clause
+    assert looks_truncated(body[:277] + " https://t.co/abc123", links=[])
+
+
+def test_truncation_detector_does_not_flag_a_short_post_or_a_real_trailing_link():
+    """A short post is not truncated, and a genuine link the tweet actually contains (it is
+    in `links`) is not the appended self-link marker."""
+    from xbrain.extract.graphql import looks_truncated
+
+    assert not looks_truncated("A short thought.", links=[])
+    real = "https://t.co/realone"
+    assert not looks_truncated("Read this: " + real, links=[real])
+
+
+def test_truncation_detector_flags_a_long_post_cut_without_any_link():
+    """When in doubt, FLAG. A ~280-char text ending mid-word with no terminal punctuation is
+    truncated even if the trailing link is absent — a detector that silently passes a
+    genuinely truncated tweet is the failure mode that produced this bug."""
+    from xbrain.extract.graphql import looks_truncated
+
+    assert looks_truncated("palabra " * 35 + "cortado a mitad de", links=[])
+
+
+def test_items_needing_refetch_selects_exactly_the_truncated_ones():
+    """The backfill's selection is pure and testable; only the browser hop is not."""
+    from datetime import datetime, timezone
+
+    from xbrain.extract.graphql import items_needing_refetch
+    from xbrain.models import Author, Item, Link
+
+    def mk(item_id: str, text: str, links: list[str] | None = None) -> Item:
+        return Item(
+            id=item_id,
+            source="bookmark",
+            url=f"https://x.com/a/status/{item_id}",
+            author=Author(handle="a", name="A"),
+            text=text,
+            created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            captured_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+            links=[Link(url=u, domain="t.co") for u in (links or [])],
+        )
+
+    cut = "palabra " * 35 + "cortado a mitad de"
+    store = {
+        "1": mk("1", cut),  # truncated
+        "2": mk("2", "Un post corto y completo."),  # fine
+        "3": mk("3", "x" * 300 + " https://t.co/aaa"),  # truncated + appended self-link
+    }
+    assert [i.id for i in items_needing_refetch(store)] == ["1", "3"]


### PR DESCRIPTION
## Root cause — verified against a real payload shape and the live store

`extract/graphql.py:105` read **`legacy.full_text`**, which X **caps at 280 characters**. For a long post X cuts the text mid-word and appends a `t.co` self-link. The real body lives in **`note_tweet.note_tweet_results.result.text`** — and nothing in the codebase ever read it.

The evidence is unambiguous in the store. Item `1874800307672420428`:

```
text  : "...electric vehicle because they used to think of it as something https://t.co/dRDW0w6SpO"
len   : 303          ← 280 chars of prose + a 23-char appended link
links : []           ← the trailing t.co is NOT in entities.urls — X added it, the tweet never contained it
```

The generator is handed **half a sentence** and told to summarise it. It finishes the sentence itself. **That is a fabrication we cause, at ingest.**

## Measured on `data/items.json` (2,168 items)

| | |
|---|---|
| items bearing the truncation signature | **535 (25%)** |
| …of which the truncated tweet is the **only** evidence | **432** |
| false flags on tweets under 200 chars | **0** |

Those 432 are where the model has nothing else to work from — no article, no transcript, no thread. It is given a fragment and asked for a summary.

## The decisive question, answered loudly: **re-extraction is NOT free**

**The raw GraphQL payloads are not on disk.** They are captured **in-flight** during the browser session (`fetch_x._fetch_tweet` → `captured.append(response.json())`) and only the *extracted* `Item` is persisted. `grep -rl note_tweet data/` returns **nothing**.

So the 535 affected items **cannot** be repaired by re-parsing what we already hold. **Repair requires a re-fetch from X, over the network.** I would rather say this plainly than have the backfill discovered to be expensive mid-run.

## The fix

- **`_tweet_text()`** — prefer the `note_tweet` long-form body; fall back to `full_text` when it is absent **or empty** (a truncated tweet is bad; an *empty* tweet is worse).
- **`looks_truncated()`** — the ingest guard that would have caught this: ~280 chars of prose, **no terminal punctuation**, plus an appended `t.co` that is **not among the tweet's own links**. Deliberately biased **towards flagging** — a detector that silently passes a genuine truncation reproduces the exact bug it exists to catch. A false flag costs a re-fetch; a missed one costs a fabrication in the knowledge base.
- **`xbrain refetch-truncated`** — reports the affected items and writes the id list; `--apply` re-fetches from X and snapshots `data/` first. **NOT RUN**, per instruction.

## Tests (written first, watched fail)

Assert **identity and structure**, never a substring:

- `test_long_post_uses_the_note_tweet_body_not_the_truncated_full_text` — `item.text == note_body`, and no `t.co` survives.
- `test_a_short_post_still_uses_full_text` — the fix must not disturb the other 75%.
- `test_an_empty_note_tweet_body_never_silently_replaces_the_tweet` — never blank an item.
- `test_truncation_detector_flags_x_s_long_post_signature` / `…does_not_flag_a_short_post_or_a_real_trailing_link` / `…flags_a_long_post_cut_without_any_link` — **when in doubt, flag**.
- `test_items_needing_refetch_selects_exactly_the_truncated_ones` — the backfill's selection is pure and tested.
- `test_refetch_full_texts_never_blanks_an_item_when_the_refetch_fails` — a failed re-fetch **leaves the truncated text alone**; blanking would be silent data loss on the one surface 432 items depend on.

The backfill core takes an injected `text_fetcher`, mirroring `fetch_x_articles`'s existing `link_fetcher` seam — so the only untested surface is the browser hop itself.

## Coordination

`pr-quoted` is in the same file on `feat/ship-quoted-tweet`. My change is confined to `_tweet_text()` + `looks_truncated()` + `items_needing_refetch()`; **I expect to rebase behind their merge** and will do so on request.

## Gate

`uv run --extra dev poe check` — **fully green**: ruff lint + format, mypy, radon all A/B, bandit, vulture, interrogate 89.7%, detect-secrets, deptry, **1311 tests, 95% coverage**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)