### PR TITLE
feat(quoted): ship the quoted post to the generators — and to the reader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,18 @@ generates an Obsidian wiki.
 
 ## Architecture
 - Pipeline: `extract → import-archive → fetch → [enrich] → generate`.
+- Quoted posts (a quote-tweet's third-party content): X embeds the quoted post — body
+  AND author — in the same timeline payload as the tweet quoting it, so `extract`
+  parses it out as a `ContentSourceSuccess(kind="quoted_tweet", author=…)` at **no
+  extra network cost** (a `ContentSourceFailure` when X tombstones it / refuses it /
+  hydrates nothing). It then reaches every LLM surface under ONE shared label —
+  `executors.api.quoted_attribution` → `Quoted post — @handle (Name)` — read by the api
+  prompt, the enrich worksheet and the judge's `_source_text`, so the attribution rule
+  (**the poster is not the author of what they quote**) is enforceable. Backfill of
+  already-stored items: `xbrain refresh-quoted --from-store` (offline join on
+  `quoted_id`, repairs the 199 of 762 whose quoted post is already an item) then
+  `xbrain refresh-quoted` (re-capture, for the rest). Both bump `content.fetched_at`,
+  so `enrich` re-generates exactly the repaired summaries.
 - Media side-pipeline: `media` (download photos) → `describe` (vision LLM);
   `refresh-media` re-captures X to backfill the playable video URL + bitrate +
   duration onto already-stored items (video-only, preserves photos/enrichment;

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -414,10 +414,11 @@ def _run_refresh_quoted_from_store(cfg: Config) -> None:
         f"{report.quoted_items_not_seen} quote-tweets quote a post we do NOT hold "
         "(run `xbrain refresh-quoted` to capture those)."
     )
-    if report.sources_attached:
+    if report.readable:
         typer.echo(
-            f"Ahora: `xbrain enrich` re-genera los {report.sources_attached} summaries "
-            "con la evidencia nueva (su `content.fetched_at` ha avanzado)."
+            f"Ahora: `xbrain enrich` re-genera los {report.readable} summaries con la "
+            "evidencia nueva (solo esos avanzan `content.fetched_at`; un post citado "
+            "ilegible se registra pero no re-enriquece)."
         )
 
 
@@ -446,10 +447,11 @@ def _run_refresh_quoted(cfg: Config, source: str, *, force: bool, headless: bool
         f"{report.already_present} already had one; "
         f"{report.quoted_items_not_seen} quote-tweets NOT re-seen (still evidence-less)."
     )
-    if report.sources_attached:
+    if report.readable:
         typer.echo(
-            f"Ahora: `xbrain enrich` re-genera los {report.sources_attached} summaries "
-            "con la evidencia nueva (su `content.fetched_at` ha avanzado)."
+            f"Ahora: `xbrain enrich` re-genera los {report.readable} summaries con la "
+            "evidencia nueva (solo esos avanzan `content.fetched_at`; un post citado "
+            "ilegible se registra pero no re-enriquece)."
         )
 
 

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -34,7 +34,12 @@ from xbrain.generate import generate as run_generate
 from xbrain.media import download_all as run_media_download
 from xbrain.media import emit_summary_line as media_emit_summary_line
 from xbrain.models import ArchiveImport, Author, Item, SourceName
-from xbrain.refresh import estimate_download_size, refresh_video_media
+from xbrain.refresh import (
+    backfill_quoted_from_store,
+    backfill_quoted_sources,
+    estimate_download_size,
+    refresh_video_media,
+)
 from xbrain.rubrics import load_vocab, save_vocab
 from xbrain.store import (
     load_state,
@@ -332,6 +337,122 @@ def _format_size_estimate(estimated_bytes: int, n_estimable: int, n_unknown: int
     )
 
 
+def _recapture_history(
+    cfg: Config, source: str, *, label: str, headless: bool = False
+) -> list[Item]:
+    """Scroll the FULL X history and return every freshly-parsed item.
+
+    The shared capture harness behind every backfill (`refresh-media`,
+    `refresh-quoted`): one scroll, one parser, so a second backfill cannot drift
+    into its own subtly different ingest path.
+
+    `known_ids` is EMPTY, which disables `extract_source`'s skip-known early-stop —
+    the whole timeline is walked, not just what is newer than the cursor. Unlike
+    `_run_extract`, the `state.json` cursors are deliberately left untouched: a
+    backfill revisits existing records, so the next `extract` cursor must not move.
+    """
+    # Mirrors `_run_extract` — the source → (target URL, GraphQL source) mapping.
+    targets = {
+        "bookmark": _BOOKMARKS_URL,
+        "own_tweet": f"https://x.com/{cfg.x_handle}",
+    }
+    source_sets: dict[str, list[SourceName]] = {
+        "bookmarks": ["bookmark"],
+        "tweets": ["own_tweet"],
+        "all": ["bookmark", "own_tweet"],
+    }
+    typer.echo(
+        f"{label} scrolls the FULL X history with no skip-known — this is "
+        "slow and human-paced and can take many minutes. Leave it running."
+    )
+    fresh: list[Item] = []
+    with x_context(cfg.storage_state_path, headless=headless) as context:
+        for src in source_sets[source]:
+            fresh.extend(extract_source(context, src, targets[src], set()))
+    return fresh
+
+
+def _guard_empty_recapture(
+    store: dict[str, Item], items_seen: int, *, label: str, force: bool
+) -> None:
+    """Abort a backfill that re-saw 0 known items against a non-empty store.
+
+    `extract_source` returns `[]` (it does NOT raise) when the session is logged in
+    but the GraphQL parser drifts or the scroll is interrupted. Re-seeing nothing is
+    therefore a likely-broken run, not a successful no-op — and since the merge was a
+    no-op the store on disk is untouched, so aborting without saving is byte-identical
+    (and the pre-snapshot already fired). `--force` downgrades it to a warning.
+    """
+    if not (store and items_seen == 0):
+        return
+    warning = (
+        f"{label} re-vio 0 de los {len(store)} items ya conocidos — "
+        "la sesión de X probablemente caducó o el parser GraphQL ha derivado "
+        "(spec §6); no se actualizó nada."
+    )
+    if not force:
+        raise RuntimeError(f"{warning} Usa --force para guardar igualmente.")
+    typer.echo(f"AVISO: {warning}", err=True)
+
+
+def _run_refresh_quoted_from_store(cfg: Config) -> None:
+    """Backfill the quoted post from items ALREADY in the store — no browser, no network.
+
+    A quote-tweet's `quoted_id` often names a post we captured in its own right, so the
+    evidence is one dict lookup away. Free, instant, and re-runnable. What it cannot
+    reach (a quoted post we never captured) is left for `refresh-quoted`.
+
+    Destructive (rewrites `items.json`) → auto-snapshots first.
+    """
+    _auto_snapshot(cfg, "refresh-quoted-from-store")
+    store = load_store(cfg.items_path)
+    report = backfill_quoted_from_store(store)
+    save_store(store, cfg.items_path)
+    typer.echo(
+        f"refresh-quoted --from-store: {report.sources_attached} quoted posts attached "
+        f"from items already in the store; {report.already_present} already had one; "
+        f"{report.quoted_items_not_seen} quote-tweets quote a post we do NOT hold "
+        "(run `xbrain refresh-quoted` to capture those)."
+    )
+    if report.sources_attached:
+        typer.echo(
+            f"Ahora: `xbrain enrich` re-genera los {report.sources_attached} summaries "
+            "con la evidencia nueva (su `content.fetched_at` ha avanzado)."
+        )
+
+
+def _run_refresh_quoted(cfg: Config, source: str, *, force: bool, headless: bool = False) -> None:
+    """Re-capture X and backfill the QUOTED POST onto already-stored quote-tweets.
+
+    No per-item fetch: X embeds the quoted post — body AND author — in the same
+    timeline payload as the tweet quoting it, so one re-capture carries everything.
+    Items that gain a quoted post get a bumped `content.fetched_at`, so the next
+    `xbrain enrich` re-generates exactly those summaries against the evidence they
+    were previously written without.
+
+    Destructive (rewrites `items.json` in place) → auto-snapshots first.
+    """
+    _auto_snapshot(cfg, "refresh-quoted")
+    store = load_store(cfg.items_path)
+    fresh = _recapture_history(cfg, source, label="refresh-quoted", headless=headless)
+    report = backfill_quoted_sources(store, fresh)
+
+    _guard_empty_recapture(store, report.items_seen, label="refresh-quoted", force=force)
+    save_store(store, cfg.items_path)
+    typer.echo(
+        f"refresh-quoted: {report.items_seen} known items re-seen; "
+        f"{report.sources_attached} quoted posts attached "
+        f"({report.readable} readable, {report.unreadable} unavailable); "
+        f"{report.already_present} already had one; "
+        f"{report.quoted_items_not_seen} quote-tweets NOT re-seen (still evidence-less)."
+    )
+    if report.sources_attached:
+        typer.echo(
+            f"Ahora: `xbrain enrich` re-genera los {report.sources_attached} summaries "
+            "con la evidencia nueva (su `content.fetched_at` ha avanzado)."
+        )
+
+
 def _run_refresh_media(cfg: Config, source: str, *, force: bool, headless: bool = False) -> None:
     """Re-capture the FULL X history and backfill playable video media in place.
 
@@ -357,45 +478,10 @@ def _run_refresh_media(cfg: Config, source: str, *, force: bool, headless: bool 
     """
     _auto_snapshot(cfg, "refresh-media")
     store = load_store(cfg.items_path)
-    # Mirrors `_run_extract` — the source → (target URL, GraphQL source) mapping.
-    targets = {
-        "bookmark": _BOOKMARKS_URL,
-        "own_tweet": f"https://x.com/{cfg.x_handle}",
-    }
-    source_sets: dict[str, list[SourceName]] = {
-        "bookmarks": ["bookmark"],
-        "tweets": ["own_tweet"],
-        "all": ["bookmark", "own_tweet"],
-    }
-    chosen = source_sets[source]
-    typer.echo(
-        "refresh-media scrolls the FULL X history with no skip-known — this is "
-        "slow and human-paced and can take many minutes. Leave it running."
-    )
-    fresh: list[Item] = []
-    with x_context(cfg.storage_state_path, headless=headless) as context:
-        for src in chosen:
-            # Empty known_ids disables the skip-known early-stop: the whole
-            # history is returned, not just the items newer than the cursor.
-            # Unlike `_run_extract`, the `state.json` cursors are intentionally
-            # left untouched — this is a backfill of existing records, not an
-            # incremental advance, so the next `extract` cursor must not move.
-            fresh.extend(extract_source(context, src, targets[src], set()))
+    fresh = _recapture_history(cfg, source, label="refresh-media", headless=headless)
     report = refresh_video_media(store, fresh)
 
-    if store and report.items_seen == 0:
-        warning = (
-            f"refresh-media re-vio 0 de los {len(store)} items ya conocidos — "
-            "la sesión de X probablemente caducó o el parser GraphQL ha derivado "
-            "(spec §6); no se actualizó nada."
-        )
-        if not force:
-            # Nothing matched, so the store is unchanged — not saving is
-            # byte-identical and the pre-snapshot already fired. Abort non-zero
-            # so a broken capture never reports success.
-            raise RuntimeError(f"{warning} Usa --force para guardar igualmente.")
-        typer.echo(f"AVISO: {warning}", err=True)
-
+    _guard_empty_recapture(store, report.items_seen, label="refresh-media", force=force)
     save_store(store, cfg.items_path)
     estimated_bytes, n_estimable, n_unknown = estimate_download_size(store)
     typer.echo(
@@ -639,6 +725,52 @@ def refresh_media(
     tardar varios minutos.
     """
     _run_refresh_media(_config(), source.value, force=force, headless=headless)
+
+
+@app.command(name="refresh-quoted")
+@_handle_cli_errors
+def refresh_quoted(
+    source: Source = typer.Option(Source.all, help="bookmarks | tweets | all"),
+    from_store: bool = typer.Option(
+        False,
+        "--from-store",
+        help="Sin red: adjunta el post citado SOLO cuando ya está en el store como "
+        "item propio (medido: 199 de 762). Instantáneo y re-ejecutable.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Guardar aunque se re-vean 0 items conocidos (sesión caducada / "
+        "drift de GraphQL). Por defecto ese caso aborta sin escribir.",
+    ),
+    headless: bool = typer.Option(False, "--headless/--no-headless", help=_HEADLESS_HELP),
+) -> None:
+    """Re-captura X y adjunta el POST CITADO a los quote-tweets ya guardados.
+
+    Con `--from-store` NO abre el navegador: hace el join `quoted_id → item` contra el
+    propio store, que ya contiene el post citado en 199 de los 762 casos (26,1%).
+    Empieza siempre por ahí — es gratis — y luego re-captura para el resto.
+
+    Los items existentes solo guardan `quoted_id`: el cuerpo del post citado y su
+    autor se perdían, así que el generador veía una reacción a secas ("Read this
+    and you'll understand") y no tenía qué resumir — el hueco lo rellenaba
+    inventando. X incrusta el post citado en el MISMO payload del timeline, así que
+    esto NO hace ni una petición extra por item: recorre el histórico completo (sin
+    saltarse ids conocidos) y re-parsea.
+
+    Solo toca las fuentes `quoted_tweet`: artículos, transcripciones, hilos y todo
+    el enriquecimiento se preservan. Idempotente (un post citado ya legible se deja
+    intacto; uno fallido se re-intenta). Los items que ganan evidencia avanzan su
+    `content.fetched_at`, de modo que el siguiente `xbrain enrich` re-genera
+    exactamente esos summaries.
+
+    Es destructivo (reescribe `items.json` in situ) → auto-snapshot antes de
+    escribir. El scroll es lento y a ritmo humano; puede tardar varios minutos.
+    """
+    if from_store:
+        _run_refresh_quoted_from_store(_config())
+        return
+    _run_refresh_quoted(_config(), source.value, force=force, headless=headless)
 
 
 def _run_describe(

--- a/src/xbrain/executors/api.py
+++ b/src/xbrain/executors/api.py
@@ -16,6 +16,7 @@ from xbrain.executors.base import EnrichmentJudgment
 from xbrain.llm_json import json_from_response
 from xbrain.models import (
     LINK_CONTENT_KINDS,
+    QUOTED_CONTENT_KINDS,
     ContentSourceSuccess,
     Item,
     MediaPhotoDescribed,
@@ -161,11 +162,16 @@ _UNFETCHED_RULE = (
     "reconstruct or guess it from the URL, the domain or world knowledge."
 )
 
-# The note stamped when an item quotes a post whose content is not on the item.
-# `quoted_id` is captured at extract time but NO fetcher downloads the quoted post,
-# so without this marker the generator is ordered (rubric-summary) to summarise
-# content that is not in its inputs — an invitation to invent.
+# The note stamped when an item quotes a post whose content is not on the item —
+# X tombstoned it (deleted), refused it (protected/suspended) or hydrated nothing.
+# Without this marker the generator is ordered (rubric-summary) to summarise content
+# that is not in its inputs — an invitation to invent. It fires ONLY on that state:
+# when the quoted body IS present, stamping it would tell the generator to ignore
+# its best evidence.
 QUOTED_CONTENT_UNFETCHED_NOTE = f"The quoted post's content was NOT fetched. {_UNFETCHED_RULE}"
+
+# The stem of the ONE label under which the quoted post travels, on every surface.
+QUOTED_LABEL = "Quoted post"
 
 
 def fetched_link_sources(item: Item) -> int:
@@ -246,12 +252,45 @@ def thread_text(item: Item) -> str | None:
 
 
 def quoted_text(item: Item) -> str | None:
-    """The fetched quoted-post body, truncated, or None — today always None."""
-    return first_source_text(item, _QUOTED_KINDS)
+    """The quoted post's body, truncated, or None when it could not be fetched."""
+    return first_source_text(item, QUOTED_CONTENT_KINDS)
+
+
+def quoted_source(item: Item) -> ContentSourceSuccess | None:
+    """The item's readable quoted-post source, or None.
+
+    THE selector. Every surface asks this one question, so "is the quoted content
+    here?" cannot get five different answers.
+    """
+    if item.content is None:
+        return None
+    for src in item.content.sources:
+        if isinstance(src, ContentSourceSuccess) and src.kind in QUOTED_CONTENT_KINDS and src.text:
+            return src
+    return None
+
+
+def quoted_attribution(item: Item) -> str | None:
+    """`Quoted post — @handle (Name)`, or None when there is no readable quote.
+
+    THE label, built once and read by all three LLM surfaces (api prompt, enrich
+    worksheet, judge source) — the whole point being that they cannot drift. The
+    author is the payload: a quoted post is a THIRD PARTY's, and #86's attribution
+    rule ("the poster is not the author of the quoted content") is only enforceable
+    if every surface is told, in the same words, WHO that third party is.
+
+    Degrades to the bare `Quoted post` when X hydrated a body but no author — naming
+    nobody, rather than letting the poster's identity silently fill the hole.
+    """
+    src = quoted_source(item)
+    if src is None:
+        return None
+    if src.author is None:
+        return QUOTED_LABEL
+    return f"{QUOTED_LABEL} — @{src.author.handle} ({src.author.name})"
 
 
 _THREAD_KINDS: frozenset[str] = frozenset({"thread"})
-_QUOTED_KINDS: frozenset[str] = frozenset({"quoted_tweet"})
 
 
 def _links_section(item: Item) -> list[str]:
@@ -284,19 +323,26 @@ def _thread_section(item: Item) -> list[str]:
 
 
 def _quoted_section(item: Item) -> list[str]:
-    """Build the quoted-post block: its fetched body, else the NOT-fetched marker.
+    """Build the quoted-post block: its body under its author's name, else the
+    NOT-fetched marker. Two DIFFERENT states, both represented.
 
-    No fetcher produces a `quoted_tweet` source today, so in practice this stamps the
-    marker. The fetched branch exists so that when one lands, the quoted body reaches
-    the LLM under its OWN label instead of being dropped by the `LINK_CONTENT_KINDS`
-    narrowing in `_article_sections`.
+    The body reaches the LLM under its OWN label — never `Linked article` (it is not a
+    link's content) and never unlabelled (it is not the poster's words). The label
+    comes from `quoted_attribution`, the same builder the worksheet and the judge read,
+    so the generator and the judge are held to one contract.
     """
     if not item.quoted_id:
         return []
+    label = quoted_attribution(item)
     body = quoted_text(item)
-    if body:
-        return ["", "Quoted post (the content this post is sharing):", body]
-    return ["", "Quoted post — content NOT fetched:", QUOTED_CONTENT_UNFETCHED_NOTE]
+    if label and body:
+        return [
+            "",
+            f"{label} — the content this post is sharing. These are that account's "
+            "words, NOT the poster's:",
+            body,
+        ]
+    return ["", f"{QUOTED_LABEL} — content NOT fetched:", QUOTED_CONTENT_UNFETCHED_NOTE]
 
 
 def _article_sections(item: Item) -> list[str]:

--- a/src/xbrain/executors/api.py
+++ b/src/xbrain/executors/api.py
@@ -335,14 +335,22 @@ def _quoted_section(item: Item) -> list[str]:
         return []
     label = quoted_attribution(item)
     body = quoted_text(item)
-    if label and body:
-        return [
-            "",
-            f"{label} — the content this post is sharing. These are that account's "
-            "words, NOT the poster's:",
-            body,
-        ]
-    return ["", f"{QUOTED_LABEL} — content NOT fetched:", QUOTED_CONTENT_UNFETCHED_NOTE]
+    if not (label and body):
+        return ["", f"{QUOTED_LABEL} — content NOT fetched:", QUOTED_CONTENT_UNFETCHED_NOTE]
+    source = quoted_source(item)
+    if source is not None and source.author is not None:
+        rule = f"These are @{source.author.handle}'s words, NOT the poster's"
+    else:
+        # X gave us the body but no author. The label already names nobody; the rule must
+        # say so OUT LOUD. "These are that account's words" would point at an account
+        # that was never named — and the summary rubric, which tells the generator to
+        # attribute the quoted words to the account in the label, would be an order to
+        # invent one.
+        rule = (
+            "The author of this quoted post is UNKNOWN — do not name one, and do not "
+            "attribute these words to the poster"
+        )
+    return ["", f"{label} — the content this post is sharing. {rule}:", body]
 
 
 def _article_sections(item: Item) -> list[str]:

--- a/src/xbrain/extract/graphql.py
+++ b/src/xbrain/extract/graphql.py
@@ -10,6 +10,11 @@ from urllib.parse import urlparse
 from xbrain.extract.video import build_video_media
 from xbrain.models import (
     Author,
+    Content,
+    ContentSource,
+    ContentSourceFailure,
+    ContentSourceSuccess,
+    FailureReason,
     Item,
     Link,
     Media,
@@ -97,6 +102,7 @@ def _tweet_to_item(tweet: dict[str, Any], source: SourceName) -> Item | None:
     author = _extract_author(tweet)
     if author is None:
         return None
+    quoted_id = legacy.get("quoted_status_id_str") or _quoted_id(tweet)
     return Item(
         id=str(rest_id),
         source=source,
@@ -107,8 +113,12 @@ def _tweet_to_item(tweet: dict[str, Any], source: SourceName) -> Item | None:
         captured_at=datetime.now(timezone.utc),
         media=_extract_media(legacy),
         links=_extract_links(legacy, tweet),
-        quoted_id=legacy.get("quoted_status_id_str") or _quoted_id(tweet),
+        quoted_id=quoted_id,
         thread=_thread_info(legacy),
+        # The quoted post rides in the SAME payload — parsed here, at no network cost.
+        # A tweet that quotes nothing keeps `content=None`: an empty `Content` would
+        # read as "already fetched" to `fetch._should_refetch`.
+        content=_quoted_content(tweet, quoted_id),
     )
 
 
@@ -226,6 +236,81 @@ def _quoted_id(tweet: dict[str, Any]) -> str | None:
     quoted = _dig(tweet, "quoted_status_result", "result")
     rest_id = quoted.get("rest_id")
     return str(rest_id) if rest_id else None
+
+
+def _quoted_result(tweet: dict[str, Any]) -> dict[str, Any]:
+    """The hydrated quoted post X embeds in the timeline entry, or `{}`.
+
+    X nests it at the tweet's top level; some payload shapes carry it under
+    `legacy` instead, so both are probed (a miss degrades to `{}` → a failure
+    source, never a wrong parse).
+    """
+    return _dig(tweet, "quoted_status_result", "result") or _dig(
+        tweet, "legacy", "quoted_status_result", "result"
+    )
+
+
+def _quoted_content(tweet: dict[str, Any], quoted_id: str | None) -> Content | None:
+    """The quoted post as a `ContentSource`, or None when the tweet quotes nothing.
+
+    **No network call.** X embeds the quoted post — its body AND its author — in the
+    very timeline payload we already capture, so this is a pure re-parse of bytes we
+    hold. Before this, only `quoted_id` was kept and the body was dropped, leaving
+    the generator a bare reaction ("Read this and you'll understand") and nothing to
+    ground it in.
+
+    Failure taxonomy — a quote we cannot read is a FAILURE state, never silence:
+    `not_found` (X tombstoned it: deleted), `forbidden` (`TweetUnavailable`:
+    protected, suspended or blocked), `empty_content` (X sent the id but hydrated no
+    post, or hydrated one with no body/author). Each keeps `quoted_id` addressable in
+    the URL, and each leaves `quoted_content_unfetched(item)` True — so #86's
+    `content NOT fetched` marker still fires and the generator is still forbidden to
+    invent the post it cannot see.
+    """
+    if not quoted_id:
+        return None
+    result = _quoted_result(tweet)
+    quoted = _unwrap(result) if result else None
+    source: ContentSource = _quoted_failure(result, quoted_id)
+    if quoted is not None:
+        author = _extract_author(quoted)
+        text = _dig(quoted, "legacy").get("full_text") or ""
+        rest_id = quoted.get("rest_id") or quoted_id
+        if author is not None and text:
+            source = ContentSourceSuccess(
+                kind="quoted_tweet",
+                url=f"https://x.com/{author.handle}/status/{rest_id}",
+                # No title: a post has none, and `notes_io.note_title` takes the first
+                # source that carries one — borrowing the field for the author would
+                # rename the note after the account it quotes.
+                text=text,
+                author=author,
+                attempts=1,
+            )
+    return Content(fetched_at=datetime.now(timezone.utc), sources=[source])
+
+
+# X's `__typename` for a quoted post it will not serve → our failure reason.
+_QUOTED_FAILURE_REASONS: dict[str, FailureReason] = {
+    "TweetTombstone": "not_found",  # deleted by its author, or by X
+    "TweetUnavailable": "forbidden",  # protected / suspended / blocked
+}
+
+
+def _quoted_failure(result: dict[str, Any], quoted_id: str) -> ContentSourceFailure:
+    """Why the quoted post is not readable. `empty_content` is the catch-all: X sent
+    us the id and no usable post, so we know a quote exists and hold none of it."""
+    typename = str(result.get("__typename") or "")
+    reason = _QUOTED_FAILURE_REASONS.get(typename, "empty_content")
+    return ContentSourceFailure(
+        kind="quoted_tweet",
+        # The id-only permalink: with no author handle there is no /<handle>/status/
+        # form, and x.com/i/status/<id> resolves to the same post.
+        url=f"https://x.com/i/status/{quoted_id}",
+        failure_reason=reason,
+        error=f"X did not serve the quoted post ({typename or 'not hydrated'})",
+        attempts=1,
+    )
 
 
 def _thread_info(legacy: dict[str, Any]) -> ThreadInfo | None:

--- a/src/xbrain/extract/graphql.py
+++ b/src/xbrain/extract/graphql.py
@@ -271,15 +271,20 @@ def _quoted_content(tweet: dict[str, Any], quoted_id: str | None) -> Content | N
         return None
     result = _quoted_result(tweet)
     quoted = _unwrap(result) if result else None
-    source: ContentSource = _quoted_failure(result, quoted_id)
+    source: ContentSource = _quoted_failure(result, quoted_id, served=quoted is not None)
     if quoted is not None:
+        # The BODY is what makes the quote evidence. An author X did not hydrate costs us
+        # the attribution — `quoted_attribution` then names nobody — but it must not cost
+        # us the body too: dropping the cure because one field is missing would be the
+        # bug wearing a different hat.
         author = _extract_author(quoted)
         text = _dig(quoted, "legacy").get("full_text") or ""
         rest_id = quoted.get("rest_id") or quoted_id
-        if author is not None and text:
+        handle = author.handle if author else "i"
+        if text:
             source = ContentSourceSuccess(
                 kind="quoted_tweet",
-                url=f"https://x.com/{author.handle}/status/{rest_id}",
+                url=f"https://x.com/{handle}/status/{rest_id}",
                 # No title: a post has none, and `notes_io.note_title` takes the first
                 # source that carries one — borrowing the field for the author would
                 # rename the note after the account it quotes.
@@ -297,18 +302,32 @@ _QUOTED_FAILURE_REASONS: dict[str, FailureReason] = {
 }
 
 
-def _quoted_failure(result: dict[str, Any], quoted_id: str) -> ContentSourceFailure:
-    """Why the quoted post is not readable. `empty_content` is the catch-all: X sent
-    us the id and no usable post, so we know a quote exists and hold none of it."""
+def _quoted_failure(
+    result: dict[str, Any], quoted_id: str, *, served: bool
+) -> ContentSourceFailure:
+    """Why the quoted post is not readable — a record of what X ACTUALLY did.
+
+    Three different facts, and they must not be flattened into one: X tombstoned the post
+    (`not_found`), X refused it (`forbidden`), or X gave us nothing usable
+    (`empty_content`). That last bucket splits again — `served` distinguishes a post X
+    HANDED US that simply carries no text (a photo/video quote: X served it, there is
+    just nothing to read) from one X never hydrated at all. Writing "X did not serve the
+    quoted post" over a media-only quote would be a false statement about the world,
+    stored in the very evidence base whose purpose is to stop us inventing facts.
+    """
     typename = str(result.get("__typename") or "")
     reason = _QUOTED_FAILURE_REASONS.get(typename, "empty_content")
+    if reason == "empty_content" and served:
+        error = "the quoted post carries no text (media-only)"
+    else:
+        error = f"X did not serve the quoted post ({typename or 'not hydrated'})"
     return ContentSourceFailure(
         kind="quoted_tweet",
         # The id-only permalink: with no author handle there is no /<handle>/status/
         # form, and x.com/i/status/<id> resolves to the same post.
         url=f"https://x.com/i/status/{quoted_id}",
         failure_reason=reason,
-        error=f"X did not serve the quoted post ({typename or 'not hydrated'})",
+        error=error,
         attempts=1,
     )
 

--- a/src/xbrain/fetch.py
+++ b/src/xbrain/fetch.py
@@ -373,35 +373,46 @@ def fetch_item(
 _TRANSIENT_FAILURES: frozenset[FailureReason] = frozenset({"timeout", "dns_error", "unknown_error"})
 
 
-def _should_refetch(content: Content | None, force: bool) -> bool:
+def _should_refetch(item: Item, force: bool) -> bool:
     """Return True if `fetch_pending` should (re)fetch this item.
 
-    - `content is None` (never fetched) → True.
+    - `item.content is None` (never fetched) → True.
     - `force=True` → True regardless of recorded state.
-    - Otherwise, True only if every `external_article` source on `content`
-      is a `ContentSourceFailure` whose `failure_reason` is in
-      `_TRANSIENT_FAILURES`. A single successful source (any
-      `ContentSourceSuccess`) or a categorised terminal failure (e.g.
-      `not_found`, `paywall`) skips. No `external_article` sources at all
-      → skip (there is nothing here for `fetch_pending`; the x.com sources
-      are handled by `fetch_x`).
+    - No `external_article` sources, but the item HAS a non-x link → True: the link
+      fetch never ran (see below).
+    - Otherwise, True only if every `external_article` source is a
+      `ContentSourceFailure` whose `failure_reason` is in `_TRANSIENT_FAILURES`. A
+      single successful source (any `ContentSourceSuccess`) or a categorised terminal
+      failure (e.g. `not_found`, `paywall`) skips.
 
-    The pre-#20 helper read `src.ok` / `src.failure_reason` as Optionals;
-    after the tagged-union refactor the variant `isinstance` check is the
-    single switch and `failure_reason` is required on the failure variant,
-    so no `is None` special-case is needed. Pre-#20 records that lacked a
-    categorised `failure_reason` are migrated to `timeout` by
-    `_normalise_legacy_content_source` (see `xbrain.models`) — they
-    therefore get one automatic retry under #19, matching the prior
-    behaviour without an extra branch here.
+    **Why "content exists" is NOT "the links were fetched".** Other stages attach
+    sources of their own kind — the `extract` stage now stamps the quoted post, and
+    `digest-video` / `expand_threads` attach transcripts and threads. Such an item
+    arrives here with `content` set and NO `external_article` source. Reading that as
+    "already fetched" would silently never download its article — for the 35% of the
+    corpus that quotes, plus every threaded or video item. So the question is asked of
+    the LINKS, not of the mere presence of content: `_build_external_sources` emits one
+    source per non-x link, so "has a non-x link but no `external_article` source" can
+    only mean the fetch has not run yet. Once it does, the sources exist and the
+    transient-failure rule below governs — no re-fetch loop.
+
+    The pre-#20 helper read `src.ok` / `src.failure_reason` as Optionals; after the
+    tagged-union refactor the variant `isinstance` check is the single switch and
+    `failure_reason` is required on the failure variant, so no `is None` special-case
+    is needed. Pre-#20 records that lacked a categorised `failure_reason` are migrated
+    to `timeout` by `_normalise_legacy_content_source` (see `xbrain.models`) — they
+    therefore get one automatic retry under #19, matching the prior behaviour without
+    an extra branch here.
     """
-    if content is None:
+    if item.content is None:
         return True
     if force:
         return True
-    external = [s for s in content.sources if s.kind == "external_article"]
+    external = [s for s in item.content.sources if s.kind == "external_article"]
     if not external:
-        return False
+        # No link body on the item: fetch iff there is a non-x link still to fetch.
+        # (x.com links are `fetch_x`'s job and must not drag the item in here.)
+        return any(not is_x_url(link.url) for link in item.links)
     return all(
         isinstance(src, ContentSourceFailure) and src.failure_reason in _TRANSIENT_FAILURES
         for src in external
@@ -431,7 +442,7 @@ def fetch_pending(
         # all links are x.com — handled by fetch_x
         if all(is_x_url(link.url) for link in item.links):
             continue
-        if not _should_refetch(item.content, force):
+        if not _should_refetch(item, force):
             continue
         if since and item.created_at < since:
             continue

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -11,8 +11,10 @@ from typing import assert_never, cast
 from xbrain.config import SUPPORTED_TOPIC_STYLES
 from xbrain.dashboard import collect_thumbnails, compute_dashboard_data, render_dashboard_html
 from xbrain.i18n import Strings, strings_for
+from xbrain.executors.api import quoted_source
 from xbrain.models import (
     ARTICLE_PARAGRAPH_SEP,
+    QUOTED_CONTENT_KINDS,
     ArticleImageBlock,
     ArticleTextBlock,
     ContentSourceFailure,
@@ -70,6 +72,81 @@ def _broken_link_line(source: ContentSourceFailure, fetched_at: datetime) -> str
     detail = " · ".join(bits) or "no se pudo recuperar"
     date = fetched_at.date().isoformat()
     return f"> ⚠ Enlace roto: <{source.url}> — {detail} (verificado {date})"
+
+
+def _blockquote(text: str) -> list[str]:
+    """Markdown-blockquote every line of `text` — the idiom for words that are NOT the
+    note author's. A blank line becomes a bare `>`, so one quote stays one quote instead
+    of breaking into two at the paragraph gap."""
+    return [f"> {line}" if line.strip() else ">" for line in text.split("\n")]
+
+
+def _quoted_failure_source(item: Item) -> ContentSourceFailure | None:
+    """The recorded reason the quoted post could not be read, or None."""
+    if item.content is None:
+        return None
+    for source in item.content.sources:
+        if isinstance(source, ContentSourceFailure) and source.kind in QUOTED_CONTENT_KINDS:
+            return source
+    return None
+
+
+def _quoted_unavailable_reason(reason: FailureReason, strings: Strings) -> str:
+    """The reader-facing wording for WHY the quoted post is missing.
+
+    `not_found` and `forbidden` are different facts about the world — a deleted post and
+    a locked account — and collapsing them into one "unavailable" would throw away the
+    only thing the reader can act on. Everything else (X hydrated nothing, a timeout)
+    honestly says just that: we do not know what was there.
+    """
+    if reason == "not_found":
+        return strings.quoted_unavailable_deleted
+    if reason == "forbidden":
+        return strings.quoted_unavailable_protected
+    return strings.quoted_unavailable_unknown
+
+
+def _quoted_lines(item: Item, strings: Strings) -> list[str]:
+    """Render the quoted post for the HUMAN — who is quoted, and what they said.
+
+    Until now the quoted body reached every LLM surface and never the reader: on a
+    quote-tweet (35% of the corpus) he met a summary ABOUT a post he could not see. And
+    a readable quote fell into the generic `## Content: <url>` branch — a third party's
+    words, with no author, inside a note whose author is the poster. That is exactly the
+    conflation the attribution rule stops for the model, rendered for the reader.
+
+    So: its own heading, NAMING the quoted account, with the body blockquoted. Inline,
+    not collapsed behind `<details>` — the video digest hides raw *evidence* (frames,
+    transcript) but shows the digest itself, and here the quoted post is not evidence
+    for the note, it IS the note's subject. Hiding the thing the summary is about would
+    reproduce the bug in a nicer wrapper.
+
+    The source is selected by `quoted_source` — the SAME helper the api prompt, the
+    enrich worksheet and the judge read — so the reader cannot be shown a different
+    quoted post from the one the model was given.
+    """
+    source = quoted_source(item)
+    if source is not None:
+        author = source.author
+        attribution = f" — @{author.handle} ({author.name})" if author else ""
+        return [
+            f"## {strings.quoted_post_header}{attribution}",
+            "",
+            *_blockquote(source.text),
+            "",
+            f"<{source.url}>",
+            "",
+        ]
+    failure = _quoted_failure_source(item)
+    if failure is None:
+        return []
+    reason = _quoted_unavailable_reason(failure.failure_reason, strings)
+    return [
+        f"## {strings.quoted_post_unavailable}",
+        "",
+        f"> ⚠ {reason} — <{failure.url}>",
+        "",
+    ]
 
 
 def generate(
@@ -617,24 +694,41 @@ def _content_lines(item: Item, strings: Strings) -> list[str]:
     digest_source = _video_source(item)
     lines: list[str] = []
     for source in content.sources:
+        # The quoted post has its OWN attributed section under the tweet (`_quoted_lines`).
+        # It must never fall through to the generic `## Content: <url>` branch, which would
+        # print a third party's words with no author inside a note whose author is the
+        # poster — and would print them twice.
+        if source.kind in QUOTED_CONTENT_KINDS:
+            continue
         if isinstance(source, ContentSourceSuccess):
-            if source.kind == "x_video":
-                # Badge only the canonical digest source (the one whose digest is
-                # fingerprinted); a second x_video source, if any, is never mis-badged.
-                badge = _verdict_badge(item, "digest", strings) if source is digest_source else None
-                lines += _video_digest_lines(source, strings, badge)
-            elif source.kind == "x_article" and source.blocks:
-                # Structured Article (#39): render the ordered text+image blocks
-                # as a blogpost. An `x_article` with EMPTY blocks (trafilatura
-                # fallback, or a pre-#39 record) falls through to the plain
-                # `source.text` path below — byte-unchanged, no regression.
-                lines += _article_blocks_lines(source, strings)
-            else:
-                heading = source.title or source.url
-                lines += [f"## {strings.content_header}: {heading}", "", source.text, ""]
+            lines += _success_source_lines(item, source, digest_source, strings)
         elif source.kind in ("external_article", "x_article"):
             lines += [_broken_link_line(source, content.fetched_at), ""]
     return lines
+
+
+def _success_source_lines(
+    item: Item,
+    source: ContentSourceSuccess,
+    digest_source: ContentSourceSuccess | None,
+    strings: Strings,
+) -> list[str]:
+    """Render one successfully-fetched source as its own kind of block.
+
+    An `x_video` becomes a `Video digest` section (#44); an `x_article` carrying
+    structured `blocks` becomes an ordered blogpost (#39 PR5), while one with EMPTY
+    blocks (trafilatura fallback, or a pre-#39 record) keeps the plain `source.text`
+    block — byte-unchanged. Everything else falls back to that plain block.
+    """
+    if source.kind == "x_video":
+        # Badge only the canonical digest source (the one whose digest is
+        # fingerprinted); a second x_video source, if any, is never mis-badged.
+        badge = _verdict_badge(item, "digest", strings) if source is digest_source else None
+        return _video_digest_lines(source, strings, badge)
+    if source.kind == "x_article" and source.blocks:
+        return _article_blocks_lines(source, strings)
+    heading = source.title or source.url
+    return [f"## {strings.content_header}: {heading}", "", source.text, ""]
 
 
 def _render_note(item: Item, strings: Strings, topic_style: str) -> str:
@@ -651,6 +745,12 @@ def _render_note(item: Item, strings: Strings, topic_style: str) -> str:
     if media_lines:
         lines += media_lines
         lines.append("")
+    # The quoted post sits directly under the tweet + its media, exactly where X puts the
+    # quote card — the same natural-read-order argument the media block makes above. It
+    # is the SUBJECT of a quote-tweet's summary, so burying it below `## Enlaces` and the
+    # permalink (where `_content_lines` renders) would leave the reader meeting the
+    # summary long before the thing it is about.
+    lines += _quoted_lines(item, strings)
     if item.links:
         lines.append("## Enlaces")
         lines += [f"- <{link.url}>" for link in item.links]

--- a/src/xbrain/i18n.py
+++ b/src/xbrain/i18n.py
@@ -35,6 +35,16 @@ class Strings:
     video_evidence_header: str  # collapsible label for the raw frames + transcript
     verify_badge_fail: str  # "Verification: FAIL" / "Verificación: FALLA" (#79 badge)
     verify_badge_review: str  # "Verification: REVIEW" / "Verificación: REVISAR" (#79 badge)
+    # The quoted post a quote-tweet is sharing. The header carries the quoted account's
+    # `@handle (Name)`, so the reader can never take a third party's words for the
+    # poster's — the same conflation the attribution rule stops on the LLM side.
+    quoted_post_header: str  # "Quoted post" / "Post citado"
+    # When we could not read the quoted post. Written down, never silently omitted: a
+    # reader who sees nothing concludes there was nothing. The reason is a fact.
+    quoted_post_unavailable: str  # "Quoted post unavailable" / "Post citado no disponible"
+    quoted_unavailable_deleted: str  # `not_found`  — X tombstoned it
+    quoted_unavailable_protected: str  # `forbidden`  — protected / suspended
+    quoted_unavailable_unknown: str  # anything else — X served us nothing usable
 
 
 _STRINGS: dict[str, Strings] = {
@@ -49,6 +59,11 @@ _STRINGS: dict[str, Strings] = {
         video_evidence_header="Frames + transcript",
         verify_badge_fail="Verification: FAIL",
         verify_badge_review="Verification: REVIEW",
+        quoted_post_header="Quoted post",
+        quoted_post_unavailable="Quoted post unavailable",
+        quoted_unavailable_deleted="deleted or never existed",
+        quoted_unavailable_protected="protected or suspended account",
+        quoted_unavailable_unknown="X served no content for it",
     ),
     "Spanish": Strings(
         topics_label="Temas",
@@ -61,6 +76,11 @@ _STRINGS: dict[str, Strings] = {
         video_evidence_header="Frames y transcripción",
         verify_badge_fail="Verificación: FALLA",
         verify_badge_review="Verificación: REVISAR",
+        quoted_post_header="Post citado",
+        quoted_post_unavailable="Post citado no disponible",
+        quoted_unavailable_deleted="borrado o inexistente",
+        quoted_unavailable_protected="cuenta protegida o suspendida",
+        quoted_unavailable_unknown="X no sirvió su contenido",
     ),
 }
 

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -64,6 +64,13 @@ ContentKind = Literal["external_article", "x_article", "thread", "quoted_tweet",
 # call site (api prompt, enrich worksheet, judge source) so the surfaces cannot drift.
 LINK_CONTENT_KINDS: frozenset[ContentKind] = frozenset({"external_article", "x_article"})
 
+# The kind whose body is the THIRD PARTY post a quote-tweet is sharing. Its own set,
+# for the same reason `LINK_CONTENT_KINDS` is one: every surface (api prompt, enrich
+# worksheet, judge source) must select it by the SAME predicate. A quoted post is not
+# a link body and not the poster's own words — it is someone else's post, and the
+# attribution guardrail depends on it keeping its own identity everywhere.
+QUOTED_CONTENT_KINDS: frozenset[ContentKind] = frozenset({"quoted_tweet"})
+
 
 class Author(BaseModel):
     """The X account that authored an item."""
@@ -636,6 +643,16 @@ class ContentSourceSuccess(BaseModel):
     title: str | None = None
     text: str
     http_status: int | None = None
+    # WHO wrote this body, when that is not the item's own author — set for
+    # `quoted_tweet` sources, whose text belongs to the THIRD PARTY being quoted
+    # (X embeds their handle + display name in the same timeline payload). This is
+    # the attribution evidence the generators were missing: without it the poster
+    # reads as the author of content they merely shared, which is the #86 bug.
+    # Optional + additive (defaults to None), so every EXISTING record LOADS
+    # unchanged — the same backward-compatible pattern as `has_speech`/`frames`/
+    # `blocks`. `None` = "the body is the item author's own, or the author is
+    # unknown"; it is never a licence to attribute the text to the poster.
+    author: Author | None = None
     # extraction attempts: 1 = single pass, 2 = + Firecrawl fallback;
     # 0 only on pre-Fase-2 records.
     attempts: int = 0

--- a/src/xbrain/refresh.py
+++ b/src/xbrain/refresh.py
@@ -24,9 +24,24 @@ eventual download size without fetching a byte.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
-from xbrain.models import Item, MediaEntry, MediaVideoPending
+from xbrain.models import (
+    QUOTED_CONTENT_KINDS,
+    Content,
+    ContentSource,
+    ContentSourceSuccess,
+    Item,
+    MediaEntry,
+    MediaVideoPending,
+)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
 
 # bitrate is bits/second and duration is milliseconds, so
 # bytes = bitrate * (duration_millis / 1000) / 8 = bitrate * duration_millis / 8000.
@@ -179,3 +194,150 @@ def estimate_download_size(store: dict[str, Item]) -> tuple[int, int, int]:
             estimated_bytes += bitrate * duration // _BITS_PER_BYTE_TIMES_MILLIS_PER_SECOND
             n_estimable += 1
     return estimated_bytes, n_estimable, n_unknown
+
+
+@dataclass
+class QuotedBackfillReport:
+    """Counts emitted by `backfill_quoted_sources` for the CLI summary line.
+
+    - ``items_seen`` — fresh items whose id is already in the store.
+    - ``sources_attached`` — stored quote-tweets that GAINED a `quoted_tweet` source.
+    - ``readable`` / ``unreadable`` — of those, the ones that carry the quoted body
+      vs the ones X would not serve (deleted, protected, not hydrated). Both are
+      progress: an unreadable quote is recorded as a demonstrable failure, which is
+      what keeps the `content NOT fetched` marker honest.
+    - ``already_present`` — already had a readable quote; left untouched (idempotent).
+    - ``quoted_items_not_seen`` — stored quote-tweets STILL holding only a `quoted_id`
+      because X did not re-surface them in this capture. The honest diagnostic: how
+      much of the corpus this run could not repair.
+    """
+
+    items_seen: int = 0
+    sources_attached: int = 0
+    readable: int = 0
+    unreadable: int = 0
+    already_present: int = 0
+    quoted_items_not_seen: int = 0
+
+
+def _quoted_source(item: Item) -> ContentSource | None:
+    """The item's `quoted_tweet` source in either variant (readable or failed)."""
+    if item.content is None:
+        return None
+    return next((s for s in item.content.sources if s.kind in QUOTED_CONTENT_KINDS), None)
+
+
+def _has_readable_quote(item: Item) -> bool:
+    source = _quoted_source(item)
+    return isinstance(source, ContentSourceSuccess) and bool(source.text)
+
+
+def _attach_quoted(item: Item, source: ContentSource, now: datetime) -> None:
+    """Put `source` on `item`, replacing any prior `quoted_tweet` and keeping the rest.
+
+    `fetched_at` advances: the item just gained the evidence its summary was generated
+    without, so `enrich._needs_reenrichment` must see a material content change and
+    flow it back through generation. Otherwise the body lands in the store and the
+    defective summary stands — the fix would ship having repaired nothing.
+    """
+    kept = (
+        [s for s in item.content.sources if s.kind not in QUOTED_CONTENT_KINDS]
+        if item.content
+        else []
+    )
+    item.content = Content(fetched_at=now, sources=[*kept, source])
+
+
+def backfill_quoted_sources(
+    store: dict[str, Item], fresh_items: list[Item], *, now: Callable[[], datetime] = _utcnow
+) -> QuotedBackfillReport:
+    """Attach the quoted post — parsed from a fresh capture — onto already-stored items.
+
+    **No per-item fetch.** X embeds the quoted post in the same timeline payload as the
+    tweet quoting it, so one re-capture of the history (the `refresh-media` harness,
+    with no skip-known) carries every quoted body and author we need. This function is
+    the pure merge: `extract.graphql` already did the parsing.
+
+    Only `quoted_tweet` sources are touched — an article body, a transcript, a thread
+    and every enrichment/description field are preserved. Idempotent: an item that
+    already holds a READABLE quote is left alone (no needless re-enrichment), while a
+    recorded FAILURE is upgraded if X serves the post this time.
+    """
+    report = QuotedBackfillReport()
+    seen: set[str] = set()
+    for fresh in fresh_items:
+        stored = store.get(fresh.id)
+        if stored is None:
+            continue  # backfill only touches known ids; adding items is `extract`'s job
+        seen.add(fresh.id)
+        report.items_seen += 1
+        incoming = _quoted_source(fresh)
+        if incoming is None:
+            continue
+        if _has_readable_quote(stored):
+            report.already_present += 1
+            continue
+        _attach_quoted(stored, incoming, now())
+        report.sources_attached += 1
+        if isinstance(incoming, ContentSourceSuccess):
+            report.readable += 1
+        else:
+            report.unreadable += 1
+    report.quoted_items_not_seen = sum(
+        1
+        for item in store.values()
+        if item.quoted_id and item.id not in seen and not _has_readable_quote(item)
+    )
+    return report
+
+
+def quoted_source_from_item(quoted: Item) -> ContentSourceSuccess:
+    """The `quoted_tweet` source for a quoted post we ALREADY hold as an item.
+
+    Its body and its author come straight off the stored item — the same fields the
+    GraphQL parser would produce from a fresh capture, because they came from exactly
+    that parser when the quoted post was itself captured.
+    """
+    return ContentSourceSuccess(
+        kind="quoted_tweet",
+        url=quoted.url,
+        text=quoted.text,
+        author=quoted.author,
+        attempts=1,
+    )
+
+
+def backfill_quoted_from_store(
+    store: dict[str, Item], *, now: Callable[[], datetime] = _utcnow
+) -> QuotedBackfillReport:
+    """Attach the quoted post to every quote-tweet whose quoted post is ALREADY in the
+    store. Pure, offline, **zero network calls**.
+
+    A quote-tweet's `quoted_id` frequently names another item we captured in its own
+    right — measured on the real store: 199 of 762 (26.1%). For those the evidence has
+    been sitting in `items.json` the whole time, one dict lookup away, while the
+    generator was left to invent it. This is the free half of the repair; the remaining
+    quote-tweets need `refresh-quoted` (a re-capture) to reach their quoted post.
+
+    A `quoted_id` we do NOT hold is left untouched — NOT stamped as a failure. The post
+    is very likely alive; we simply never captured it, and a re-capture can still bring
+    it in. Stamping it `not_found` would be inventing a fact about X, which is the class
+    of bug this whole effort exists to kill.
+    """
+    report = QuotedBackfillReport()
+    for item in store.values():
+        if not item.quoted_id:
+            continue
+        if _has_readable_quote(item):
+            report.already_present += 1
+            continue
+        # `quoted_id == item.id` would make the item its own evidence — a self-quote is
+        # not a thing X produces, but a corrupt record must not become a citation loop.
+        quoted = store.get(item.quoted_id) if item.quoted_id != item.id else None
+        if quoted is None or not quoted.text:
+            report.quoted_items_not_seen += 1
+            continue
+        _attach_quoted(item, quoted_source_from_item(quoted), now())
+        report.sources_attached += 1
+        report.readable += 1
+    return report

--- a/src/xbrain/refresh.py
+++ b/src/xbrain/refresh.py
@@ -28,8 +28,10 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
+from xbrain.executors.api import quoted_source
 from xbrain.models import (
     QUOTED_CONTENT_KINDS,
+    Author,
     Content,
     ContentSource,
     ContentSourceSuccess,
@@ -221,31 +223,73 @@ class QuotedBackfillReport:
 
 
 def _quoted_source(item: Item) -> ContentSource | None:
-    """The item's `quoted_tweet` source in either variant (readable or failed)."""
+    """The item's `quoted_tweet` source in either variant (readable or failed).
+
+    The either-variant selector, for deciding what is RECORDED. "Is there readable
+    evidence?" is a different question with exactly one answer in this codebase —
+    `executors.api.quoted_source`, which every LLM surface reads — so it is imported,
+    not re-implemented here.
+    """
     if item.content is None:
         return None
     return next((s for s in item.content.sources if s.kind in QUOTED_CONTENT_KINDS), None)
 
 
-def _has_readable_quote(item: Item) -> bool:
-    source = _quoted_source(item)
-    return isinstance(source, ContentSourceSuccess) and bool(source.text)
+def _quoted_evidence(item: Item) -> tuple[str, Author | None] | None:
+    """Exactly what the LLM surfaces READ from the quoted post, or None.
 
-
-def _attach_quoted(item: Item, source: ContentSource, now: datetime) -> None:
-    """Put `source` on `item`, replacing any prior `quoted_tweet` and keeping the rest.
-
-    `fetched_at` advances: the item just gained the evidence its summary was generated
-    without, so `enrich._needs_reenrichment` must see a material content change and
-    flow it back through generation. Otherwise the body lands in the store and the
-    defective summary stands — the fix would ship having repaired nothing.
+    Every quoted surface — the api prompt's body + label, the worksheet's `quoted_text` +
+    `quoted_attribution`, the judge's `[Quoted post — …]` block, and the `NOT fetched`
+    marker's on/off — is a function of `quoted_source(item)`, i.e. of exactly this pair.
+    So this IS the generator's view, and comparing it before/after answers the only
+    question that matters: did anything the model will read actually change?
     """
+    source = quoted_source(item)
+    return None if source is None else (source.text, source.author)
+
+
+def _readable_evidence(source: ContentSource) -> tuple[str, Author | None] | None:
+    """`_quoted_evidence` for a source about to be attached (it replaces any prior one)."""
+    if isinstance(source, ContentSourceSuccess) and source.text:
+        return (source.text, source.author)
+    return None
+
+
+def _attach_quoted(item: Item, source: ContentSource, now: datetime) -> bool:
+    """Put `source` on `item`, replacing any prior `quoted_tweet` and keeping the rest.
+    Return True iff the LLM-visible evidence changed (and `fetched_at` was advanced).
+
+    **The clock moves only when the EVIDENCE moves.** `enrich._needs_reenrichment` keys
+    on `content.fetched_at > enriched_at`, and `verify` fingerprints the OUTPUT — so an
+    unconditional bump would, on every single run: re-run the model on a byte-identical
+    prompt, non-deterministically rewrite a good summary, AND staleness-invalidate every
+    persisted verdict badge on the item. A deleted or protected quote re-attaches
+    identically on each re-capture, so that churn would be permanent. This is bug #44,
+    and `fetch.fetch_item` / `fetch_x._attach_x_sources` both guard it (via
+    `_sources_materially_equal`) with a comment describing this exact failure.
+
+    The guard here is STRICTER than `_sources_materially_equal`: identical sources
+    obviously leave the evidence identical, but so does replacing one *unreadable* record
+    with a different unreadable one (`not_found` → `forbidden`, a changed `error`
+    string). No LLM surface reads those fields — the `NOT fetched` marker fires either
+    way — so there is nothing to re-generate. Record the failure; do not move the clock.
+    """
+    changed = _quoted_evidence(item) != _readable_evidence(source)
     kept = (
         [s for s in item.content.sources if s.kind not in QUOTED_CONTENT_KINDS]
         if item.content
         else []
     )
-    item.content = Content(fetched_at=now, sources=[*kept, source])
+    if item.content is not None:
+        fetched_at = now if changed else item.content.fetched_at
+    else:
+        # No content yet. Starting the clock at `now()` for a record no generator will
+        # read would itself trip `_needs_reenrichment` — the churn, from a standing
+        # start. Anchor at capture time instead: nothing was fetched, and the item's own
+        # capture is when we learned what we know.
+        fetched_at = now if changed else item.captured_at
+    item.content = Content(fetched_at=fetched_at, sources=[*kept, source])
+    return changed
 
 
 def backfill_quoted_sources(
@@ -272,23 +316,38 @@ def backfill_quoted_sources(
         seen.add(fresh.id)
         report.items_seen += 1
         incoming = _quoted_source(fresh)
-        if incoming is None:
-            continue
-        if _has_readable_quote(stored):
-            report.already_present += 1
-            continue
-        _attach_quoted(stored, incoming, now())
-        report.sources_attached += 1
-        if isinstance(incoming, ContentSourceSuccess):
-            report.readable += 1
-        else:
-            report.unreadable += 1
+        if incoming is not None:
+            _merge_quoted(stored, incoming, report, now)
     report.quoted_items_not_seen = sum(
         1
         for item in store.values()
-        if item.quoted_id and item.id not in seen and not _has_readable_quote(item)
+        if item.quoted_id and item.id not in seen and quoted_source(item) is None
     )
     return report
+
+
+def _merge_quoted(
+    stored: Item,
+    incoming: ContentSource,
+    report: QuotedBackfillReport,
+    now: Callable[[], datetime],
+) -> None:
+    """Merge one freshly-captured quoted source onto its stored item, tallying `report`.
+
+    Skipped when the item already holds a READABLE quote (there is nothing better to
+    gain), and when the incoming record is byte-identical to the one we hold — a
+    re-capture re-serves the same deleted post on every run, and rewriting an identical
+    failure would churn the store for nothing.
+    """
+    if quoted_source(stored) is not None or _quoted_source(stored) == incoming:
+        report.already_present += 1
+        return
+    _attach_quoted(stored, incoming, now())
+    report.sources_attached += 1
+    if isinstance(incoming, ContentSourceSuccess):
+        report.readable += 1
+    else:
+        report.unreadable += 1
 
 
 def quoted_source_from_item(quoted: Item) -> ContentSourceSuccess:
@@ -328,7 +387,7 @@ def backfill_quoted_from_store(
     for item in store.values():
         if not item.quoted_id:
             continue
-        if _has_readable_quote(item):
+        if quoted_source(item) is not None:
             report.already_present += 1
             continue
         # `quoted_id == item.id` would make the item its own evidence — a self-quote is

--- a/src/xbrain/rubrics/rubric-summary.md
+++ b/src/xbrain/rubrics/rubric-summary.md
@@ -11,7 +11,10 @@ Produce a `summary` for one X post (a bookmark or the user's own tweet).
   3. the poster's own **thread**,
   4. the **fetched article** body and its title,
   5. the **video** title, transcript and frame descriptions,
-  6. the **image descriptions**.
+  6. the **image descriptions**,
+  7. the **quoted post** — its body AND the `@handle (Name)` of the account that wrote
+     it, shown together under a `Quoted post — @handle (Name)` label. When that label
+     is present, the quoted body is evidence and so is that account's name.
 
   Nothing else is evidence. Not your world knowledge, not recognising the topic, the
   voice or the byline, and **not a link's URL or domain** — a domain is topic signal,
@@ -43,11 +46,17 @@ Produce a `summary` for one X post (a bookmark or the user's own tweet).
   post says. NEVER describe, reconstruct or guess the linked content from its
   URL, its domain or your own knowledge of it.
 - **Retweets / quotes:** summarise the shared content **when it is present** in the
-  item (a fetched article, a transcript, a quoted body). When it is not — the item
-  says `content NOT fetched`, or carries only a `quoted_content_note` — summarise
-  the post's own text instead. Never reconstruct the shared content you cannot see.
+  item (a fetched article, a transcript, a quoted body under its `Quoted post` label).
+  A quote-tweet's own text is often a bare reaction ("Read this", "This is huge") — the
+  substance is in the quoted post, so summarise THAT, and say what it actually says.
+  When it is not present — the item says `content NOT fetched`, or carries only a
+  `quoted_content_note` — summarise the post's own text instead. Never reconstruct the
+  shared content you cannot see: if the reaction does not say what it is reacting to,
+  neither do you.
 - **Attribution:** the post's author is who POSTED it. On a repost, a quote or a clip
   of someone else, the words are a third party's — do not name the poster as the
   speaker or author of that content, and do not name a speaker the item never names.
+  On a quote-tweet the quoted account is named for you in the `Quoted post — @handle
+  (Name)` label: THAT is the author of the quoted words, and the poster is not.
 - **Noise** (greetings, one-word posts): a short factual description is fine.
 - Output the summary text only. No markdown, no headings, no quotes.

--- a/src/xbrain/rubrics/rubric-verify.md
+++ b/src/xbrain/rubrics/rubric-verify.md
@@ -3,8 +3,8 @@
 You are an independent judge. You receive one generated enrichment `output` (a
 short `summary`, a long-form video `digest`, or a `topics` assignment), the
 `source` it was made from (video transcript + frame descriptions, article body,
-tweet text), and the generation `rubric` that produced it. Judge the output —
-default to SKEPTICAL.
+the quoted post a quote-tweet is sharing, tweet text), and the generation `rubric`
+that produced it. Judge the output — default to SKEPTICAL.
 
 Two axes:
 
@@ -25,15 +25,32 @@ that content unless the source itself says so. If the source does not name the
 speaker, the output must not name one either — an invented attribution is a
 faithfulness failure like any other.
 
+**The `[Quoted post — @handle (Name)]` block IS trusted authorship metadata — for the
+body beneath it.** It is the one exception to the paragraph above, and it runs the
+opposite way. That block means: X told us this quoted post was written by THAT account.
+So naming that account as the author/speaker of the quoted words is SUPPORTED, not
+invented — and naming the POSTER as their author is a faithfulness FAILURE. The two
+rules point the same direction: attribute the quoted words to the account in the quoted
+label, never to the account in `[Author]`. If the block instead reads `[Quoted post]`
+with no handle, the quoted author is UNKNOWN: the output must name nobody as its author.
+
 **Check every named speaker BEFORE you judge anything else.** Whenever the output
 names a person as the one who says / explains / argues / shows something, ask: does
 the SOURCE name them as the speaker or author of that content? The `[Author]` block
-does not — it says who posted it. Worked example: the source carries
-`[Author] @poster (Poster Name)` and a first-person transcript that never names its
-speaker; the output says *"Poster Name explains why RL is terrible"*. That is a
-faithfulness FAILURE — an invented attribution — **even when every other fact in the
-output is verbatim from the transcript**, and even when the output's only other
-problems are formatting ones. Do not let a clean-looking output past this check.
+does not — it says who posted it. A `[Quoted post — @handle (Name)]` block DOES, for
+the quoted body. Worked example: the source carries `[Author] @poster (Poster Name)`
+and a first-person transcript that never names its speaker; the output says *"Poster
+Name explains why RL is terrible"*. That is a faithfulness FAILURE — an invented
+attribution — **even when every other fact in the output is verbatim from the
+transcript**, and even when the output's only other problems are formatting ones. Do
+not let a clean-looking output past this check.
+
+Worked example, the other way: the source carries `[Author] @alice (Alice)` and
+`[Quoted post — @karpathy (Andrej Karpathy)]` with a body announcing he is leaving
+OpenAI; the output says *"Andrej Karpathy anuncia que deja OpenAI; Alice lo comparte."*
+That is a PASS on faithfulness. The name is not world knowledge — the source names him,
+in the quoted label — and the roles are the right way round. Flagging this as an
+invented attribution is the mirror-image error, and it FAILS a correct output.
 
 **Content marked as never downloaded is not evidence.** When the source carries a
 `content NOT fetched` marker (a linked page, or a quoted post), any output claim

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -29,7 +29,9 @@ from xbrain.executors.api import (
     QUOTED_CONTENT_UNFETCHED_NOTE,
     _content_image_descriptions,
     _video_frame_descriptions,
+    quoted_attribution,
     quoted_content_unfetched,
+    quoted_text,
     thread_text,
     unfetched_links_note,
 )
@@ -139,6 +141,25 @@ def _article_parts(item: Item) -> list[str]:
     return [label, source.text[:ARTICLE_CHAR_LIMIT]]
 
 
+def _quoted_parts(item: Item) -> list[str]:
+    """The quoted post the item is sharing, under a label that NAMES ITS AUTHOR.
+
+    The judge must see every surface the generators see, or a summary correctly
+    grounded in the quoted body gets flagged unsupported (a false FAIL) — the mirror
+    of the bug that motivated this: the generator, shown nothing, invented instead.
+
+    The label carries the third party's `@handle (Name)` — built by the SAME
+    `quoted_attribution` the generators read — so the judge can enforce #86's
+    attribution rule: the poster is not the author of the content they quoted. Its own
+    label, never `[Linked article]`: a quoted post is not the content of any link.
+    """
+    label = quoted_attribution(item)
+    body = quoted_text(item)
+    if not (label and body):
+        return []
+    return [f"[{label}]", body]
+
+
 def _unfetched_parts(item: Item) -> list[str]:
     """The markers for content the pipeline never downloaded: links whose body is
     missing (all of them, or the remainder of a PARTIAL fetch) and a quoted post, which
@@ -163,8 +184,8 @@ def _source_text(item: Item) -> str:
     Concatenates the labelled evidence present on the item — the author metadata (WHO
     POSTED it, not who wrote its content), the video title + FULL transcript (what it
     says) + frame descriptions (what it shows), the image descriptions, the fetched
-    article body, the poster's own thread text, and the tweet text — so a claim in the
-    output can be traced to it. The judge must see everything the GENERATORS see: an
+    article body, the poster's own thread text, the QUOTED post (under its own author's
+    name), and the tweet text — so a claim in the output can be traced to it. The judge must see everything the GENERATORS see: an
     output grounded in a photo description or an article title would otherwise be
     judged against a source that never held it, and flagged unsupported (a false FAIL).
 
@@ -189,6 +210,7 @@ def _source_text(item: Item) -> str:
     thread = thread_text(item)
     if thread:
         parts += ["[Thread — full text, same author]", thread]
+    parts += _quoted_parts(item)
     parts += _unfetched_parts(item)
     if item.text:
         parts += ["[Tweet]", item.text]

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 from xbrain.executors.api import (
     QUOTED_CONTENT_UNFETCHED_NOTE,
+    quoted_attribution,
+    quoted_text,
     _content_image_descriptions,
     _video_frame_descriptions,
     first_source_text,
@@ -126,10 +128,12 @@ def export_worksheet(
             "page), `thread` (the poster's own full thread text — not a linked "
             "page), `video_transcript` (the full talk — what the video SAYS), "
             "`video_frame_descriptions` (what the video SHOWS: slides/screens, "
-            "present even when there is no transcript) and `image_descriptions` "
-            "(content-bearing photos) — weigh them all as topic signal, not just "
-            "`text`. `unfetched_links_note` / `quoted_content_note` mark content "
-            "that was NEVER downloaded: obey them — never describe or guess it. "
+            "present even when there is no transcript), `image_descriptions` "
+            "(content-bearing photos) and `quoted_text` (the post this one is "
+            "QUOTING — a third party's words, whose author `quoted_attribution` "
+            "names; the poster is NOT that author) — weigh them all as topic "
+            "signal, not just `text`. `unfetched_links_note` / `quoted_content_note` "
+            "mark content that was NEVER downloaded: obey them — never describe or guess it. "
             "Name no entity that none of these surfaces names: `links` carry a URL "
             "and a domain, which are topic signal only — never a name, never content. "
             "Then run: xbrain enrich --apply <this file>."
@@ -163,10 +167,20 @@ def export_worksheet(
                 # agent must not reconstruct the linked content from the URL/domain
                 # (see `links_content_unfetched`).
                 "unfetched_links_note": unfetched_links_note(it),
-                # Guardrail: `quoted_id` is captured but no fetcher downloads the
-                # quoted post, so the shared content is NOT in this worksheet. Without
-                # this note the summary rubric's "summarise the shared content" rule
-                # would be an order to invent it.
+                # The quoted post — the THIRD PARTY content a quote-tweet is reacting
+                # to, parsed from the same X payload as the tweet itself. It is the
+                # evidence the generator was missing: without it, a bare reaction
+                # ("Read this and you'll understand") had nothing to summarise, and the
+                # model filled the hole from world knowledge. `quoted_attribution`
+                # names WHOSE words these are — the same label the api prompt and the
+                # judge read, so the attribution rule is enforceable.
+                "quoted_text": quoted_text(it),
+                "quoted_attribution": quoted_attribution(it),
+                # Guardrail, unchanged in spirit: when the quoted post could NOT be
+                # fetched (deleted, protected, not hydrated), say so — the summary
+                # rubric's "summarise the shared content" rule would otherwise be an
+                # order to invent it. Fires only on that state; a fetched quote ships
+                # its body above instead.
                 "quoted_content_note": (
                     QUOTED_CONTENT_UNFETCHED_NOTE if quoted_content_unfetched(it) else None
                 ),

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -389,62 +389,75 @@ def _content_with_source(*, ok: bool, failure_reason="timeout", kind="external_a
     )
 
 
+def _refetch(content, force: bool, *, urls=("https://example.com/p",)) -> bool:
+    """`_should_refetch` asks the question of the ITEM, not of a bare `Content`.
+
+    It has to: "content exists" is not "the links were fetched" — the extract stage
+    stamps the quoted post, `digest-video` a transcript. So the decision reads the
+    item's LINKS. These wrappers keep the truth table below stated in terms of the
+    content, with the item's links held at the default single non-x link.
+    """
+    item = _item("1", list(urls))
+    item.content = content
+    return _should_refetch(item, force=force)
+
+
 # --- Truth table on _should_refetch ---
 
 
 def test_should_refetch_when_content_is_none():
-    assert _should_refetch(None, force=False) is True
-    assert _should_refetch(None, force=True) is True
+    assert _refetch(None, force=False) is True
+    assert _refetch(None, force=True) is True
 
 
 def test_should_skip_successful_fetch_without_force():
     c = _content_with_source(ok=True, text="body")
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_refetch_successful_fetch_with_force():
     c = _content_with_source(ok=True, text="body")
-    assert _should_refetch(c, force=True) is True
+    assert _refetch(c, force=True) is True
 
 
 def test_should_refetch_all_transient_timeout():
     c = _content_with_source(ok=False, failure_reason="timeout")
-    assert _should_refetch(c, force=False) is True
+    assert _refetch(c, force=False) is True
 
 
 def test_should_refetch_all_transient_dns_error():
     c = _content_with_source(ok=False, failure_reason="dns_error")
-    assert _should_refetch(c, force=False) is True
+    assert _refetch(c, force=False) is True
 
 
 def test_should_skip_terminal_not_found_without_force():
     c = _content_with_source(ok=False, failure_reason="not_found")
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_skip_terminal_paywall_without_force():
     c = _content_with_source(ok=False, failure_reason="paywall")
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_skip_terminal_forbidden_without_force():
     c = _content_with_source(ok=False, failure_reason="forbidden")
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_skip_terminal_js_required_without_force():
     c = _content_with_source(ok=False, failure_reason="js_required")
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_skip_terminal_empty_content_without_force():
     c = _content_with_source(ok=False, failure_reason="empty_content")
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_refetch_terminal_with_force():
     c = _content_with_source(ok=False, failure_reason="not_found")
-    assert _should_refetch(c, force=True) is True
+    assert _refetch(c, force=True) is True
 
 
 def test_should_skip_mixed_transient_and_terminal():
@@ -456,7 +469,7 @@ def test_should_skip_mixed_transient_and_terminal():
             ContentSourceFailure(kind="external_article", url="b", failure_reason="not_found"),
         ],
     )
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_skip_mixed_transient_and_success():
@@ -468,7 +481,7 @@ def test_should_skip_mixed_transient_and_success():
             ContentSourceSuccess(kind="external_article", url="b", text="got it"),
         ],
     )
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False) is False
 
 
 def test_should_skip_only_x_sources():
@@ -483,7 +496,7 @@ def test_should_skip_only_x_sources():
             ),
         ],
     )
-    assert _should_refetch(c, force=False) is False
+    assert _refetch(c, force=False, urls=("https://x.com/i/article/1",)) is False
 
 
 # --- Integration on fetch_pending ---
@@ -565,7 +578,7 @@ def test_should_refetch_legacy_uncategorized_failure_migrates_to_transient():
     # which would mislabel the actual cause).
     assert src.failure_reason == "unknown_error"
     c = Content(fetched_at=datetime(2026, 5, 17, tzinfo=timezone.utc), sources=[src])
-    assert _should_refetch(c, force=False) is True
+    assert _refetch(c, force=False) is True
 
 
 def test_should_refetch_external_transient_alongside_xcom_source():
@@ -589,7 +602,7 @@ def test_should_refetch_external_transient_alongside_xcom_source():
             ),
         ],
     )
-    assert _should_refetch(c, force=False) is True
+    assert _refetch(c, force=False) is True
 
 
 def test_fetch_pending_replaces_sources_does_not_append():
@@ -631,7 +644,7 @@ def test_extractor_exception_persists_as_transient_failure():
     assert failure.failure_reason == "unknown_error"
     assert "network blip" in failure.error
     # And `_should_refetch` correctly retries on the next run
-    assert _should_refetch(content, force=False) is True
+    assert _refetch(content, force=False) is True
 
 
 def test_content_source_from_uncategorised_failure_is_transient():
@@ -830,3 +843,74 @@ def test_force_refetch_unchanged_success_does_not_reenrich():
     assert item.content is not None
     assert item.content.fetched_at == _T0  # preserved despite --force
     assert items_pending_enrichment(store) == []  # not re-enriched
+
+
+# --- A non-link source must never mask an unfetched link ---
+#
+# Since the quoted post is parsed at EXTRACT time, a quote-tweet arrives at `fetch`
+# with `content` ALREADY stamped — but with no `external_article` source. Reading
+# "content exists" as "nothing left to fetch" would silently never fetch the article
+# of every quote-tweet that also links out. 35% of the corpus quotes.
+
+_QUOTED = ContentSourceSuccess(
+    kind="quoted_tweet",
+    url="https://x.com/karpathy/status/999",
+    text="I am leaving OpenAI.",
+    author=Author(handle="karpathy", name="Andrej Karpathy"),
+)
+
+
+def _item_with(sources, *, urls=("https://example.com/a",)) -> Item:
+    return Item(
+        id="1",
+        source="bookmark",
+        url="https://x.com/a/status/1",
+        author=Author(handle="a", name="A"),
+        text="Read this and you'll understand better this career move",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url=u, domain="example.com") for u in urls],
+        quoted_id="999",
+        content=(
+            Content(fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc), sources=list(sources))
+            if sources is not None
+            else None
+        ),
+    )
+
+
+def test_a_quoted_source_does_not_mask_an_unfetched_link():
+    """The regression guard: content stamped by the EXTRACT stage (a quoted post) is
+    not evidence that the item's LINK was ever fetched."""
+    assert _should_refetch(_item_with([_QUOTED]), force=False) is True
+
+
+def test_fetch_pending_still_fetches_the_article_of_a_quote_tweet():
+    """End to end: the article of a quote-tweet is fetched, and the quoted post
+    SURVIVES the fetch (only `external_article` sources are rebuilt)."""
+    item = _item_with([_QUOTED])
+    store = {"1": item}
+
+    fetched = fetch_pending(store, extractor=lambda url: FetchSuccess(title="T", text="body"))
+
+    assert fetched == 1
+    kinds = sorted(s.kind for s in store["1"].content.sources)
+    assert kinds == ["external_article", "quoted_tweet"]
+    assert _QUOTED in store["1"].content.sources
+
+
+def test_an_item_whose_links_are_all_fetched_is_not_refetched_despite_a_quote():
+    """The other arm — the fix must not turn into a re-fetch-forever loop."""
+    item = _item_with(
+        [
+            _QUOTED,
+            ContentSourceSuccess(kind="external_article", url="https://example.com/a", text="b"),
+        ]
+    )
+    assert _should_refetch(item, force=False) is False
+
+
+def test_an_item_with_only_x_links_and_a_quote_is_not_fetched():
+    """x.com links are `fetch_x`'s job — a quoted source must not drag them here."""
+    item = _item_with([_QUOTED], urls=("https://x.com/b/status/2",))
+    assert _should_refetch(item, force=False) is False

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -12,7 +12,7 @@ from xbrain.models import (
     Item,
     Link,
 )
-from xbrain.notes_io import slugify
+from xbrain.notes_io import note_filename, slugify
 
 
 def _item(item_id: str, with_link: bool, text: str | None = None) -> Item:
@@ -1379,3 +1379,190 @@ def test_generate_no_badge_when_output_fixed_before_write(tmp_path: Path):
     body = _note_body(tmp_path)
     assert "❌" not in body and "Verification: FAIL" not in body
     assert "B - fixed before the write." in body  # the current output still renders
+
+
+# ------------------------------------------------------- the quoted post, for the READER
+#
+# The quoted post reaches every LLM surface (#98) and never reached the human: on 762
+# notes (35%) the reader met a summary ABOUT a post they could not see. Worse, a
+# readable quote fell into the generic `## Content: <url>` branch — a THIRD PARTY's
+# words, unattributed, in a note whose author is the poster. That is the very
+# conflation the attribution rule exists to stop, rendered for the reader.
+
+from xbrain.executors.api import quoted_source, quoted_text  # noqa: E402
+from xbrain.i18n import SUPPORTED_LANGUAGES, strings_for  # noqa: E402
+from xbrain.models import QUOTED_CONTENT_KINDS  # noqa: E402
+
+_QUOTED_BODY = "Karpathy's career moves map AI's centre of gravity.\n\n2015: co-founds OpenAI."
+
+
+def _sections(note: str) -> dict[str, str]:
+    """Split a rendered note into `{"## Heading": body}`.
+
+    So a test can assert WHICH section a span sits under. `assert body in note` would
+    pass even with the quoted post served under `## Content` — the exact mislabelling
+    this PR removes.
+    """
+    sections: dict[str, list[str]] = {}
+    heading: str | None = None
+    for line in note.split("\n"):
+        if line.startswith("## "):
+            heading = line
+            sections.setdefault(heading, [])
+        elif heading is not None:
+            sections[heading].append(line)
+    return {key: "\n".join(value) for key, value in sections.items()}
+
+
+def _quoting_item(source) -> Item:
+    """A quote-tweet as it really exists in the store: enriched (all 762 are), so it
+    already has a note — this PR changes what that note SHOWS, not which notes exist."""
+    item = _item("1", with_link=False, text="Read this and you'll understand this career move")
+    item.quoted_id = "999"
+    item.enriched = Enrichment(
+        summary="Un post sobre la trayectoria de Karpathy.",
+        primary_topic="ai",
+        topics=["ai"],
+        executor="api",
+        enriched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+    )
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc), sources=[source] if source else []
+    )
+    return item
+
+
+def _readable_quote() -> ContentSourceSuccess:
+    return ContentSourceSuccess(
+        kind="quoted_tweet",
+        url="https://x.com/karpathy/status/999",
+        text=_QUOTED_BODY,
+        author=Author(handle="karpathy", name="Andrej Karpathy"),
+    )
+
+
+def _note_text(item: Item, tmp_path: Path, language: str = "Spanish") -> str:
+    generate({item.id: item}, tmp_path, output_language=language)
+    return (tmp_path / "items" / note_filename(item)).read_text(encoding="utf-8")
+
+
+def _quoted_heading(note: str, strings) -> str:
+    return next(h for h in _sections(note) if h.startswith(f"## {strings.quoted_post_header}"))
+
+
+def test_the_note_names_the_quoted_author_and_shows_their_words(tmp_path: Path):
+    """WHO is quoted and WHAT they said — the two facts the reader was denied."""
+    strings = strings_for("Spanish")
+    note = _note_text(_quoting_item(_readable_quote()), tmp_path)
+    heading = _quoted_heading(note, strings)
+
+    assert heading == f"## {strings.quoted_post_header} — @karpathy (Andrej Karpathy)"
+    body = _sections(note)[heading]
+    assert "> Karpathy's career moves map AI's centre of gravity." in body
+    assert "> 2015: co-founds OpenAI." in body
+    assert "<https://x.com/karpathy/status/999>" in body
+
+
+def test_the_quoted_body_is_never_rendered_as_generic_content(tmp_path: Path):
+    """The regression this PR exists for: a readable quote used to fall into the
+    generic `## Content: <url>` branch — a third party's words with no author, inside
+    a note attributed to the poster."""
+    strings = strings_for("Spanish")
+    note = _note_text(_quoting_item(_readable_quote()), tmp_path)
+    sections = _sections(note)
+
+    assert not any(h.startswith(f"## {strings.content_header}") for h in sections)
+    # and the body appears under the quoted heading, nowhere else
+    assert _QUOTED_BODY.splitlines()[0] not in sections["## Tweet"]
+
+
+def test_the_quoted_post_is_distinguished_from_the_posters_own_words(tmp_path: Path):
+    """The whole failure mode is the two being conflated. The poster's text stays under
+    `## Tweet`; the quoted words sit under their own heading, blockquoted."""
+    note = _note_text(_quoting_item(_readable_quote()), tmp_path)
+    sections = _sections(note)
+    strings = strings_for("Spanish")
+
+    assert "Read this and you'll understand this career move" in sections["## Tweet"]
+    assert (
+        "Read this and you'll understand this career move"
+        not in sections[_quoted_heading(note, strings)]
+    )
+    # Every line of the quoted body is blockquoted — markdown's own idiom for words that
+    # are not the note author's — and NEVER appears unquoted anywhere in the note.
+    quoted_body = sections[_quoted_heading(note, strings)]
+    for line in _QUOTED_BODY.split("\n"):
+        if line.strip():
+            assert f"> {line}" in quoted_body
+            assert f"\n{line}\n" not in note
+
+
+def test_the_note_shows_exactly_the_body_the_LLMs_were_shown(tmp_path: Path):
+    """Identity, not coincidence: the reader sees the SAME source the generator and the
+    judge saw — selected by the SAME helper (`quoted_source`), not a parallel lookup."""
+    item = _quoting_item(_readable_quote())
+    note = _note_text(item, tmp_path)
+    source = quoted_source(item)
+
+    assert source is not None
+    assert source.author is not None
+    assert f"@{source.author.handle} ({source.author.name})" in _quoted_heading(
+        note, strings_for("Spanish")
+    )
+    for line in quoted_text(item).split("\n"):
+        if line.strip():
+            assert f"> {line}" in note
+
+
+def test_an_unavailable_quoted_post_is_written_down_not_silently_omitted(tmp_path: Path):
+    """A reader who sees nothing assumes there was nothing. A quote we could not read is
+    a FACT — carry it, with its reason."""
+    strings = strings_for("Spanish")
+    failure = ContentSourceFailure(
+        kind="quoted_tweet", url="https://x.com/i/status/999", failure_reason="not_found"
+    )
+    note = _note_text(_quoting_item(failure), tmp_path)
+    sections = _sections(note)
+    heading = f"## {strings.quoted_post_unavailable}"
+
+    assert heading in sections
+    assert strings.quoted_unavailable_deleted in sections[heading]
+    assert "<https://x.com/i/status/999>" in sections[heading]
+
+
+def test_the_unavailable_reason_distinguishes_deleted_from_protected(tmp_path: Path):
+    """`not_found` and `forbidden` are different facts about the world and must not
+    collapse into one wording."""
+    strings = strings_for("Spanish")
+    protected = ContentSourceFailure(
+        kind="quoted_tweet", url="https://x.com/i/status/999", failure_reason="forbidden"
+    )
+    note = _note_text(_quoting_item(protected), tmp_path)
+    body = _sections(note)[f"## {strings.quoted_post_unavailable}"]
+
+    assert strings.quoted_unavailable_protected in body
+    assert strings.quoted_unavailable_deleted not in body
+
+
+def test_a_note_with_no_quote_renders_no_quoted_section(tmp_path: Path):
+    strings = strings_for("Spanish")
+    note = _note_text(_item("1", with_link=True), tmp_path)
+
+    assert strings.quoted_post_header not in note
+    assert strings.quoted_post_unavailable not in note
+
+
+def test_the_quoted_section_is_localised_in_every_supported_language(tmp_path: Path):
+    """The dataclass enforces presence; this enforces USE — a hardcoded Spanish header
+    would render Spanish inside an English vault."""
+    for index, language in enumerate(SUPPORTED_LANGUAGES):
+        strings = strings_for(language)
+        out = tmp_path / f"vault-{index}"
+        note = _note_text(_quoting_item(_readable_quote()), out, language=language)
+        assert f"## {strings.quoted_post_header} — @karpathy (Andrej Karpathy)" in note
+
+
+def test_the_quoted_kind_is_selected_by_the_shared_frozenset(tmp_path: Path):
+    """Guards the drift this whole workstream is about: the renderer must not grow its
+    own private notion of what a quoted post is."""
+    assert _readable_quote().kind in QUOTED_CONTENT_KINDS

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -570,3 +570,159 @@ def test_synthesized_article_link_routes_as_article():
 
     assert link is not None
     assert _classify_x_url(link.url) == "article"
+
+
+# --------------------------------------------------------------- quoted posts
+#
+# The quoted post is a THIRD PARTY's content that the poster is reacting to. X
+# embeds it in the very timeline payload we already capture, so parsing it out
+# costs no extra network call. Before this, only its `quoted_id` was kept and the
+# body was dropped — leaving the generator a bare reaction ("Read this and you'll
+# understand") with nothing to summarise, and inviting it to invent the thing
+# being reacted to.
+
+
+def _quoted_author_block(handle: str, name: str) -> dict:
+    return {"user_results": {"result": {"legacy": {"screen_name": handle, "name": name}}}}
+
+
+def _quoting_tweet(quoted_result: dict | None, *, quoted_id: str | None = "222") -> dict:
+    """Tweet 111 quoting tweet `quoted_id`; `quoted_result` is what X hydrated
+    (None = X sent the id but embedded no post)."""
+    tweet = _tweet_result("111", "alice", "Read this and you'll understand better this career move")
+    if quoted_id is not None:
+        tweet["legacy"]["quoted_status_id_str"] = quoted_id
+    if quoted_result is not None:
+        tweet["quoted_status_result"] = {"result": quoted_result}
+    return tweet
+
+
+def _quoted_post(**over) -> dict:
+    quoted = _tweet_result("222", "karpathy", "I am leaving OpenAI.")
+    quoted["core"] = _quoted_author_block("karpathy", "Andrej Karpathy")
+    quoted.update(over)
+    return quoted
+
+
+def _timeline(tweet: dict) -> dict:
+    return {
+        "data": {
+            "bookmark_timeline_v2": {
+                "timeline": {
+                    "instructions": [
+                        {
+                            "type": "TimelineAddEntries",
+                            "entries": [
+                                {
+                                    "entryId": f"tweet-{tweet['rest_id']}",
+                                    "content": {
+                                        "itemContent": {
+                                            "itemType": "TimelineTweet",
+                                            "tweet_results": {"result": tweet},
+                                        }
+                                    },
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+
+def _only_source(tweet: dict):
+    items = parse_tweets(_timeline(tweet), "bookmark")
+    assert len(items) == 1
+    item = items[0]
+    assert item.content is not None, "the quoting item must carry a Content block"
+    assert len(item.content.sources) == 1
+    return item, item.content.sources[0]
+
+
+def test_quoted_post_body_and_author_land_as_a_content_source():
+    """The quoted post's TEXT and its AUTHOR are the evidence that was missing.
+
+    The author matters as much as the body: the quoted post is a third party's,
+    and naming the poster as its author is the attribution bug #86 guards against.
+    """
+    from xbrain.models import Author, ContentSourceSuccess
+
+    item, source = _only_source(_quoting_tweet(_quoted_post()))
+
+    assert isinstance(source, ContentSourceSuccess)
+    assert source.kind == "quoted_tweet"
+    assert source.text == "I am leaving OpenAI."
+    assert source.author == Author(handle="karpathy", name="Andrej Karpathy")
+    assert source.url == "https://x.com/karpathy/status/222"
+    assert item.quoted_id == "222"
+
+
+def test_the_quoted_source_carries_no_title():
+    """`notes_io.note_title` takes the first source with a `title` — a quoted post
+    has no title, and borrowing that field for the author would hijack note titles."""
+    _, source = _only_source(_quoting_tweet(_quoted_post()))
+    assert source.title is None
+
+
+def test_the_quoted_source_is_not_a_link_content_kind():
+    """It must never be mistaken for a fetched LINK body: a quoted post is not the
+    content of any link the post points at."""
+    from xbrain.executors.api import fetched_link_sources
+    from xbrain.models import LINK_CONTENT_KINDS
+
+    item, source = _only_source(_quoting_tweet(_quoted_post()))
+
+    assert source.kind not in LINK_CONTENT_KINDS
+    assert fetched_link_sources(item) == 0
+
+
+def test_a_deleted_quoted_post_lands_as_a_not_found_failure():
+    from xbrain.models import ContentSourceFailure
+
+    tombstone = {"__typename": "TweetTombstone", "tombstone": {"text": {"text": "unavailable"}}}
+    _, source = _only_source(_quoting_tweet(tombstone))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.kind == "quoted_tweet"
+    assert source.failure_reason == "not_found"
+    assert source.url == "https://x.com/i/status/222"
+
+
+def test_a_protected_quoted_post_lands_as_a_forbidden_failure():
+    from xbrain.models import ContentSourceFailure
+
+    unavailable = {"__typename": "TweetUnavailable", "reason": "Protected"}
+    _, source = _only_source(_quoting_tweet(unavailable))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "forbidden"
+
+
+def test_an_unhydrated_quoted_post_lands_as_an_empty_content_failure():
+    """X sent the id but embedded no post — we know a quote exists and hold none
+    of it. That is a FAILURE state, not the absence of a quote."""
+    from xbrain.models import ContentSourceFailure
+
+    _, source = _only_source(_quoting_tweet(None))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "empty_content"
+    assert source.url == "https://x.com/i/status/222"
+
+
+def test_a_quoted_post_with_no_body_and_no_author_is_an_empty_content_failure():
+    from xbrain.models import ContentSourceFailure
+
+    _, source = _only_source(_quoting_tweet({"__typename": "Tweet", "rest_id": "222"}))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "empty_content"
+
+
+def test_a_tweet_that_quotes_nothing_gets_no_content_block():
+    """No quote → no source, and crucially no EMPTY `Content` that would later read
+    as "already fetched" to the link fetcher."""
+    items = parse_tweets(_timeline(_tweet_result("111", "alice", "just a post")), "bookmark")
+    assert items[0].quoted_id is None
+    assert items[0].content is None

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -726,3 +726,36 @@ def test_a_tweet_that_quotes_nothing_gets_no_content_block():
     items = parse_tweets(_timeline(_tweet_result("111", "alice", "just a post")), "bookmark")
     assert items[0].quoted_id is None
     assert items[0].content is None
+
+
+# ------------------------------------------- L6/M5: an honest record of what X did
+
+
+def test_a_media_only_quoted_post_is_not_recorded_as_X_refusing_it():
+    """X DID serve the post — it simply carries no text (a photo/video quote). Recording
+    "X did not serve the quoted post" is a false statement about the world, in the very
+    evidence store whose whole purpose is to stop us inventing facts."""
+    from xbrain.models import ContentSourceFailure
+
+    media_only = _quoted_post()
+    media_only["legacy"]["full_text"] = ""
+    _, source = _only_source(_quoting_tweet(media_only))
+
+    assert isinstance(source, ContentSourceFailure)
+    assert source.failure_reason == "empty_content"
+    assert "no text" in (source.error or "")
+    assert "did not serve" not in (source.error or "")
+
+
+def test_a_quoted_post_with_a_body_but_no_author_still_ships_its_body():
+    """The body is evidence even when X hydrates no author. Dropping it would throw away
+    the cure because one field is missing; the attribution simply names nobody."""
+    from xbrain.models import ContentSourceSuccess
+
+    anonymous = _quoted_post()
+    del anonymous["core"]
+    _, source = _only_source(_quoting_tweet(anonymous))
+
+    assert isinstance(source, ContentSourceSuccess)
+    assert source.text == "I am leaving OpenAI."
+    assert source.author is None

--- a/tests/test_guardrail_contract.py
+++ b/tests/test_guardrail_contract.py
@@ -20,12 +20,14 @@ import pytest
 
 from xbrain.executors.api import (
     QUOTED_CONTENT_UNFETCHED_NOTE,
+    QUOTED_LABEL,
     _user_prompt,
     fetched_link_sources,
     quoted_attribution,
     unfetched_links_note,
 )
 from xbrain.models import Author, Content, ContentSourceSuccess, Item, Link, Topic
+from xbrain.rubrics import load_rubric
 from xbrain.verification import _source_text
 from xbrain.worksheet import export_worksheet
 
@@ -280,3 +282,91 @@ def test_the_attribution_degrades_when_the_quoted_author_is_unknown():
 
     assert quoted_attribution(item) == "Quoted post"
     assert "@" not in quoted_attribution(item)
+
+
+# ------------------- H3: the two rubrics must not teach OPPOSITE readings of one label
+#
+# The generator is now told the `Quoted post — @handle (Name)` label names the author of
+# the quoted words. The judge's rubric says a `@handle (Name)` label is item metadata and
+# "does NOT establish who WROTE or SPOKE the content", and orders a named-speaker check
+# FIRST. Left alone, the judge would flag a CORRECT attribution as invented — false FAILs
+# concentrated on exactly the 762 items this change repairs.
+
+
+def _rubric(name: str) -> str:
+    return load_rubric(name, language="Spanish")
+
+
+def test_both_rubrics_speak_of_the_same_quoted_label():
+    """One label, one contract. Compared against the shared constant BY REFERENCE, so
+    renaming `QUOTED_LABEL` cannot leave a rubric quietly talking about the old one."""
+    for name in ("summary", "verify"):
+        assert QUOTED_LABEL in _rubric(name)
+
+
+def test_the_judge_rubric_declares_the_quoted_block_to_BE_authorship():
+    """The judge must be told that the quoted block is trusted authorship metadata for
+    the body beneath it — otherwise its `[Author]` rule ("names WHO POSTED, nothing
+    more") swallows the quoted label too, and a correct attribution reads as invented.
+
+    Pins the INSTRUCTION, not the heading: a rubric that merely mentions "Quoted post"
+    while still teaching that such a label is not authorship would pass a bare substring
+    check and still produce the false FAILs.
+    """
+    verify = _rubric("verify")
+    quoted_rules = [para for para in verify.split("\n\n") if QUOTED_LABEL in para]
+    assert quoted_rules
+    rule = " ".join(quoted_rules).lower()
+
+    # the block ESTABLISHES who wrote the quoted body…
+    assert "authorship" in rule
+    assert "written by" in rule or "wrote" in rule
+    # …naming THAT account is SUPPORTED (this is precisely the false FAIL the judge,
+    # left with only the `[Author]` rule, would otherwise emit on a correct output)…
+    assert "supported" in rule
+    # …and the poster is explicitly not the author of those words.
+    assert "poster" in rule
+
+
+def test_the_judge_rubric_enumerates_the_quoted_post_as_source():
+    """The rubric's opening enumeration of what the `source` contains must list the
+    quoted post, or the judge is told to check against a surface it was never promised."""
+    opening = _rubric("verify").split("## 1.")[0].lower()
+    assert "quoted" in opening or "citado" in opening
+
+
+# ------------------------------------ M5: no author → name NOBODY, and say so plainly
+
+
+def _bodied_quote_without_author(item: Item) -> Item:
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        sources=[
+            ContentSourceSuccess(
+                kind="quoted_tweet", url="https://x.com/i/status/999", text="a body, no author"
+            )
+        ],
+    )
+    return item
+
+
+def test_an_authorless_quote_tells_the_generator_the_author_is_UNKNOWN():
+    """`quoted_attribution` correctly degrades to a label naming nobody — but the prompt
+    still said "These are that account's words", a pronoun pointing at no account, while
+    the rubric tells the generator to attribute using a name it was never given. Say the
+    quiet part: the author is unknown, do not invent one."""
+    item = _bodied_quote_without_author(_item(quoted=True))
+    prompt = _user_prompt(item, VOCAB)
+
+    assert "a body, no author" in prompt  # the body is still evidence
+    assert "that account's" not in prompt  # the dangling pronoun is gone
+    lowered = prompt.lower()
+    assert "unknown" in lowered and "do not name" in lowered
+
+
+def test_a_quote_WITH_an_author_still_names_them_as_the_third_party():
+    item = _item(quoted=True, quoted_fetched=True)
+    prompt = _user_prompt(item, VOCAB)
+
+    assert quoted_attribution(item) in prompt
+    assert "NOT the poster's" in prompt

--- a/tests/test_guardrail_contract.py
+++ b/tests/test_guardrail_contract.py
@@ -21,6 +21,8 @@ import pytest
 from xbrain.executors.api import (
     QUOTED_CONTENT_UNFETCHED_NOTE,
     _user_prompt,
+    fetched_link_sources,
+    quoted_attribution,
     unfetched_links_note,
 )
 from xbrain.models import Author, Content, ContentSourceSuccess, Item, Link, Topic
@@ -30,7 +32,35 @@ from xbrain.worksheet import export_worksheet
 VOCAB = [Topic(slug="misc", description="Noise.")]
 
 
-def _item(*, links: int = 0, quoted: bool = False, article: bool = False) -> Item:
+QUOTED_SOURCE = ContentSourceSuccess(
+    kind="quoted_tweet",
+    url="https://x.com/karpathy/status/999",
+    text="I am leaving OpenAI.",
+    author=Author(handle="karpathy", name="Andrej Karpathy"),
+)
+
+
+def _blocks(source_text: str) -> dict[str, str]:
+    """Split `_source_text` into `{[Label]: body}`.
+
+    So a test can assert WHICH label a span sits under. A bare `assert body in text`
+    would pass even if the quoted post were served under `[Linked article]` — the
+    exact mislabelling that tells the judge a link was downloaded when none was.
+    """
+    blocks: dict[str, list[str]] = {}
+    label: str | None = None
+    for line in source_text.split("\n"):
+        if line.startswith("[") and line.endswith("]"):
+            label = line
+            blocks.setdefault(label, [])
+        elif label is not None:
+            blocks[label].append(line)
+    return {key: "\n".join(value) for key, value in blocks.items()}
+
+
+def _item(
+    *, links: int = 0, quoted: bool = False, article: bool = False, quoted_fetched: bool = False
+) -> Item:
     sources = (
         [
             ContentSourceSuccess(
@@ -43,6 +73,8 @@ def _item(*, links: int = 0, quoted: bool = False, article: bool = False) -> Ite
         if article
         else []
     )
+    if quoted_fetched:
+        sources = [*sources, QUOTED_SOURCE]
     return Item(
         id="1",
         source="bookmark",
@@ -145,3 +177,106 @@ def test_the_partial_fetch_note_states_the_counts():
     note = unfetched_links_note(_item(links=2, article=True))
     assert note is not None
     assert "1 of 2" in note
+
+
+# ------------------------------------------- the FETCHED quote: same one contract
+#
+# A fetched quote and an unfetched quote are DIFFERENT states and both must be
+# represented. The unfetched marker (above) is damage control; these pin the fix:
+# the quoted body + its author reach every surface, under ONE shared attribution.
+
+
+def test_every_surface_carries_the_fetched_quoted_body_under_the_same_attribution(tmp_path):
+    """The generator's two surfaces and the judge's source must name the quoted
+    post's author IDENTICALLY — via the one shared builder, not three hand-written
+    labels that can drift. Compared by REFERENCE to `quoted_attribution`."""
+    item = _item(quoted=True, quoted_fetched=True)
+    label = quoted_attribution(item)
+
+    assert label == "Quoted post — @karpathy (Andrej Karpathy)"
+    assert label in _user_prompt(item, VOCAB)  # generator: api prompt
+    entry = _worksheet_entry(item, tmp_path)  # generator: worksheet
+    assert entry["quoted_attribution"] == label
+    assert entry["quoted_text"] == QUOTED_SOURCE.text
+    assert f"[{label}]" in _source_text(item)  # judge: verify source
+
+
+def test_the_fetched_quoted_body_reaches_every_surface(tmp_path):
+    item = _item(quoted=True, quoted_fetched=True)
+    body = QUOTED_SOURCE.text
+
+    assert body in _user_prompt(item, VOCAB)
+    assert _worksheet_entry(item, tmp_path)["quoted_text"] == body
+    assert body in _source_text(item)
+
+
+def test_a_fetched_quote_silences_the_unfetched_marker(tmp_path):
+    """#86's marker must fire ONLY when the content genuinely is not there. Stamping
+    `content NOT fetched` over a body we DID fetch would order the generator to
+    ignore its best evidence."""
+    item = _item(quoted=True, quoted_fetched=True)
+
+    assert QUOTED_CONTENT_UNFETCHED_NOTE not in _user_prompt(item, VOCAB)
+    assert _worksheet_entry(item, tmp_path)["quoted_content_note"] is None
+    text = _source_text(item)
+    assert QUOTED_CONTENT_UNFETCHED_NOTE not in text
+    assert "[Quoted post — content NOT fetched]" not in text
+
+
+def test_an_unfetched_quote_still_fires_the_marker_and_carries_no_body(tmp_path):
+    """The other arm: #86's guardrail stays honest when the quote could not be
+    fetched (deleted, protected, not hydrated)."""
+    item = _item(quoted=True, quoted_fetched=False)
+
+    assert QUOTED_CONTENT_UNFETCHED_NOTE in _user_prompt(item, VOCAB)
+    entry = _worksheet_entry(item, tmp_path)
+    assert entry["quoted_content_note"] == QUOTED_CONTENT_UNFETCHED_NOTE
+    assert entry["quoted_text"] is None
+    assert entry["quoted_attribution"] is None
+    assert "[Quoted post — content NOT fetched]" in _source_text(item)
+
+
+def test_the_quoted_body_sits_under_the_quoted_label_never_the_article_label():
+    """Structural, not substring. With BOTH a fetched article and a fetched quote on
+    one item, each body must sit under its OWN label. Serving the quoted post as a
+    `[Linked article]` would tell the judge a link was downloaded and hand it text
+    that is not that link's content."""
+    item = _item(quoted=True, quoted_fetched=True, links=1, article=True)
+    blocks = _blocks(_source_text(item))
+    quoted_block = blocks[f"[{quoted_attribution(item)}]"]
+    # The article label embeds the title (`[Linked article — The piece]`), so find it
+    # by its stem rather than pinning a literal that a title change would break.
+    article_label = next(key for key in blocks if key.startswith("[Linked article"))
+    article_block = blocks[article_label]
+
+    assert QUOTED_SOURCE.text in quoted_block
+    assert QUOTED_SOURCE.text not in article_block
+    assert "the fetched article body" in article_block
+    assert "the fetched article body" not in quoted_block
+
+
+def test_the_quoted_post_never_counts_as_a_fetched_LINK_body():
+    """It is a third party's post, not the body of any link — it must not silence the
+    unfetched-links guardrail."""
+    item = _item(quoted=True, quoted_fetched=True, links=1)
+
+    assert fetched_link_sources(item) == 0
+    assert unfetched_links_note(item) is not None
+    assert unfetched_links_note(item) in _source_text(item)
+
+
+def test_the_attribution_degrades_when_the_quoted_author_is_unknown():
+    """A quoted body whose author X did not hydrate still ships — under a label that
+    names NOBODY, rather than silently inheriting the poster's identity."""
+    item = _item(quoted=True)
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        sources=[
+            ContentSourceSuccess(
+                kind="quoted_tweet", url="https://x.com/i/status/999", text="a body, no author"
+            )
+        ],
+    )
+
+    assert quoted_attribution(item) == "Quoted post"
+    assert "@" not in quoted_attribution(item)

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -47,6 +47,11 @@ def test_strings_dataclass_has_exactly_the_expected_fields() -> None:
         "video_evidence_header",
         "verify_badge_fail",
         "verify_badge_review",
+        "quoted_post_header",
+        "quoted_post_unavailable",
+        "quoted_unavailable_deleted",
+        "quoted_unavailable_protected",
+        "quoted_unavailable_unknown",
     }
 
 
@@ -89,3 +94,18 @@ def test_strings_dataclass_is_frozen() -> None:
     s = strings_for("English")
     with pytest.raises(dataclasses.FrozenInstanceError):
         s.topics_label = "mutated"  # type: ignore[misc]
+
+
+def test_every_language_localises_the_quoted_post_strings() -> None:
+    """The quoted post is rendered into the human's note, so its headers must speak the
+    vault's language — a hardcoded Spanish `Post citado` would sit in an English vault.
+    Asserts the strings DIFFER per language, not merely that they are present: a field
+    copied verbatim across languages passes a presence check and still reads wrong."""
+    english, spanish = strings_for("English"), strings_for("Spanish")
+
+    assert english.quoted_post_header == "Quoted post"
+    assert spanish.quoted_post_header == "Post citado"
+    assert english.quoted_post_unavailable != spanish.quoted_post_unavailable
+    assert english.quoted_unavailable_deleted != spanish.quoted_unavailable_deleted
+    assert english.quoted_unavailable_protected != spanish.quoted_unavailable_protected
+    assert english.quoted_unavailable_unknown != spanish.quoted_unavailable_unknown

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -376,8 +376,8 @@ def test_estimate_mixes_estimable_and_unknown_across_items():
 
 # --------------------------------------------------------- quoted-post backfill
 
-from xbrain.models import Content, ContentSourceFailure, ContentSourceSuccess  # noqa: E402
-from xbrain.refresh import backfill_quoted_sources  # noqa: E402
+from xbrain.models import Content, ContentSourceFailure, ContentSourceSuccess, Enrichment  # noqa: E402
+from xbrain.refresh import _quoted_source, backfill_quoted_sources  # noqa: E402
 
 _T0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
 
@@ -618,3 +618,105 @@ def test_offline_backfill_is_idempotent_and_preserves_other_sources():
     assert second.sources_attached == 0
     assert second.already_present == 1
     assert article in store["1"].content.sources
+
+
+# ------------------------------- H2: the clock moves only when the EVIDENCE moves
+#
+# `content.fetched_at > enriched_at` is what flags an item for re-enrichment, and
+# `verify` fingerprints the OUTPUT — so bumping the clock on a run that changed no LLM
+# surface re-runs the model on a byte-identical prompt, non-deterministically rewrites a
+# good summary, AND staleness-invalidates every persisted verdict badge. Every run.
+# Forever. This is bug #44 reopened; `fetch_item` and `fetch_x._attach_x_sources` both
+# guard it, and `_attach_quoted` must too.
+
+from xbrain.enrich import items_pending_enrichment  # noqa: E402
+
+
+def _enriched_at(when: datetime) -> Enrichment:
+    return Enrichment(
+        summary="s", primary_topic="t", topics=["t"], executor="api", enriched_at=when
+    )
+
+
+def _unreadable() -> ContentSourceFailure:
+    return ContentSourceFailure(
+        kind="quoted_tweet", url="https://x.com/i/status/999", failure_reason="not_found"
+    )
+
+
+def _enriched_quote_item(sources) -> Item:
+    item = _quoted_item("1", sources=sources)
+    item.enriched = _enriched_at(datetime(2026, 5, 2, tzinfo=timezone.utc))  # after _T0
+    return item
+
+
+def test_re_attaching_an_identical_unreadable_quote_does_not_move_the_clock():
+    """A deleted quote re-attaches identically on every re-capture. Nothing the model
+    reads has changed, so the item must NOT come back pending."""
+    store = {"1": _enriched_quote_item([_unreadable()])}
+    fresh = [_quoted_item("1", sources=[_unreadable()])]
+
+    backfill_quoted_sources(store, fresh)
+
+    assert store["1"].content.fetched_at == _T0
+    assert items_pending_enrichment(store) == []
+
+
+def test_recording_a_first_unreadable_quote_does_not_move_the_clock():
+    """An item that had NO quoted source and gains a FAILURE one: the failure is
+    recorded, but no LLM surface changed (the `NOT fetched` marker already fired on the
+    bare `quoted_id`), so re-enriching would be a wasted, identical call."""
+    item = _enriched_quote_item(None)
+    store = {"1": item}
+    fresh = [_quoted_item("1", sources=[_unreadable()])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.unreadable == 1
+    assert _quoted_source(store["1"]) == _unreadable()  # the failure IS recorded
+    assert items_pending_enrichment(store) == []  # …but the model is not re-run
+
+
+def test_gaining_a_READABLE_quote_does_move_the_clock():
+    """The other arm — real new evidence must re-enrich, or the fix repairs nothing."""
+    store = {"1": _enriched_quote_item([_unreadable()])}
+    fresh = [_quoted_item("1", sources=[_quoted_success()])]
+
+    backfill_quoted_sources(store, fresh)
+
+    assert store["1"].content.fetched_at > _T0
+    assert [i.id for i in items_pending_enrichment(store)] == ["1"]
+
+
+def test_the_offline_backfill_obeys_the_same_clock_rule():
+    from xbrain.refresh import backfill_quoted_from_store
+
+    store = {"1": _enriched_quote_item([_unreadable()])}  # quotes 999, which we do NOT hold
+
+    backfill_quoted_from_store(store)
+
+    assert store["1"].content.fetched_at == _T0
+    assert items_pending_enrichment(store) == []
+
+
+def test_backfill_is_a_no_op_on_an_identical_failure_record():
+    """Re-running must not churn the store: an identical failure is left exactly as-is."""
+    store = {"1": _enriched_quote_item([_unreadable()])}
+    fresh = [_quoted_item("1", sources=[_unreadable()])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.sources_attached == 0
+    assert report.already_present == 1
+
+
+# ---------------------------------------------- L7: ONE selector, not two that agree
+
+
+def test_refresh_and_the_llm_surfaces_share_one_readable_quote_selector():
+    """Two selectors that agree today are the drift this whole workstream exists to
+    stop. Identity, by reference — not "they return the same thing"."""
+    from xbrain import refresh
+    from xbrain.executors import api
+
+    assert refresh.quoted_source is api.quoted_source

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -372,3 +372,249 @@ def test_estimate_mixes_estimable_and_unknown_across_items():
     assert estimated == 8_160_000
     assert n_estimable == 1
     assert n_unknown == 1
+
+
+# --------------------------------------------------------- quoted-post backfill
+
+from xbrain.models import Content, ContentSourceFailure, ContentSourceSuccess  # noqa: E402
+from xbrain.refresh import backfill_quoted_sources  # noqa: E402
+
+_T0 = datetime(2026, 5, 1, tzinfo=timezone.utc)
+
+
+def _quoted_item(item_id: str, *, sources=None, quoted_id: str | None = "999") -> Item:
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/a/status/{item_id}",
+        author=Author(handle="a", name="A"),
+        text="Read this and you'll understand better this career move",
+        created_at=_T0,
+        captured_at=_T0,
+        quoted_id=quoted_id,
+        content=Content(fetched_at=_T0, sources=list(sources)) if sources is not None else None,
+    )
+
+
+def _quoted_success() -> ContentSourceSuccess:
+    return ContentSourceSuccess(
+        kind="quoted_tweet",
+        url="https://x.com/karpathy/status/999",
+        text="I am leaving OpenAI.",
+        author=Author(handle="karpathy", name="Andrej Karpathy"),
+    )
+
+
+def test_backfill_attaches_the_quoted_source_to_a_stored_item():
+    """The 762 stored quote-tweets hold only a `quoted_id`. A re-capture carries the
+    quoted post in the SAME payload, so the backfill is a re-parse, not a fetch."""
+    store = {"1": _quoted_item("1")}
+    fresh = [_quoted_item("1", sources=[_quoted_success()])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.items_seen == 1
+    assert report.sources_attached == 1
+    assert report.readable == 1
+    assert store["1"].content is not None
+    assert store["1"].content.sources == [_quoted_success()]
+
+
+def test_backfill_preserves_every_other_source_and_all_enrichment():
+    """It appends the quoted post. An article body, a transcript or a thread already
+    on the item must survive untouched — this is a backfill, not a rebuild."""
+    article = ContentSourceSuccess(
+        kind="external_article", url="https://example.com/p", title="T", text="the article body"
+    )
+    store = {"1": _quoted_item("1", sources=[article])}
+    fresh = [_quoted_item("1", sources=[_quoted_success()])]
+
+    backfill_quoted_sources(store, fresh)
+
+    assert article in store["1"].content.sources
+    assert _quoted_success() in store["1"].content.sources
+
+
+def test_backfill_advances_fetched_at_so_the_item_re_enriches():
+    """The item just gained the evidence its summary was missing — it must flow back
+    through `enrich` (`content.fetched_at > enriched_at`), or the defective summary
+    stands and the whole fix ships without repairing anything."""
+    store = {"1": _quoted_item("1", sources=[])}
+    fresh = [_quoted_item("1", sources=[_quoted_success()])]
+
+    backfill_quoted_sources(store, fresh)
+
+    assert store["1"].content.fetched_at > _T0
+
+
+def test_backfill_upgrades_an_unreadable_quote_to_a_readable_one():
+    """A post that was deleted-at-capture but is readable now must be upgradeable —
+    and the stale failure must not linger alongside the body."""
+    failure = ContentSourceFailure(
+        kind="quoted_tweet", url="https://x.com/i/status/999", failure_reason="not_found"
+    )
+    store = {"1": _quoted_item("1", sources=[failure])}
+    fresh = [_quoted_item("1", sources=[_quoted_success()])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert store["1"].content.sources == [_quoted_success()]
+    assert report.sources_attached == 1
+
+
+def test_backfill_is_idempotent_on_an_already_readable_quote():
+    store = {"1": _quoted_item("1", sources=[_quoted_success()])}
+    fresh = [_quoted_item("1", sources=[_quoted_success()])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.already_present == 1
+    assert report.sources_attached == 0
+    assert store["1"].content.fetched_at == _T0  # untouched → no needless re-enrich
+
+
+def test_backfill_records_an_unreadable_quote_as_a_failure_not_as_silence():
+    """A deleted/protected quote still gets a source — so #86's `NOT fetched` marker
+    keeps firing and the state is demonstrable, not merely absent."""
+    failure = ContentSourceFailure(
+        kind="quoted_tweet", url="https://x.com/i/status/999", failure_reason="forbidden"
+    )
+    store = {"1": _quoted_item("1")}
+    fresh = [_quoted_item("1", sources=[failure])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.unreadable == 1
+    assert report.readable == 0
+    assert store["1"].content.sources == [failure]
+
+
+def test_backfill_ignores_fresh_items_not_already_in_the_store():
+    """Backfill only touches known ids — it never adds new items (that is `extract`)."""
+    store = {"1": _quoted_item("1")}
+    fresh = [_quoted_item("2", sources=[_quoted_success()])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.items_seen == 0
+    assert "2" not in store
+    assert store["1"].content is None
+
+
+def test_backfill_counts_the_quote_tweets_x_never_re_surfaced():
+    """The honest diagnostic: how many quote-tweets are still evidence-less because X
+    did not show them again. Without it the run reports success over a silent gap."""
+    store = {"1": _quoted_item("1"), "2": _quoted_item("2")}
+    fresh = [_quoted_item("1", sources=[_quoted_success()])]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.quoted_items_not_seen == 1
+
+
+def test_backfill_leaves_non_quoting_items_alone():
+    store = {"1": _quoted_item("1", quoted_id=None)}
+    fresh = [_quoted_item("1", quoted_id=None)]
+
+    report = backfill_quoted_sources(store, fresh)
+
+    assert report.sources_attached == 0
+    assert report.quoted_items_not_seen == 0
+    assert store["1"].content is None
+
+
+# ------------------------------------- offline backfill: the quote is already OURS
+#
+# Measured on the real store: 199 of the 762 quote-tweets (26.1%) quote a post that
+# is ALREADY an item in `items.json` — we hold its body and its author right now.
+# Those need no capture at all: the repair is a join on `quoted_id`.
+
+
+def _plain_item(item_id: str, *, handle: str, name: str, text: str) -> Item:
+    return Item(
+        id=item_id,
+        source="bookmark",
+        url=f"https://x.com/{handle}/status/{item_id}",
+        author=Author(handle=handle, name=name),
+        text=text,
+        created_at=_T0,
+        captured_at=_T0,
+    )
+
+
+def test_offline_backfill_joins_the_quoted_post_already_in_the_store():
+    """No network: the quoted post IS an item we hold. Its body and author become the
+    `quoted_tweet` source on the quoting item."""
+    from xbrain.refresh import backfill_quoted_from_store
+
+    quoted = _plain_item(
+        "999", handle="karpathy", name="Andrej Karpathy", text="I am leaving OpenAI."
+    )
+    store = {"1": _quoted_item("1"), "999": quoted}
+
+    report = backfill_quoted_from_store(store)
+
+    assert report.sources_attached == 1
+    assert report.readable == 1
+    source = store["1"].content.sources[0]
+    assert isinstance(source, ContentSourceSuccess)
+    assert source.kind == "quoted_tweet"
+    assert source.text == "I am leaving OpenAI."
+    assert source.author == Author(handle="karpathy", name="Andrej Karpathy")
+    assert source.url == quoted.url
+
+
+def test_offline_backfill_leaves_a_quote_we_do_not_hold_alone():
+    """`quoted_id` points at a post that is not in the store — nothing to join. It is
+    NOT stamped as a failure: the post may be perfectly alive, we simply never captured
+    it, and the re-capture route can still repair it."""
+    from xbrain.refresh import backfill_quoted_from_store
+
+    store = {"1": _quoted_item("1")}
+
+    report = backfill_quoted_from_store(store)
+
+    assert report.sources_attached == 0
+    assert report.quoted_items_not_seen == 1
+    assert store["1"].content is None
+
+
+def test_offline_backfill_skips_an_empty_quoted_body():
+    from xbrain.refresh import backfill_quoted_from_store
+
+    store = {"1": _quoted_item("1"), "999": _plain_item("999", handle="b", name="B", text="")}
+
+    report = backfill_quoted_from_store(store)
+
+    assert report.sources_attached == 0
+    assert store["1"].content is None
+
+
+def test_offline_backfill_never_quotes_the_item_itself():
+    """A self-referential `quoted_id` must not make an item its own evidence."""
+    from xbrain.refresh import backfill_quoted_from_store
+
+    store = {"1": _quoted_item("1", quoted_id="1")}
+
+    report = backfill_quoted_from_store(store)
+
+    assert report.sources_attached == 0
+    assert store["1"].content is None
+
+
+def test_offline_backfill_is_idempotent_and_preserves_other_sources():
+    from xbrain.refresh import backfill_quoted_from_store
+
+    article = ContentSourceSuccess(
+        kind="external_article", url="https://example.com/p", text="the article body"
+    )
+    quoted = _plain_item("999", handle="k", name="K", text="quoted body")
+    store = {"1": _quoted_item("1", sources=[article]), "999": quoted}
+
+    first = backfill_quoted_from_store(store)
+    second = backfill_quoted_from_store(store)
+
+    assert first.sources_attached == 1
+    assert second.sources_attached == 0
+    assert second.already_present == 1
+    assert article in store["1"].content.sources


### PR DESCRIPTION
> **#99 is folded into this PR** (commit `dbcaddf`) and closed. H1 of the review *is* that rendering work, and it belongs beside the commit that introduces the `author` field. This PR is the whole change: the quoted post reaches the models **and** the human, or neither.

## The argument for this change, in one line

We spent the day building judges, auditors, ensembles, a deterministic entity checker and a contract to bind them. Then this:

> The stored summary claims *"su movimiento profesional hacia **Anthropic**"*. The quoted post, finally visible in the note, **never mentions Anthropic**.

**The most effective verification layer available was showing the user the evidence next to the claim.** It costs no tokens, has no false positives, needs no threshold, and it lets the *reader* catch the invention — not just the judge. That is what the second half of this PR does.

## The bug

**762 of 2,168 items (35.1%) are quote-tweets, and they are 3.3× more defective than the rest — 12.2% vs 3.7%. 46% of all defects in the corpus.**

A quote-tweet's substance lives in the post it *quotes*; the poster's own text is often a bare reaction. We captured `quoted_id` and threw the post away. Meanwhile `rubric-summary` ordered the generator to *"summarise the substantive content being shared."* Told to summarise something it was never shown, the model filled the hole from world knowledge:

> **tweet:** `Read this and you'll understand better this career move`
> **summary:** `Víctor recomienda leer el hilo citado sobre Karpathy … su movimiento profesional hacia Anthropic.`

Neither name appeared on any surface. #86 stamped a `content NOT fetched` marker so the judge could flag it. **That was damage control. This is the fix.**

## Free — it was in the payload all along

X embeds the quoted post — **body AND author** — in the same timeline GraphQL response `extract` already captures. `_quoted_id` was *already* reaching into that object for its `rest_id` and discarding the rest. **Zero new network calls.**

## To the models

| Surface | Before | After |
|---|---|---|
| `extract/graphql.py` | `quoted_id` only | `ContentSourceSuccess(kind="quoted_tweet", author=…)` + typed failures |
| `executors/api.py` | `NOT fetched` marker | body under `Quoted post — @handle (Name)` |
| `worksheet.py` | — | `quoted_text` + `quoted_attribution` |
| `verification.py` | — | `[Quoted post — @handle (Name)]` block |
| `rubric-summary.md` | — | evidence surface **#7** |
| `rubric-verify.md` | — | that block **IS** authorship (see H3) |

**One label, not a sixth list.** All surfaces call `executors.api.quoted_attribution`. Naming the third party is what makes #86's attribution rule *enforceable*: the poster is **not** the author of what they quote.

Failure taxonomy — a quote we cannot read is a demonstrable failure, never silence: `not_found` (tombstoned) · `forbidden` (protected/suspended) · `empty_content` (nothing hydrated, **or** media-only — distinguished, because X *did* serve that one).

## To the reader

`_content_lines`'s catch-all `else` rendered a readable quote as `## Contenido: <url>` + the body: **a third party's words, unattributed, under the same heading the item's own fetched article uses, in a note whose frontmatter says `author: vgonpa`.** The #86 conflation, in the user-facing artifact, at 35% of the corpus. The unreadable case vanished silently.

```markdown
## Tweet

Read this and you’ll understand better this career move

## Post citado — @aakashgupta (Aakash Gupta)

> Karpathy's career moves are the single most accurate map of AI's center of gravity over the last decade.
>
> 2015: co-founds OpenAI when the frontier is pure research. 2017: leaves for Tesla…

<https://x.com/aakashgupta/status/2056791503427760258>
```

**Inline, not `<details>`** — the video digest collapses raw *evidence*; a quoted post is not evidence for the note, it **IS the note's subject**, and hiding the thing the summary is about reproduces the bug in a nicer wrapper. **Above the summary's subject-line**, under the tweet where X puts the quote card. **Blockquoted**, markdown's own idiom for words that are not the author's. **Unavailable carries its reason** (deleted ≠ locked account). **Localised** — and the i18n test asserts the languages *differ*, since a string copied verbatim passes a presence check and still reads wrong.

## The landmine, and the review findings

**`_should_refetch` returned `False` whenever content existed with no `external_article` source.** Stamping the quoted post at extract gives every quote-tweet that shape — so **the article of every quote-tweet that also links out would have been silently never fetched.** A latent bug already in `develop` (threads and `x_video` hit it too), which this change would have detonated across 35% of the corpus. It now asks the *item*, not a bare `Content`.

Adversarial review (3 HIGH, 3 minor) — all fixed in `ada9039`:

- **H1** — the unattributed note. Above.
- **H2** — `_attach_quoted` bumped `fetched_at` unconditionally. A deleted quote re-attaches identically every run → item flagged pending-enrichment **forever** → each run burns an LLM call, non-deterministically rewrites a good summary, and **staleness-invalidates every persisted verdict badge**. Bug #44 reopened. The clock now moves only when the **evidence** moves: `_quoted_evidence(item)` is exactly what the surfaces read (`quoted_source` → `(text, author)`), and `fetched_at` advances iff that pair changes. **Stricter than `_sources_materially_equal`** — swapping one unreadable record for a *different* unreadable one (`not_found`→`forbidden`) is materially different yet changes no surface. Verified: 3 consecutive runs on a deleted quote leave `fetched_at` untouched and `items_pending_enrichment == []`; a *readable* quote still re-enriches.
- **H3** — the two rubrics taught **opposite** readings of one label. `rubric-summary` says the quoted label names the author; `rubric-verify` said a `@handle (Name)` block "does NOT establish who WROTE or SPOKE the content" and ordered a named-speaker check first — so a correctly-grounded summary would be flagged as invented, **false FAILs concentrated on exactly the 762 items this PR repairs.** `rubric-verify` now declares the quoted block to **BE** trusted authorship metadata for the body beneath it, with the mirror worked example (a correct quoted attribution is a **PASS**).
- **M5** — an authorless body no longer says "that account's words" (a pronoun pointing at nobody); it says the author is **UNKNOWN — do not name one**. The extractor no longer *drops* an authorless body either: the body is the evidence.
- **L6** — a media-only quote is no longer recorded as "X did not serve the quoted post". X *did* serve it. A false record in the evidence base whose purpose is to stop us inventing facts.
- **L7** — one selector for "has a readable quote", not two that agree today. Pinned by `assert refresh.quoted_source is api.quoted_source`.

## Tests — identity and structure, never a substring

This repo has shipped four tests that passed for the wrong reason, one satisfied by a section *header*. So:

- **`_blocks()`** / **`_sections()`** assert **which label a body sits under** — a quoted body under `[Linked article]` or `## Contenido` **fails**, where `assert body in text` would pass.
- Labels compared **by reference** to the shared builder, not matched as text.
- Both arms of every state: a fetched quote **silences** the marker; an unfetched one **still fires** it. `"Quoted post"` alone is satisfied by *both* headers, so no test leans on it.
- The rubric test pins the **instruction** ("supported", "authorship", "written by", "poster") — a rubric that merely mentions "Quoted post" while still teaching that such a label isn't authorship fails.

**Gate:** ruff ✅ format ✅ mypy ✅ **radon all A/B** ✅ bandit ✅ vulture ✅ interrogate 89.9% ✅ detect-secrets ✅ deptry ✅ **1358 tests, 95% coverage** ✅ · CI green.
Backwards compatible: the real 2,168-item store loads unchanged (`author` is optional + additive).

## Backfill — NOT run

```bash
xbrain refresh-quoted --from-store   # offline join on quoted_id. Repairs 199/762 (26.1%). No network.
xbrain refresh-quoted                # re-capture (shares the refresh-media harness) for the other 563
xbrain enrich                        # re-generates exactly the repaired summaries
```

**199 of the 762 are repairable from data we already hold** — the quoted post is frequently already an item in `items.json`. Measured, not estimated.

⚠️ **Sequencing: PR-H (#95, `note_tweet`) must land before any backfill runs**, or we persist 280-char truncated quoted bodies and mark them enriched — a milder version of the bug we are fixing. Both backfill routes inherit that truncation, so #95 fixes both at once.

## Follow-up

**Persist the raw X payload at ingest** (PR-J). Had we kept it, all 762 would be repairable offline instead of 199. Worth doing before the next parse bug.