### PR TITLE
feat(generate): show the quoted post in the note — attributed, or honestly missing

### DIFF
--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -11,8 +11,10 @@ from typing import assert_never, cast
 from xbrain.config import SUPPORTED_TOPIC_STYLES
 from xbrain.dashboard import collect_thumbnails, compute_dashboard_data, render_dashboard_html
 from xbrain.i18n import Strings, strings_for
+from xbrain.executors.api import quoted_source
 from xbrain.models import (
     ARTICLE_PARAGRAPH_SEP,
+    QUOTED_CONTENT_KINDS,
     ArticleImageBlock,
     ArticleTextBlock,
     ContentSourceFailure,
@@ -70,6 +72,81 @@ def _broken_link_line(source: ContentSourceFailure, fetched_at: datetime) -> str
     detail = " · ".join(bits) or "no se pudo recuperar"
     date = fetched_at.date().isoformat()
     return f"> ⚠ Enlace roto: <{source.url}> — {detail} (verificado {date})"
+
+
+def _blockquote(text: str) -> list[str]:
+    """Markdown-blockquote every line of `text` — the idiom for words that are NOT the
+    note author's. A blank line becomes a bare `>`, so one quote stays one quote instead
+    of breaking into two at the paragraph gap."""
+    return [f"> {line}" if line.strip() else ">" for line in text.split("\n")]
+
+
+def _quoted_failure_source(item: Item) -> ContentSourceFailure | None:
+    """The recorded reason the quoted post could not be read, or None."""
+    if item.content is None:
+        return None
+    for source in item.content.sources:
+        if isinstance(source, ContentSourceFailure) and source.kind in QUOTED_CONTENT_KINDS:
+            return source
+    return None
+
+
+def _quoted_unavailable_reason(reason: FailureReason, strings: Strings) -> str:
+    """The reader-facing wording for WHY the quoted post is missing.
+
+    `not_found` and `forbidden` are different facts about the world — a deleted post and
+    a locked account — and collapsing them into one "unavailable" would throw away the
+    only thing the reader can act on. Everything else (X hydrated nothing, a timeout)
+    honestly says just that: we do not know what was there.
+    """
+    if reason == "not_found":
+        return strings.quoted_unavailable_deleted
+    if reason == "forbidden":
+        return strings.quoted_unavailable_protected
+    return strings.quoted_unavailable_unknown
+
+
+def _quoted_lines(item: Item, strings: Strings) -> list[str]:
+    """Render the quoted post for the HUMAN — who is quoted, and what they said.
+
+    Until now the quoted body reached every LLM surface and never the reader: on a
+    quote-tweet (35% of the corpus) he met a summary ABOUT a post he could not see. And
+    a readable quote fell into the generic `## Content: <url>` branch — a third party's
+    words, with no author, inside a note whose author is the poster. That is exactly the
+    conflation the attribution rule stops for the model, rendered for the reader.
+
+    So: its own heading, NAMING the quoted account, with the body blockquoted. Inline,
+    not collapsed behind `<details>` — the video digest hides raw *evidence* (frames,
+    transcript) but shows the digest itself, and here the quoted post is not evidence
+    for the note, it IS the note's subject. Hiding the thing the summary is about would
+    reproduce the bug in a nicer wrapper.
+
+    The source is selected by `quoted_source` — the SAME helper the api prompt, the
+    enrich worksheet and the judge read — so the reader cannot be shown a different
+    quoted post from the one the model was given.
+    """
+    source = quoted_source(item)
+    if source is not None:
+        author = source.author
+        attribution = f" — @{author.handle} ({author.name})" if author else ""
+        return [
+            f"## {strings.quoted_post_header}{attribution}",
+            "",
+            *_blockquote(source.text),
+            "",
+            f"<{source.url}>",
+            "",
+        ]
+    failure = _quoted_failure_source(item)
+    if failure is None:
+        return []
+    reason = _quoted_unavailable_reason(failure.failure_reason, strings)
+    return [
+        f"## {strings.quoted_post_unavailable}",
+        "",
+        f"> ⚠ {reason} — <{failure.url}>",
+        "",
+    ]
 
 
 def generate(
@@ -617,24 +694,41 @@ def _content_lines(item: Item, strings: Strings) -> list[str]:
     digest_source = _video_source(item)
     lines: list[str] = []
     for source in content.sources:
+        # The quoted post has its OWN attributed section under the tweet (`_quoted_lines`).
+        # It must never fall through to the generic `## Content: <url>` branch, which would
+        # print a third party's words with no author inside a note whose author is the
+        # poster — and would print them twice.
+        if source.kind in QUOTED_CONTENT_KINDS:
+            continue
         if isinstance(source, ContentSourceSuccess):
-            if source.kind == "x_video":
-                # Badge only the canonical digest source (the one whose digest is
-                # fingerprinted); a second x_video source, if any, is never mis-badged.
-                badge = _verdict_badge(item, "digest", strings) if source is digest_source else None
-                lines += _video_digest_lines(source, strings, badge)
-            elif source.kind == "x_article" and source.blocks:
-                # Structured Article (#39): render the ordered text+image blocks
-                # as a blogpost. An `x_article` with EMPTY blocks (trafilatura
-                # fallback, or a pre-#39 record) falls through to the plain
-                # `source.text` path below — byte-unchanged, no regression.
-                lines += _article_blocks_lines(source, strings)
-            else:
-                heading = source.title or source.url
-                lines += [f"## {strings.content_header}: {heading}", "", source.text, ""]
+            lines += _success_source_lines(item, source, digest_source, strings)
         elif source.kind in ("external_article", "x_article"):
             lines += [_broken_link_line(source, content.fetched_at), ""]
     return lines
+
+
+def _success_source_lines(
+    item: Item,
+    source: ContentSourceSuccess,
+    digest_source: ContentSourceSuccess | None,
+    strings: Strings,
+) -> list[str]:
+    """Render one successfully-fetched source as its own kind of block.
+
+    An `x_video` becomes a `Video digest` section (#44); an `x_article` carrying
+    structured `blocks` becomes an ordered blogpost (#39 PR5), while one with EMPTY
+    blocks (trafilatura fallback, or a pre-#39 record) keeps the plain `source.text`
+    block — byte-unchanged. Everything else falls back to that plain block.
+    """
+    if source.kind == "x_video":
+        # Badge only the canonical digest source (the one whose digest is
+        # fingerprinted); a second x_video source, if any, is never mis-badged.
+        badge = _verdict_badge(item, "digest", strings) if source is digest_source else None
+        return _video_digest_lines(source, strings, badge)
+    if source.kind == "x_article" and source.blocks:
+        return _article_blocks_lines(source, strings)
+    heading = source.title or source.url
+    return [f"## {strings.content_header}: {heading}", "", source.text, ""]
 
 
 def _render_note(item: Item, strings: Strings, topic_style: str) -> str:
@@ -651,6 +745,12 @@ def _render_note(item: Item, strings: Strings, topic_style: str) -> str:
     if media_lines:
         lines += media_lines
         lines.append("")
+    # The quoted post sits directly under the tweet + its media, exactly where X puts the
+    # quote card — the same natural-read-order argument the media block makes above. It
+    # is the SUBJECT of a quote-tweet's summary, so burying it below `## Enlaces` and the
+    # permalink (where `_content_lines` renders) would leave the reader meeting the
+    # summary long before the thing it is about.
+    lines += _quoted_lines(item, strings)
     if item.links:
         lines.append("## Enlaces")
         lines += [f"- <{link.url}>" for link in item.links]

--- a/src/xbrain/i18n.py
+++ b/src/xbrain/i18n.py
@@ -35,6 +35,16 @@ class Strings:
     video_evidence_header: str  # collapsible label for the raw frames + transcript
     verify_badge_fail: str  # "Verification: FAIL" / "Verificación: FALLA" (#79 badge)
     verify_badge_review: str  # "Verification: REVIEW" / "Verificación: REVISAR" (#79 badge)
+    # The quoted post a quote-tweet is sharing. The header carries the quoted account's
+    # `@handle (Name)`, so the reader can never take a third party's words for the
+    # poster's — the same conflation the attribution rule stops on the LLM side.
+    quoted_post_header: str  # "Quoted post" / "Post citado"
+    # When we could not read the quoted post. Written down, never silently omitted: a
+    # reader who sees nothing concludes there was nothing. The reason is a fact.
+    quoted_post_unavailable: str  # "Quoted post unavailable" / "Post citado no disponible"
+    quoted_unavailable_deleted: str  # `not_found`  — X tombstoned it
+    quoted_unavailable_protected: str  # `forbidden`  — protected / suspended
+    quoted_unavailable_unknown: str  # anything else — X served us nothing usable
 
 
 _STRINGS: dict[str, Strings] = {
@@ -49,6 +59,11 @@ _STRINGS: dict[str, Strings] = {
         video_evidence_header="Frames + transcript",
         verify_badge_fail="Verification: FAIL",
         verify_badge_review="Verification: REVIEW",
+        quoted_post_header="Quoted post",
+        quoted_post_unavailable="Quoted post unavailable",
+        quoted_unavailable_deleted="deleted or never existed",
+        quoted_unavailable_protected="protected or suspended account",
+        quoted_unavailable_unknown="X served no content for it",
     ),
     "Spanish": Strings(
         topics_label="Temas",
@@ -61,6 +76,11 @@ _STRINGS: dict[str, Strings] = {
         video_evidence_header="Frames y transcripción",
         verify_badge_fail="Verificación: FALLA",
         verify_badge_review="Verificación: REVISAR",
+        quoted_post_header="Post citado",
+        quoted_post_unavailable="Post citado no disponible",
+        quoted_unavailable_deleted="borrado o inexistente",
+        quoted_unavailable_protected="cuenta protegida o suspendida",
+        quoted_unavailable_unknown="X no sirvió su contenido",
     ),
 }
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -12,7 +12,7 @@ from xbrain.models import (
     Item,
     Link,
 )
-from xbrain.notes_io import slugify
+from xbrain.notes_io import note_filename, slugify
 
 
 def _item(item_id: str, with_link: bool, text: str | None = None) -> Item:
@@ -1379,3 +1379,190 @@ def test_generate_no_badge_when_output_fixed_before_write(tmp_path: Path):
     body = _note_body(tmp_path)
     assert "❌" not in body and "Verification: FAIL" not in body
     assert "B - fixed before the write." in body  # the current output still renders
+
+
+# ------------------------------------------------------- the quoted post, for the READER
+#
+# The quoted post reaches every LLM surface (#98) and never reached the human: on 762
+# notes (35%) the reader met a summary ABOUT a post they could not see. Worse, a
+# readable quote fell into the generic `## Content: <url>` branch — a THIRD PARTY's
+# words, unattributed, in a note whose author is the poster. That is the very
+# conflation the attribution rule exists to stop, rendered for the reader.
+
+from xbrain.executors.api import quoted_source, quoted_text  # noqa: E402
+from xbrain.i18n import SUPPORTED_LANGUAGES, strings_for  # noqa: E402
+from xbrain.models import QUOTED_CONTENT_KINDS  # noqa: E402
+
+_QUOTED_BODY = "Karpathy's career moves map AI's centre of gravity.\n\n2015: co-founds OpenAI."
+
+
+def _sections(note: str) -> dict[str, str]:
+    """Split a rendered note into `{"## Heading": body}`.
+
+    So a test can assert WHICH section a span sits under. `assert body in note` would
+    pass even with the quoted post served under `## Content` — the exact mislabelling
+    this PR removes.
+    """
+    sections: dict[str, list[str]] = {}
+    heading: str | None = None
+    for line in note.split("\n"):
+        if line.startswith("## "):
+            heading = line
+            sections.setdefault(heading, [])
+        elif heading is not None:
+            sections[heading].append(line)
+    return {key: "\n".join(value) for key, value in sections.items()}
+
+
+def _quoting_item(source) -> Item:
+    """A quote-tweet as it really exists in the store: enriched (all 762 are), so it
+    already has a note — this PR changes what that note SHOWS, not which notes exist."""
+    item = _item("1", with_link=False, text="Read this and you'll understand this career move")
+    item.quoted_id = "999"
+    item.enriched = Enrichment(
+        summary="Un post sobre la trayectoria de Karpathy.",
+        primary_topic="ai",
+        topics=["ai"],
+        executor="api",
+        enriched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+    )
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc), sources=[source] if source else []
+    )
+    return item
+
+
+def _readable_quote() -> ContentSourceSuccess:
+    return ContentSourceSuccess(
+        kind="quoted_tweet",
+        url="https://x.com/karpathy/status/999",
+        text=_QUOTED_BODY,
+        author=Author(handle="karpathy", name="Andrej Karpathy"),
+    )
+
+
+def _note_text(item: Item, tmp_path: Path, language: str = "Spanish") -> str:
+    generate({item.id: item}, tmp_path, output_language=language)
+    return (tmp_path / "items" / note_filename(item)).read_text(encoding="utf-8")
+
+
+def _quoted_heading(note: str, strings) -> str:
+    return next(h for h in _sections(note) if h.startswith(f"## {strings.quoted_post_header}"))
+
+
+def test_the_note_names_the_quoted_author_and_shows_their_words(tmp_path: Path):
+    """WHO is quoted and WHAT they said — the two facts the reader was denied."""
+    strings = strings_for("Spanish")
+    note = _note_text(_quoting_item(_readable_quote()), tmp_path)
+    heading = _quoted_heading(note, strings)
+
+    assert heading == f"## {strings.quoted_post_header} — @karpathy (Andrej Karpathy)"
+    body = _sections(note)[heading]
+    assert "> Karpathy's career moves map AI's centre of gravity." in body
+    assert "> 2015: co-founds OpenAI." in body
+    assert "<https://x.com/karpathy/status/999>" in body
+
+
+def test_the_quoted_body_is_never_rendered_as_generic_content(tmp_path: Path):
+    """The regression this PR exists for: a readable quote used to fall into the
+    generic `## Content: <url>` branch — a third party's words with no author, inside
+    a note attributed to the poster."""
+    strings = strings_for("Spanish")
+    note = _note_text(_quoting_item(_readable_quote()), tmp_path)
+    sections = _sections(note)
+
+    assert not any(h.startswith(f"## {strings.content_header}") for h in sections)
+    # and the body appears under the quoted heading, nowhere else
+    assert _QUOTED_BODY.splitlines()[0] not in sections["## Tweet"]
+
+
+def test_the_quoted_post_is_distinguished_from_the_posters_own_words(tmp_path: Path):
+    """The whole failure mode is the two being conflated. The poster's text stays under
+    `## Tweet`; the quoted words sit under their own heading, blockquoted."""
+    note = _note_text(_quoting_item(_readable_quote()), tmp_path)
+    sections = _sections(note)
+    strings = strings_for("Spanish")
+
+    assert "Read this and you'll understand this career move" in sections["## Tweet"]
+    assert (
+        "Read this and you'll understand this career move"
+        not in sections[_quoted_heading(note, strings)]
+    )
+    # Every line of the quoted body is blockquoted — markdown's own idiom for words that
+    # are not the note author's — and NEVER appears unquoted anywhere in the note.
+    quoted_body = sections[_quoted_heading(note, strings)]
+    for line in _QUOTED_BODY.split("\n"):
+        if line.strip():
+            assert f"> {line}" in quoted_body
+            assert f"\n{line}\n" not in note
+
+
+def test_the_note_shows_exactly_the_body_the_LLMs_were_shown(tmp_path: Path):
+    """Identity, not coincidence: the reader sees the SAME source the generator and the
+    judge saw — selected by the SAME helper (`quoted_source`), not a parallel lookup."""
+    item = _quoting_item(_readable_quote())
+    note = _note_text(item, tmp_path)
+    source = quoted_source(item)
+
+    assert source is not None
+    assert source.author is not None
+    assert f"@{source.author.handle} ({source.author.name})" in _quoted_heading(
+        note, strings_for("Spanish")
+    )
+    for line in quoted_text(item).split("\n"):
+        if line.strip():
+            assert f"> {line}" in note
+
+
+def test_an_unavailable_quoted_post_is_written_down_not_silently_omitted(tmp_path: Path):
+    """A reader who sees nothing assumes there was nothing. A quote we could not read is
+    a FACT — carry it, with its reason."""
+    strings = strings_for("Spanish")
+    failure = ContentSourceFailure(
+        kind="quoted_tweet", url="https://x.com/i/status/999", failure_reason="not_found"
+    )
+    note = _note_text(_quoting_item(failure), tmp_path)
+    sections = _sections(note)
+    heading = f"## {strings.quoted_post_unavailable}"
+
+    assert heading in sections
+    assert strings.quoted_unavailable_deleted in sections[heading]
+    assert "<https://x.com/i/status/999>" in sections[heading]
+
+
+def test_the_unavailable_reason_distinguishes_deleted_from_protected(tmp_path: Path):
+    """`not_found` and `forbidden` are different facts about the world and must not
+    collapse into one wording."""
+    strings = strings_for("Spanish")
+    protected = ContentSourceFailure(
+        kind="quoted_tweet", url="https://x.com/i/status/999", failure_reason="forbidden"
+    )
+    note = _note_text(_quoting_item(protected), tmp_path)
+    body = _sections(note)[f"## {strings.quoted_post_unavailable}"]
+
+    assert strings.quoted_unavailable_protected in body
+    assert strings.quoted_unavailable_deleted not in body
+
+
+def test_a_note_with_no_quote_renders_no_quoted_section(tmp_path: Path):
+    strings = strings_for("Spanish")
+    note = _note_text(_item("1", with_link=True), tmp_path)
+
+    assert strings.quoted_post_header not in note
+    assert strings.quoted_post_unavailable not in note
+
+
+def test_the_quoted_section_is_localised_in_every_supported_language(tmp_path: Path):
+    """The dataclass enforces presence; this enforces USE — a hardcoded Spanish header
+    would render Spanish inside an English vault."""
+    for index, language in enumerate(SUPPORTED_LANGUAGES):
+        strings = strings_for(language)
+        out = tmp_path / f"vault-{index}"
+        note = _note_text(_quoting_item(_readable_quote()), out, language=language)
+        assert f"## {strings.quoted_post_header} — @karpathy (Andrej Karpathy)" in note
+
+
+def test_the_quoted_kind_is_selected_by_the_shared_frozenset(tmp_path: Path):
+    """Guards the drift this whole workstream is about: the renderer must not grow its
+    own private notion of what a quoted post is."""
+    assert _readable_quote().kind in QUOTED_CONTENT_KINDS

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -47,6 +47,11 @@ def test_strings_dataclass_has_exactly_the_expected_fields() -> None:
         "video_evidence_header",
         "verify_badge_fail",
         "verify_badge_review",
+        "quoted_post_header",
+        "quoted_post_unavailable",
+        "quoted_unavailable_deleted",
+        "quoted_unavailable_protected",
+        "quoted_unavailable_unknown",
     }
 
 
@@ -89,3 +94,18 @@ def test_strings_dataclass_is_frozen() -> None:
     s = strings_for("English")
     with pytest.raises(dataclasses.FrozenInstanceError):
         s.topics_label = "mutated"  # type: ignore[misc]
+
+
+def test_every_language_localises_the_quoted_post_strings() -> None:
+    """The quoted post is rendered into the human's note, so its headers must speak the
+    vault's language — a hardcoded Spanish `Post citado` would sit in an English vault.
+    Asserts the strings DIFFER per language, not merely that they are present: a field
+    copied verbatim across languages passes a presence check and still reads wrong."""
+    english, spanish = strings_for("English"), strings_for("Spanish")
+
+    assert english.quoted_post_header == "Quoted post"
+    assert spanish.quoted_post_header == "Post citado"
+    assert english.quoted_post_unavailable != spanish.quoted_post_unavailable
+    assert english.quoted_unavailable_deleted != spanish.quoted_unavailable_deleted
+    assert english.quoted_unavailable_protected != spanish.quoted_unavailable_protected
+    assert english.quoted_unavailable_unknown != spanish.quoted_unavailable_unknown


### PR DESCRIPTION
> **Stacked on #98.** Base is `feat/ship-quoted-tweet`, not `develop` — this PR consumes `quoted_source`, `ContentSourceSuccess.author` and `QUOTED_CONTENT_KINDS`, which land in #98. **Merge #98 first**, then this retargets to `develop` cleanly. Diff here is this PR only.

## The brief said the quoted post never reaches the human. Half right — and the other half is worse.

**The failure case is silently dropped**, as expected: `_content_lines`'s failure branch guards on `source.kind in ("external_article", "x_article")`, so an unreadable quote renders nothing. A reader who sees nothing concludes there was nothing.

**But the readable case is not dropped — it renders *unattributed*.** It falls through to the generic `else` branch:

```
## Contenido: https://x.com/karpathy/status/999

I am leaving OpenAI.
```

A **third party's words, with no author, inside a note whose frontmatter says `author: vgonpa`.** That is exactly the conflation the attribution rule exists to stop — the one that slipped past the judge 8/8 — rendered for the reader. As it stands, #98 would ship 762 unattributed quoted bodies into the vault. This PR is what makes #98 safe for the human, not a cosmetic follow-up.

## After

```markdown
## Tweet

Read this and you’ll understand better this career move

## Post citado — @aakashgupta (Aakash Gupta)

> Karpathy's career moves are the single most accurate map of AI's center of gravity over the last decade.
>
> 2015: co-founds OpenAI when the frontier is pure research. 2017: leaves for Tesla…

<https://x.com/aakashgupta/status/2056791503427760258>
```

That is the **real note**, rendered from the real store. Note what it now exposes: the stored summary claims *"su movimiento profesional hacia **Anthropic**"* — and the quoted post, finally visible, **never mentions Anthropic**. The reader can now *see* that the summary is wrong. Showing the evidence makes the defect auditable by the human, not just by the judge.

## Design calls, and why

**Inline, not collapsed.** `_video_digest_lines` hides raw *evidence* (frames, transcript) behind `<details>` but shows the digest itself. A quoted post is **not evidence for the note — it IS the note's subject.** Hiding the thing the summary is about would reproduce the bug in a nicer wrapper. It is also short (a post), so there is nothing to protect the reader from.

**Placed under the tweet + media**, where X itself puts the quote card — the same natural-read-order argument `_render_note` already makes for photos ("*matching how X itself renders them — natural read order, no jumping*"). `_content_lines` renders at the very bottom, past `## Enlaces` and the permalink; the reader would meet the summary long before its subject.

**Blockquoted body.** Markdown's own idiom for words that are not the author's. The poster's text stays under `## Tweet`; the quoted words sit under their own heading. The two can no longer be read as one voice — which is the entire failure mode.

**Unavailable carries the REASON.** `not_found` → "borrado o inexistente" · `forbidden` → "cuenta protegida o suspendida" · anything else → "X no sirvió su contenido". A deleted post and a locked account are different facts about the world; collapsing them into one "unavailable" throws away the only thing the reader can act on.

**One source of truth.** The section is selected by `quoted_source` / `QUOTED_CONTENT_KINDS` — the same helper and frozenset the api prompt, the enrich worksheet and the judge read. The reader cannot be shown a different quoted post from the one the model was given, and the renderer grows no private notion of what a quoted post is.

**Localised** — 5 new `i18n.Strings` fields; the frozen dataclass + the existing field-pinning test force every language to carry them.

## Tests — structure and identity, never a substring

This repo has now shipped **four** tests that passed for the wrong reason, one of them satisfied by a section *header*. So:

- **`_sections()`** splits the note into `{"## Heading": body}` and asserts **which section a span sits under**. A quoted body served under `## Contenido` **fails** — where `assert body in note` would have passed. That is the actual regression, and it is pinned.
- Identity, not coincidence: the body rendered is asserted equal to `quoted_text(item)` and the attribution to `quoted_source(item).author` — **by reference to the shared helpers**, not re-derived.
- The poster's own words are asserted **present under `## Tweet` and absent from the quoted section** — the conflation, tested directly.
- Every line of the quoted body must be blockquoted **and never appear unquoted anywhere in the note**.
- Both unavailable arms distinguished (`not_found` ≠ `forbidden`), so one wording cannot swallow the other.
- The i18n test asserts the languages **DIFFER**, not merely that the fields exist — a string copied verbatim across languages passes a presence check and still reads wrong in an English vault.

## Gate

ruff ✅ · format ✅ · mypy ✅ · **radon all A/B** ✅ · bandit ✅ · vulture ✅ · interrogate 89.7% ✅ · detect-secrets ✅ · deptry ✅ · **1345 tests, 95% coverage** ✅

The quoted-kind guard pushed `_content_lines` to radon **C(11)**; I extracted its success branch to `_success_source_lines` and it is back to A/B, behaviour unchanged.

## Safe to land without a render

Pure rendering: **no model call, no regeneration, `enrich`/`verify` untouched, summary text not modified.** Nothing is written until `xbrain generate` next runs, so the nightly picks it up. (`generate` currently fails from this harness with an iCloud EPERM on the vault, so I verified by rendering the real item into a scratch directory — never his vault.)

## Two observations, not changed

1. **`_has_note` is `links OR media OR enriched`** — a freshly-extracted quote-tweet with no link and no media would be invisible until `enrich` runs, the same blind spot they already fixed for photo-only tweets. **Measured: 0 items affected today** (all 762 quote-tweets are enriched, so all already have notes). Left alone rather than speculatively creating notes.
2. **`_broken_link_line` is hardcoded Spanish** (`"⚠ Enlace roto"`, `"verificado"`, `_FAILURE_ES`) regardless of `output_language` — pre-existing, untouched here, but it means an English vault already has one Spanish line. Worth its own PR.