### PR TITLE
feat(verify): bind a verdict to the CONTRACT it was judged under, not just the output

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -90,6 +90,7 @@ from xbrain.vocab import (
 from xbrain.verification import (
     aggregate_verify_judgments,
     apply_verdicts_to_store,
+    count_invalidated_verdicts,
     cross_check_fingerprints,
     export_verify_worksheet,
     import_verify_fingerprints,
@@ -1432,7 +1433,10 @@ def _write_verify_report(cfg: Config, json_report: str, md_report: str) -> None:
 
 
 def _verify_write_verdicts(
-    cfg: Config, records: list[dict], fingerprints: dict[tuple[str, str], str]
+    cfg: Config,
+    records: list[dict],
+    fingerprints: dict[tuple[str, str], str],
+    contracts: dict[tuple[str, str], str],
 ) -> None:
     """Opt-in write path for `verify --apply --write-verdicts` (and its post-audit twin,
     `verify --audit --apply --write-verdicts`): persist each FINAL verdict onto its item with
@@ -1449,12 +1453,33 @@ def _verify_write_verdicts(
     """
     _auto_snapshot(cfg, "verify-write-verdicts")
     store = load_store(cfg.items_path)
-    result = apply_verdicts_to_store(store, records, fingerprints)
+    result = apply_verdicts_to_store(store, records, fingerprints, contracts)
     save_store(store, cfg.items_path)
     typer.echo(f"{result.summary()} → {cfg.items_path}")
 
 
-def _audit_write_fingerprints(records: list[dict], apply: list[Path]) -> dict[tuple[str, str], str]:
+def _echo_invalidated_verdicts(cfg: Config, store: dict[str, Item]) -> None:
+    """Say how many STORED verdicts the current contract has retired, before exporting a
+    fresh worksheet.
+
+    The number is the point. A contract change (a rubric rewrite, a new evidence surface,
+    a re-fetched article) silently retires verdicts that were perfectly valid under the old
+    rules — they paint no badge and must be re-judged. Reporting it is the difference
+    between "the verification layer covers the corpus" and knowing how much of it actually
+    does right now.
+    """
+    invalidated, stored = count_invalidated_verdicts(store, cfg.output_language)
+    if invalidated:
+        typer.echo(
+            f"⚠️  {invalidated} de {stored} verdicts almacenados quedaron OBSOLETOS: se "
+            "juzgaron bajo otro contrato (otro output, otra fuente u otra rúbrica). No "
+            "pintan badge; hay que re-verificarlos."
+        )
+
+
+def _audit_write_fingerprints(
+    records: list[dict], apply: list[Path], stamp: str = "output_fingerprint"
+) -> dict[tuple[str, str], str]:
     """The JUDGED fingerprints for the post-audit write.
 
     The MERGED RECORDS are the authority — they are what the report being written describes,
@@ -1464,7 +1489,9 @@ def _audit_write_fingerprints(records: list[dict], apply: list[Path]) -> dict[tu
     one the record lacks. Nothing here recomputes a fingerprint from the live store — that is
     the invariant the whole plumbing exists to protect (#79).
     """
-    return cross_check_fingerprints(record_fingerprints(records), import_verify_fingerprints(apply))
+    return cross_check_fingerprints(
+        record_fingerprints(records, stamp), import_verify_fingerprints(apply, stamp)
+    )
 
 
 def _verify_audit_apply(
@@ -1502,7 +1529,12 @@ def _verify_audit_apply(
     _echo_audit_log(audit_log)
     if write_verdicts:
         _reject_unaudited_write(aggregated, audit_log)
-        _verify_write_verdicts(cfg, records, _audit_write_fingerprints(records, apply))
+        _verify_write_verdicts(
+            cfg,
+            records,
+            _audit_write_fingerprints(records, apply),
+            _audit_write_fingerprints(records, apply, "contract_fingerprint"),
+        )
     # The report is written LAST, and only once the store write has succeeded. It is the report
     # that carries `audited: True`, which the guard above reads to refuse a second audit — so
     # marking it before a write that then dies would block the retry behind `--force`, which
@@ -1636,15 +1668,18 @@ def verify_command(
         # so a verdict binds to the output the judge saw — never a live recompute. They are
         # stamped onto the records too, carrying them into verify-report.json → the audit.
         fingerprints = import_verify_fingerprints(apply)
+        contracts = import_verify_fingerprints(apply, "contract_fingerprint")
         aggregated = aggregate_verify_judgments([import_verify_judgments(path) for path in apply])
         stamp_record_fingerprints(aggregated, fingerprints)
+        stamp_record_fingerprints(aggregated, contracts, "contract_fingerprint")
         _write_verify_report(cfg, *render_verify_report(aggregated))
         if write_verdicts:
-            _verify_write_verdicts(cfg, aggregated, fingerprints)
+            _verify_write_verdicts(cfg, aggregated, fingerprints, contracts)
         return
 
     chosen = _resolve_verify_executor(executor, cfg)
     store = load_store(cfg.items_path)
+    _echo_invalidated_verdicts(cfg, store)
     pairs = items_for_verification(store, parse_targets(target))
     if not pairs:
         typer.echo("No hay outputs que verificar.")

--- a/src/xbrain/evidence.py
+++ b/src/xbrain/evidence.py
@@ -1,0 +1,218 @@
+"""What counts as EVIDENCE for a generated output — one definition, four consumers.
+
+THE PROBLEM THIS EXISTS TO KILL. Four components each need to know what may support a
+claim in a generated `summary` / `digest` / `topics`:
+
+  1. the GENERATOR — what the worksheet (or the `api` prompt) actually hands the agent
+  2. the RUBRIC    — what the judge is told may support a claim
+  3. the JUDGE     — what `verification._source_text` actually puts in front of it
+  4. the CHECKER   — what the deterministic entity-grounding check searches for a name
+
+Each used to keep its OWN hand-written list, and nothing bound them. The suite was green
+while the four contradicted one another, because every change tested only its own side.
+The contradictions were real and measured in the corpus: the judge was handed the linked
+article for a DIGEST whose generator never receives it (so it excused inventions the
+generator had no way to source), and neither generator shipped the author display name
+that the rubric promised the judge.
+
+THE INVARIANT. `evidence_surfaces(item, target)` is the single source of truth:
+
+    generator fields  ⊇  evidence_surfaces(item, target)
+    judge source      ==  evidence_surfaces(item, target)
+    checker evidence  ==  evidence_surfaces(item, target)
+    verify rubric     declares every surface it admits
+
+`tests/test_evidence_contract.py` asserts exactly that, per target, by identity against
+this module. Add a surface to one component and forget the others → red.
+
+EVIDENCE IS TARGET-DEPENDENT, and getting it wrong is a bug in BOTH directions. Judge a
+digest against the article and you excuse an invention it could not have sourced. Judge a
+summary against the digest's narrower set and you flag the generator for using evidence
+it was correctly given. So:
+
+* `digest` — the video only, plus the post it arrived in: author metadata · tweet text ·
+  video title · transcript · frame descriptions. `export_video_digest_worksheet` ships
+  exactly these. (The video TITLE is admitted deliberately: the digest worksheet has
+  always shipped it, and the judge's source carries it, so a digest that names the talk
+  is grounded, not invented.)
+* `summary` / `topics` — the same, PLUS the surfaces the enrich worksheet also ships:
+  the poster's own thread · the fetched article's title and body · the image
+  descriptions.
+
+A URL IS NOT A SURFACE. A link's URL/domain is topic signal — never a name, never
+content. It is deliberately absent from every surface set, so no name can be grounded in
+it. This is not pedantry: a summary in the corpus reconstructed a whole article — its
+publication ("Axios") and a company ("Anthropic") — out of the slug
+`axios.com/2025/05/28/ai-jobs-white-collar-unemployment-anthropic`, of a link that was
+never fetched. The judge could not flag it, because its own rubric carved the URL out of
+"unsupported". `rubric-verify.md` now says what the generator's rubric says: a domain is
+topic signal, never a name.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from xbrain.executors.api import (
+    _content_image_descriptions,
+    _video_frame_descriptions,
+    thread_text,
+)
+from xbrain.models import Item, VerifyTarget
+from xbrain.rubrics import ARTICLE_CHAR_LIMIT
+from xbrain.worksheet import _link_content_source, _video_source, _video_transcript
+
+
+@dataclass(frozen=True)
+class Surface:
+    """One labelled evidence surface present on an item.
+
+    `values` are the ATOMIC pieces of evidence — the handle and the display name, each
+    frame description, the article body. `text` is only how the JUDGE renders them.
+
+    The distinction is load-bearing. A generator ships the author's handle and display
+    name as two JSON fields and the frame descriptions as a list; the judge renders them
+    as `@handle (Name)` and as bullets. Comparing the two by their rendered text would
+    make the contract check blind to exactly the surfaces that are shipped as parts —
+    which is how the missing display name survived. The contract compares `values`.
+
+    A surface with no values is never built: an empty labelled block would tell the judge
+    evidence exists where there is none.
+    """
+
+    key: str
+    label: str
+    values: tuple[str, ...]
+
+    @property
+    def text(self) -> str:
+        """How the judge's source renders this surface."""
+        if self.key == "author":
+            handle, *rest = self.values
+            name = rest[0] if rest else ""
+            return f"@{handle} ({name})" if name else f"@{handle}"
+        if self.key in _BULLETED:
+            return "\n".join(f"- {value}" for value in self.values)
+        return "\n".join(self.values)
+
+
+# Surfaces whose evidence is a LIST of independent items; the judge reads them as bullets.
+_BULLETED = frozenset({"video_frames", "images"})
+
+
+def _author(item: Item) -> tuple[str, ...]:
+    """The handle and the display name. Empty when there is no handle — an empty
+    `[Author]` block would present a garbage anchor as trusted metadata (#92)."""
+    if not item.author.handle:
+        return ()
+    return tuple(value for value in (item.author.handle, item.author.name) if value)
+
+
+def _video_title(item: Item) -> tuple[str, ...]:
+    source = _video_source(item)
+    return (source.title,) if source and source.title else ()
+
+
+def _article_title(item: Item) -> tuple[str, ...]:
+    source = _link_content_source(item)
+    return (source.title,) if source and source.title else ()
+
+
+def _article_body(item: Item) -> tuple[str, ...]:
+    source = _link_content_source(item)
+    return (source.text[:ARTICLE_CHAR_LIMIT],) if source else ()
+
+
+def _one(value: str | None) -> tuple[str, ...]:
+    """A single-valued surface, dropped when the item has nothing there."""
+    return (value,) if value and value.strip() else ()
+
+
+# key → (judge-source label, extractor, the phrase `rubric-verify` must use to declare it).
+# The rubric phrase is part of the contract: a surface the rubric has no word for cannot
+# be bound to it, so `test_evidence_contract` requires one for every key.
+_SURFACES: dict[str, tuple[str, Callable[[Item], tuple[str, ...]], str]] = {
+    "author": ("[Author]", _author, "author metadata"),
+    "video_title": ("[Video title]", _video_title, "video title"),
+    "video_transcript": (
+        "[Video transcript]",
+        lambda item: _one(_video_transcript(item)),
+        "video transcript",
+    ),
+    "video_frames": (
+        "[Video frames shown]",
+        lambda item: tuple(_video_frame_descriptions(item)),
+        "video frame descriptions",
+    ),
+    "images": (
+        "[Images in the post]",
+        lambda item: tuple(_content_image_descriptions(item)),
+        "image descriptions",
+    ),
+    "article_title": ("[Linked article title]", _article_title, "fetched article title"),
+    "article": ("[Linked article]", _article_body, "fetched article body"),
+    "thread": (
+        "[Thread — full text, same author]",
+        lambda item: _one(thread_text(item)),
+        "poster's own thread",
+    ),
+    "tweet": ("[Tweet]", lambda item: _one(item.text), "tweet text"),
+}
+
+# The surfaces each target's GENERATOR is handed — in the order the judge reads them.
+# `digest` is the video and the post it arrived in; `summary`/`topics` add everything the
+# enrich worksheet also ships. Declared per TARGET (no item needed), because the rubric
+# binding and the contract fingerprint need the set before any item is in hand.
+_DIGEST_KEYS: tuple[str, ...] = (
+    "author",
+    "video_title",
+    "video_transcript",
+    "video_frames",
+    "tweet",
+)
+_ENRICH_KEYS: tuple[str, ...] = (
+    "author",
+    "video_title",
+    "video_transcript",
+    "video_frames",
+    "images",
+    "article_title",
+    "article",
+    "thread",
+    "tweet",
+)
+
+SURFACE_KEYS: dict[VerifyTarget, tuple[str, ...]] = {
+    "digest": _DIGEST_KEYS,
+    "summary": _ENRICH_KEYS,
+    "topics": _ENRICH_KEYS,
+}
+
+SURFACE_RUBRIC_PHRASES: dict[str, str] = {key: spec[2] for key, spec in _SURFACES.items()}
+
+
+def evidence_surfaces(item: Item, target: VerifyTarget) -> list[Surface]:
+    """The labelled surfaces that may support a claim in `item`'s `target` output.
+
+    Only surfaces the item actually carries are returned: an absent one contributes
+    nothing rather than an empty block. This is the ONE definition — the generators, the
+    judge, the rubric and the entity checker all resolve "is this evidence?" through it.
+    """
+    surfaces: list[Surface] = []
+    for key in SURFACE_KEYS[target]:
+        label, extract, _phrase = _SURFACES[key]
+        values = tuple(value for value in extract(item) if value and value.strip())
+        if values:
+            surfaces.append(Surface(key=key, label=label, values=values))
+    return surfaces
+
+
+def evidence_text(item: Item, target: VerifyTarget) -> str:
+    """Every admitted surface's text as one blob — what the deterministic entity check
+    searches when it asks "does this name appear on ANY evidence surface?".
+
+    Labels are deliberately excluded: they are the judge's scaffolding, not content, and
+    a name must be grounded in what the item SAYS, not in what we called the box.
+    """
+    return "\n".join(surface.text for surface in evidence_surfaces(item, target))

--- a/src/xbrain/executors/api.py
+++ b/src/xbrain/executors/api.py
@@ -349,7 +349,7 @@ def _user_prompt(item: Item, vocab: list[Topic]) -> str:
         "Controlled vocabulary (use only these slugs):",
         _vocab_block(vocab),
         "",
-        f"Post author: @{item.author.handle}",
+        f"Post author: @{item.author.handle} ({item.author.name})",
         f"Post text:\n{item.text}",
     ]
     if item.bookmark_folder:

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -30,7 +30,7 @@ from xbrain.models import (
     VideoFrame,
 )
 from xbrain.notes_io import DEFAULT_TAIL, note_filename, slugify, title_of, user_tail, wrap
-from xbrain.verification import ALL_TARGETS, VerifyTarget, fingerprint_output
+from xbrain.verification import ALL_TARGETS, VerifyTarget, verdict_is_current
 from xbrain.video_digest import _video_source
 
 logger = logging.getLogger(__name__)
@@ -245,8 +245,13 @@ def _verdict_badge(item: Item, target: str, strings: Strings) -> str | None:
     verdict = item.verification.get(target)
     if verdict is None or verdict.verdict not in _VERDICT_BADGE_EMOJI:
         return None
-    if fingerprint_output(item, cast(VerifyTarget, target)) != verdict.output_fingerprint:
-        return None  # stale: the judged output changed since the verdict was stored
+    if not verdict_is_current(item, cast(VerifyTarget, target), strings.language):
+        # STALE — the verdict was reached under a different contract than the one in force
+        # now: the output was re-generated, or the SOURCE the judge read changed (a frame
+        # description landed, an article got fetched), or the RUBRICS were rewritten. It
+        # says nothing about what a reader sees today, so it paints NOTHING. A verdict with
+        # no contract fingerprint at all (stored before #PR-D) is stale by construction.
+        return None
     label = strings.verify_badge_fail if verdict.verdict == "FAIL" else strings.verify_badge_review
     issue = next((flag for flag in verdict.flags if flag), None)
     suffix = f" — {' '.join(issue.splitlines())}" if issue else ""

--- a/src/xbrain/i18n.py
+++ b/src/xbrain/i18n.py
@@ -25,6 +25,8 @@ class Strings:
     suggest variance that does not exist.
     """
 
+    language: str  # the output language these strings belong to — the rubric the judge
+    # was handed is language-substituted, so the verdict's contract hash needs it (PR-D).
     topics_label: str  # "Temas" / "Topics"
     content_header: str  # "Contenido" / "Content"
     summary_header: str  # "Resumen" / "Summary"
@@ -39,6 +41,7 @@ class Strings:
 
 _STRINGS: dict[str, Strings] = {
     "English": Strings(
+        language="English",
         topics_label="Topics",
         content_header="Content",
         summary_header="Summary",
@@ -51,6 +54,7 @@ _STRINGS: dict[str, Strings] = {
         verify_badge_review="Verification: REVIEW",
     ),
     "Spanish": Strings(
+        language="Spanish",
         topics_label="Temas",
         content_header="Contenido",
         summary_header="Resumen",

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -882,6 +882,12 @@ class VerificationVerdict(BaseModel):
     faithfulness: Verdict = "PASS"
     adherence: Verdict = "PASS"
     output_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    # The FULL judging contract: the output + the source the judge read for this target +
+    # the rubrics it applied (see `verification.contract_fingerprint`). This — not
+    # `output_fingerprint` — is what decides whether a badge may paint. Optional, so a
+    # verdict stored before it existed still LOADS; None means "judged under a contract we
+    # cannot reconstruct" → permanently stale, never grandfathered in.
+    contract_fingerprint: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     verified_at: datetime
     flags: list[str] = Field(default_factory=list)
 

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -845,6 +845,12 @@ class Enrichment(BaseModel):
 # alias keeps them in lockstep and rejects a garbage value at load — see `VerificationVerdict`.
 Verdict = Literal["PASS", "REVIEW", "FAIL"]
 
+# The generated outputs a verdict can be about. It lives HERE, not in `verification`,
+# because `evidence` needs it too and evidence must not import the judge (the judge
+# imports evidence). `verification` re-exports both names, so its callers are unchanged.
+VerifyTarget = Literal["summary", "digest", "topics"]
+ALL_TARGETS: tuple[VerifyTarget, ...] = ("summary", "digest", "topics")
+
 
 class VerificationVerdict(BaseModel):
     """A stored per-target verification verdict for an item — opt-in, written by

--- a/src/xbrain/rubrics/rubric-verify.md
+++ b/src/xbrain/rubrics/rubric-verify.md
@@ -2,15 +2,41 @@
 
 You are an independent judge. You receive one generated enrichment `output` (a
 short `summary`, a long-form video `digest`, or a `topics` assignment), the
-`source` it was made from (video transcript + frame descriptions, article body,
-tweet text), and the generation `rubric` that produced it. Judge the output —
-default to SKEPTICAL.
+`source` it was made from, and the generation `rubric` that produced it. Judge the
+output — default to SKEPTICAL.
+
+## 0. The evidence surfaces — what may support a claim
+
+The `source` carries EXACTLY the surfaces the generator was handed, each under its own
+label. Nothing outside them is evidence: not your world knowledge, not recognising the
+topic, the voice or the byline, and **not a link's URL or domain**.
+
+- **`digest`** — the video and the post it arrived in:
+  the **author metadata** (`@handle` + display name) ·
+  the **tweet text** ·
+  the **video title** ·
+  the **video transcript** ·
+  the **video frame descriptions**.
+  The digest generator receives these and NOTHING else — no article, no thread, no
+  images. Never excuse a digest claim by evidence its generator never had.
+- **`summary` / `topics`** — all of the above, PLUS
+  the **poster's own thread** ·
+  the **fetched article title** ·
+  the **fetched article body** ·
+  the **image descriptions**.
+
+**A URL is topic signal — never a name and never content.** A link to `nytimes.com` does
+not license naming the publication; `axios.com/2025/05/28/ai-jobs-...-anthropic` does not
+license naming Axios, nor Anthropic, nor anything about the piece. Naming the
+publication, company, product, organisation or person a URL belongs to — when no evidence
+surface names it — is UNSUPPORTED. Flag it. The domain may hint at the TOPIC; it can
+never ground a NAME.
 
 Two axes:
 
 ## 1. Faithfulness (PRIMARY)
 Every claim, number, name, date and quote in the output MUST be supported by the
-`source`. If the output states something the source does not — a hallucinated
+evidence surfaces above. If the output states something they do not — a hallucinated
 figure, a speaker/company not present, an invented conclusion — that is a
 faithfulness failure. Cite the offending span. A single unsupported factual claim
 is enough to FAIL, regardless of how well-written the output is. When the source
@@ -35,11 +61,13 @@ faithfulness FAILURE — an invented attribution — **even when every other fac
 output is verbatim from the transcript**, and even when the output's only other
 problems are formatting ones. Do not let a clean-looking output past this check.
 
-**Content marked as never downloaded is not evidence.** When the source carries a
-`content NOT fetched` marker (a linked page, or a quoted post), any output claim
-describing that content — beyond the URL/domain itself — is unsupported. Flag it.
-The marker also appears on a PARTIAL fetch (some links fetched, some not): a
-present `[Linked article]` block is evidence only for the link it came from.
+**Content marked as never downloaded is not evidence — and neither is its URL.** When
+the source carries a `content NOT fetched` marker (a linked page, or a quoted post), ANY
+output claim describing that content is unsupported, including the name of the
+publication or company the URL points at. The link is shown so you can see what was
+*not* read, not so you can read it. Flag every claim about it. The marker also appears on
+a PARTIAL fetch (some links fetched, some not): a present `[Linked article]` block is
+evidence only for the link it came from.
 
 ## 2. Adherence (SECONDARY)
 Does the output obey its own generation `rubric`?

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -22,6 +22,7 @@ from collections import Counter
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import cast
 
@@ -104,6 +105,101 @@ def fingerprint_output(item: Item, target: VerifyTarget) -> str | None:
     if output is None:
         return None
     return hashlib.sha256(output.encode("utf-8")).hexdigest()
+
+
+# Bumped ONLY when the composition of the contract hash itself changes (not when a rubric
+# or a source changes — those are hashed). It makes the retirement of every previously
+# stored fingerprint explicit and greppable, instead of an accident of collision-freedom.
+_CONTRACT_VERSION = "xbrain-verify-contract/v1"
+
+
+@lru_cache(maxsize=None)
+def rubric_digest(target: VerifyTarget, language: str) -> str:
+    """The sha256 of BOTH rubrics the judge was handed for `target`, rendered in `language`.
+
+    The judge reads two: `rubric-verify` (how to judge) and the target's generation rubric
+    (what the output was supposed to obey — the adherence axis is judged against it). A
+    change to EITHER changes the rules the verdict was reached under, so both are hashed.
+
+    CACHED per `(target, language)`: `generate` runs the staleness check once per item over
+    thousands of notes, and the rubrics do not change inside a run. Re-reading and re-hashing
+    two files per item would make the badge check O(corpus) file I/O for no information.
+    A test that edits a rubric on disk must call `rubric_digest.cache_clear()`.
+    """
+    verify = load_rubric("verify", language=language)
+    generation = load_rubric(_TARGET_RUBRIC[target], language=language)
+    return hashlib.sha256(f"{verify}\0{generation}".encode()).hexdigest()
+
+
+def contract_fingerprint(item: Item, target: VerifyTarget, language: str) -> str | None:
+    """The sha256 binding a verdict to the FULL contract it was judged under, or None when
+    there is no output for `target`.
+
+    A verdict is not a property of the output alone: it is the result of judging THAT
+    output, against THAT source, under THOSE rubrics. `fingerprint_output` hashed only the
+    first, so #86 could rewrite what the judge reads (author metadata, thread, quoted-post
+    markers, images, titles) AND rewrite the rubrics, without touching one output
+    character — and every stored verdict still matched, still looked current, and still
+    painted its badge. Including verdicts issued under the contract that was measured
+    letting a false attribution through 8 times out of 8. A verdict that lies is the one
+    thing this layer exists to prevent.
+
+    THREE ARMS, all hashed:
+    * the OUTPUT text (`_output_for`) — the claim under judgment;
+    * the SOURCE the judge actually read for THIS target (`_source_text(item, target)`,
+      i.e. `evidence_surfaces` + the not-fetched markers) — the evidence it was checked
+      against. Target-scoped: a digest and a summary are judged against different sources;
+    * the RUBRICS (`rubric_digest`) — the rules it was checked by.
+
+    Any change to any arm changes the fingerprint, so the verdict goes stale automatically,
+    with nobody having to remember. The hash is a content hash, not a security primitive;
+    the NUL separators just keep two arms from concatenating into a third value.
+    """
+    output = _output_for(item, target)
+    if output is None:
+        return None
+    blob = "\0".join(
+        [
+            _CONTRACT_VERSION,
+            target,
+            output,
+            _source_text(item, target),
+            rubric_digest(target, language),
+        ]
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def verdict_is_current(item: Item, target: VerifyTarget, language: str) -> bool:
+    """True when the item's stored verdict for `target` was judged under the CURRENT
+    contract — the only condition under which a badge may paint.
+
+    A verdict with no `contract_fingerprint` (stored before this existed) is NOT current:
+    we cannot reconstruct what it was judged against, so we do not get to claim it still
+    holds. It is retired, not grandfathered.
+    """
+    verdict = item.verification.get(target)
+    if verdict is None or verdict.contract_fingerprint is None:
+        return False
+    return verdict.contract_fingerprint == contract_fingerprint(item, target, language)
+
+
+def count_invalidated_verdicts(store: dict[str, Item], language: str) -> tuple[int, int]:
+    """`(invalidated, total)` stored verdicts across the store, under the current contract.
+
+    The CLI reports it because the number IS the point: it says how much of the stored
+    verification a contract change has just retired, instead of letting stale verdicts keep
+    painting badges nobody re-earned.
+    """
+    invalidated = total = 0
+    for item in store.values():
+        for target in item.verification:
+            if target not in ALL_TARGETS:
+                continue
+            total += 1
+            if not verdict_is_current(item, cast(VerifyTarget, target), language):
+                invalidated += 1
+    return invalidated, total
 
 
 def _unfetched_parts(item: Item, target: VerifyTarget) -> list[str]:
@@ -198,6 +294,11 @@ def export_verify_worksheet(
                 # verdict binds to the JUDGED text, not to whatever the store holds at write
                 # time (#79). Threaded through the filled worksheet to `apply_verdicts_to_store`.
                 "output_fingerprint": fingerprint_output(item, target),
+                # The contract the judge is being handed RIGHT NOW: this output, this
+                # source, these rubrics. Threaded through the filled worksheet to the
+                # writer, so the stored verdict is bound to what was actually judged —
+                # never to a contract that changed while the judging was in flight.
+                "contract_fingerprint": contract_fingerprint(item, target, output_language),
                 "source": _source_text(item, target),
                 "generation_rubric": load_rubric(_TARGET_RUBRIC[target], language=output_language),
             }
@@ -245,16 +346,20 @@ def _fold_fingerprints(stamps: Iterable[tuple[tuple[str, str], str]]) -> dict[tu
     return fingerprints
 
 
-def _entry_stamps(entries: Iterable[object]) -> Iterator[tuple[tuple[str, str], str]]:
-    """Every valid judged-fingerprint stamp carried by `entries` (worksheet items or report
-    records — both key it the same way), skipping the missing/garbage ones."""
+def _entry_stamps(
+    entries: Iterable[object], stamp: str = "output_fingerprint"
+) -> Iterator[tuple[tuple[str, str], str]]:
+    """Every valid `stamp` carried by `entries` (worksheet items or report records — both key
+    it the same way), skipping the missing/garbage ones."""
     for entry in entries:
-        resolved = _entry_fingerprint(entry)
+        resolved = _entry_fingerprint(entry, stamp)
         if resolved is not None:
             yield resolved
 
 
-def import_verify_fingerprints(paths: list[Path]) -> dict[tuple[str, str], str]:
+def import_verify_fingerprints(
+    paths: list[Path], stamp: str = "output_fingerprint"
+) -> dict[tuple[str, str], str]:
     """Map every `(item_id, target)` to the fingerprint of the output that was JUDGED, read
     from the worksheet(s) `items` block (stamped by `export_verify_worksheet`, and carried
     through to the audit worksheet by `export_audit_worksheet`).
@@ -267,11 +372,13 @@ def import_verify_fingerprints(paths: list[Path]) -> dict[tuple[str, str], str]:
     Conflicting stamps drop the key (see `_fold_fingerprints`).
     """
     return _fold_fingerprints(
-        stamp for path in paths for stamp in _entry_stamps(_worksheet_items(path))
+        found for path in paths for found in _entry_stamps(_worksheet_items(path), stamp)
     )
 
 
-def record_fingerprints(records: Iterable[object]) -> dict[tuple[str, str], str]:
+def record_fingerprints(
+    records: Iterable[object], stamp: str = "output_fingerprint"
+) -> dict[tuple[str, str], str]:
     """The judged fingerprints carried BY the aggregated records themselves (stamped into
     `verify-report.json` by `stamp_record_fingerprints`).
 
@@ -280,7 +387,7 @@ def record_fingerprints(records: Iterable[object]) -> dict[tuple[str, str], str]
     including the ones the auditor never saw (the clean passes outside the consequential set).
     A record with no stamp, or a hand-edited one, resolves to nothing → `fingerprint-missing`.
     """
-    return _fold_fingerprints(_entry_stamps(records))
+    return _fold_fingerprints(_entry_stamps(records, stamp))
 
 
 def cross_check_fingerprints(
@@ -312,7 +419,9 @@ def cross_check_fingerprints(
 
 
 def stamp_record_fingerprints(
-    aggregated: list[dict], fingerprints: dict[tuple[str, str], str]
+    aggregated: list[dict],
+    fingerprints: dict[tuple[str, str], str],
+    stamp: str = "output_fingerprint",
 ) -> None:
     """Stamp each aggregated record with the JUDGED fingerprint of its output, in place.
 
@@ -324,7 +433,7 @@ def stamp_record_fingerprints(
     for record in aggregated:
         fingerprint = fingerprints.get((str(record.get("item_id")), str(record.get("target"))))
         if fingerprint is not None:
-            record["output_fingerprint"] = fingerprint
+            record[stamp] = fingerprint
 
 
 def _worksheet_items(path: Path) -> list:
@@ -336,16 +445,22 @@ def _worksheet_items(path: Path) -> list:
     return items if isinstance(items, list) else []
 
 
-def _entry_fingerprint(entry: object) -> tuple[tuple[str, str], str] | None:
-    """`((item_id, target), fingerprint)` for a worksheet entry carrying a valid stamped
-    fingerprint, else None (a non-dict entry or a missing/garbage hash)."""
+def _entry_fingerprint(
+    entry: object, stamp: str = "output_fingerprint"
+) -> tuple[tuple[str, str], str] | None:
+    """`((item_id, target), fingerprint)` for a worksheet entry carrying a valid `stamp`,
+    else None (a non-dict entry or a missing/garbage hash).
+
+    `stamp` selects WHICH fingerprint: `output_fingerprint` (the judged text) or
+    `contract_fingerprint` (the whole judging contract). One reader, so both stamps inherit
+    the same validation and the same fail-safe conflict handling."""
     if not isinstance(entry, dict):
         return None
-    fingerprint = entry.get("output_fingerprint")
+    fingerprint = entry.get(stamp)
     key = (str(entry.get("item_id")), str(entry.get("target")))
     if isinstance(fingerprint, str) and _FINGERPRINT_RE.match(fingerprint):
         return key, fingerprint
-    logger.debug("worksheet entry %s carries no valid output_fingerprint", key)
+    logger.debug("worksheet entry %s carries no valid %s", key, stamp)
     return None
 
 
@@ -603,7 +718,10 @@ class VerdictWriteResult:
 
 
 def _verdict_skip_reason(
-    record: object, store: dict[str, Item], fingerprints: dict[tuple[str, str], str]
+    record: object,
+    store: dict[str, Item],
+    fingerprints: dict[tuple[str, str], str],
+    contracts: dict[tuple[str, str], str],
 ) -> str | None:
     """Why this aggregated record cannot be written as a verdict, or None if it can.
 
@@ -626,16 +744,28 @@ def _verdict_skip_reason(
         return "fingerprint-missing"
     if not _FINGERPRINT_RE.match(fingerprint):
         return "fingerprint-invalid"
+    contract = contracts.get((item_id, target))
+    if contract is None:
+        # A worksheet from before the contract stamp existed. The verdict may be perfectly
+        # good, but we cannot say WHAT it was judged against — and a verdict we cannot bind
+        # to a contract is exactly the lie this closes. Skip it; re-verify to write it.
+        return "contract-missing"
+    if not _FINGERPRINT_RE.match(contract):
+        return "contract-invalid"
     return None
 
 
-def _build_verdict(record: dict, output_fingerprint: str) -> VerificationVerdict:
-    """Assemble one `VerificationVerdict` from an aggregated record + its JUDGED fingerprint."""
+def _build_verdict(
+    record: dict, output_fingerprint: str, contract_fingerprint_: str
+) -> VerificationVerdict:
+    """Assemble one `VerificationVerdict` from an aggregated record + the JUDGED fingerprints:
+    the output the judges read, and the CONTRACT they judged it under."""
     return VerificationVerdict(
         verdict=cast(Verdict, _verdict_of(record, "verdict")),
         faithfulness=_axis(record.get("faithfulness")),
         adherence=_axis(record.get("adherence")),
         output_fingerprint=output_fingerprint,
+        contract_fingerprint=contract_fingerprint_,
         verified_at=datetime.now(timezone.utc),
         flags=_flag_issues(record.get("flags") or []),
     )
@@ -661,6 +791,7 @@ def apply_verdicts_to_store(
     store: dict[str, Item],
     aggregated: list[dict],
     fingerprints: dict[tuple[str, str], str],
+    contracts: dict[tuple[str, str], str],
 ) -> VerdictWriteResult:
     """Persist each aggregated verdict onto its item as a `VerificationVerdict`, keyed by
     target, storing the JUDGED output fingerprint from `fingerprints` (opt-in
@@ -684,14 +815,14 @@ def apply_verdicts_to_store(
     written = 0
     skipped: list[tuple[str, str, str]] = []
     for record in aggregated:
-        reason = _verdict_skip_reason(record, store, fingerprints)
+        reason = _verdict_skip_reason(record, store, fingerprints, contracts)
         if reason is not None:
             as_dict = record if isinstance(record, dict) else {}
             skipped.append((str(as_dict.get("item_id")), str(as_dict.get("target")), reason))
             continue
         item_id, target = str(record["item_id"]), str(record["target"])
         store[item_id].verification[target] = _build_verdict(
-            record, fingerprints[(item_id, target)]
+            record, fingerprints[(item_id, target)], contracts[(item_id, target)]
         )
         written += 1
     return VerdictWriteResult(written=written, skipped=skipped)

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -23,25 +23,23 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal, cast
+from typing import cast
 
+from xbrain.evidence import evidence_surfaces
 from xbrain.executors.api import (
     QUOTED_CONTENT_UNFETCHED_NOTE,
-    _content_image_descriptions,
-    _video_frame_descriptions,
     quoted_content_unfetched,
-    thread_text,
     unfetched_links_note,
 )
-from xbrain.models import Item, Verdict, VerificationVerdict
-from xbrain.rubrics import ARTICLE_CHAR_LIMIT, load_rubric
+from xbrain.models import ALL_TARGETS, Item, Verdict, VerificationVerdict, VerifyTarget
+from xbrain.rubrics import load_rubric
 from xbrain.video_digest import _video_source
-from xbrain.worksheet import _link_content_source, _video_transcript
 
 logger = logging.getLogger(__name__)
 
-VerifyTarget = Literal["summary", "digest", "topics"]
-ALL_TARGETS: tuple[VerifyTarget, ...] = ("summary", "digest", "topics")
+# Re-exported from `models` so every existing caller (`generate`, `verification_audit`,
+# the entity checker) keeps importing them from here.
+__all__ = ["ALL_TARGETS", "VerifyTarget"]
 
 # A stored/exported output fingerprint is a lowercase-hex sha256 (see `fingerprint_output`);
 # anything else in a filled worksheet is hand-edited garbage and is rejected, not trusted.
@@ -108,42 +106,19 @@ def fingerprint_output(item: Item, target: VerifyTarget) -> str | None:
     return hashlib.sha256(output.encode("utf-8")).hexdigest()
 
 
-def _video_parts(item: Item) -> list[str]:
-    """The video evidence: its title, the FULL transcript (what it says) and the frame
-    descriptions (what it shows). The title reaches the digest generator, so the judge
-    must see it too — a digest naming the talk is otherwise unsupported."""
-    source = _video_source(item)
-    parts: list[str] = []
-    if source and source.title:
-        parts += ["[Video title]", source.title]
-    transcript = _video_transcript(item)
-    if transcript:
-        parts += ["[Video transcript]", transcript]
-    frames = _video_frame_descriptions(item)
-    if frames:
-        parts += ["[Video frames shown]", *(f"- {description}" for description in frames)]
-    return parts
-
-
-def _article_parts(item: Item) -> list[str]:
-    """The fetched LINKED article, with its title (which the api prompt already ships).
-
-    Only `LINK_CONTENT_KINDS` reach this label. A thread or a transcript under it would
-    tell the judge a page was downloaded when none was, and hand it the wrong text as
-    that page's content.
-    """
-    source = _link_content_source(item)
-    if source is None:
-        return []
-    label = f"[Linked article — {source.title}]" if source.title else "[Linked article]"
-    return [label, source.text[:ARTICLE_CHAR_LIMIT]]
-
-
-def _unfetched_parts(item: Item) -> list[str]:
+def _unfetched_parts(item: Item, target: VerifyTarget) -> list[str]:
     """The markers for content the pipeline never downloaded: links whose body is
     missing (all of them, or the remainder of a PARTIAL fetch) and a quoted post, which
     no fetcher retrieves. An output describing either is then checkable as unsupported
-    instead of being waved through against evidence that is not there."""
+    instead of being waved through against evidence that is not there.
+
+    Only for the ENRICH targets. The digest generator is never handed the links or the
+    quote — `export_video_digest_worksheet` ships the video and the post — so there is
+    nothing to guard, and a marker listing URLs would put a domain in front of a judge
+    whose generator never saw one.
+    """
+    if target == "digest":
+        return []
     parts: list[str] = []
     links_note = unfetched_links_note(item)
     if links_note:
@@ -157,41 +132,27 @@ def _unfetched_parts(item: Item) -> list[str]:
     return parts
 
 
-def _source_text(item: Item) -> str:
-    """The ground-truth source the judge checks the output against.
+def _source_text(item: Item, target: VerifyTarget) -> str:
+    """The ground-truth source the judge checks `target`'s output against.
 
-    Concatenates the labelled evidence present on the item — the author metadata (WHO
-    POSTED it, not who wrote its content), the video title + FULL transcript (what it
-    says) + frame descriptions (what it shows), the image descriptions, the fetched
-    article body, the poster's own thread text, and the tweet text — so a claim in the
-    output can be traced to it. The judge must see everything the GENERATORS see: an
-    output grounded in a photo description or an article title would otherwise be
-    judged against a source that never held it, and flagged unsupported (a false FAIL).
+    It is EXACTLY `evidence_surfaces(item, target)` — the one definition the generators,
+    the rubric and the entity checker also read (see `xbrain.evidence`) — plus the
+    markers for content nobody downloaded. The judge therefore sees neither less nor more
+    than the generator was handed:
 
-    Every kind of evidence keeps its OWN label. A thread is the poster's own words, not
-    a fetched page. Serving one under `[Linked article]` would affirmatively tell the
-    skeptical judge that a link was downloaded and hand it text that is not that link's
-    content — turning an unsupported claim about the linked piece into a PASS. Content
-    the pipeline never downloaded (a link's body, a quoted post) is marked as such.
+    * LESS would flag a claim the generator was entitled to make (the 36+ false
+      author-attribution flags that started this).
+    * MORE would excuse an invention the generator could not have sourced — which is what
+      a target-BLIND source did: it handed the linked article, the thread and the images
+      to the judge of a DIGEST, whose generator receives none of them.
+
+    Every surface keeps its own label, so a thread is never read as a fetched page and a
+    transcript is never read as an article.
     """
     parts: list[str] = []
-    # No handle, no block. The rubric tells the judge the `[Author]` block is TRUSTED
-    # metadata, so an empty one (`[Author]\n@ ()`) would present a garbage anchor as
-    # trustworthy. Omitting it is the strict direction: with no author in the source,
-    # the judge has nobody to attribute anything to.
-    if item.author.handle:
-        parts += ["[Author]", f"@{item.author.handle} ({item.author.name})"]
-    parts += _video_parts(item)
-    images = _content_image_descriptions(item)
-    if images:
-        parts += ["[Images in the post]", *(f"- {description}" for description in images)]
-    parts += _article_parts(item)
-    thread = thread_text(item)
-    if thread:
-        parts += ["[Thread — full text, same author]", thread]
-    parts += _unfetched_parts(item)
-    if item.text:
-        parts += ["[Tweet]", item.text]
+    for surface in evidence_surfaces(item, target):
+        parts += [surface.label, surface.text]
+    parts += _unfetched_parts(item, target)
     return "\n".join(parts)
 
 
@@ -237,7 +198,7 @@ def export_verify_worksheet(
                 # verdict binds to the JUDGED text, not to whatever the store holds at write
                 # time (#79). Threaded through the filled worksheet to `apply_verdicts_to_store`.
                 "output_fingerprint": fingerprint_output(item, target),
-                "source": _source_text(item),
+                "source": _source_text(item, target),
                 "generation_rubric": load_rubric(_TARGET_RUBRIC[target], language=output_language),
             }
             for item, target in pairs

--- a/src/xbrain/verification_audit.py
+++ b/src/xbrain/verification_audit.py
@@ -129,7 +129,7 @@ def export_audit_worksheet(
                 "author": item.author.handle,
                 "output": _output_for(item, target),
                 "output_fingerprint": record.get("output_fingerprint"),
-                "source": _source_text(item),
+                "source": _source_text(item, target),
                 "current_verdict": record.get("verdict"),
                 "faithfulness": record.get("faithfulness"),
                 "adherence": record.get("adherence"),

--- a/src/xbrain/video_digest.py
+++ b/src/xbrain/video_digest.py
@@ -20,17 +20,7 @@ from pathlib import Path
 from xbrain.executors.api import _video_frame_descriptions
 from xbrain.models import ContentSourceSuccess, Item
 from xbrain.rubrics import load_rubric
-from xbrain.worksheet import _video_transcript
-
-
-def _video_source(item: Item) -> ContentSourceSuccess | None:
-    """The item's first `x_video` content source, or None when it has none."""
-    if item.content is None:
-        return None
-    for source in item.content.sources:
-        if isinstance(source, ContentSourceSuccess) and source.kind == "x_video":
-            return source
-    return None
+from xbrain.worksheet import _video_source, _video_transcript
 
 
 def _has_digestible_content(source: ContentSourceSuccess) -> bool:
@@ -95,6 +85,9 @@ def export_video_digest_worksheet(
             {
                 "item_id": item.id,
                 "author": item.author.handle,
+                # Evidence, not decoration: the rubric promises the judge "@handle +
+                # display name", so the generator must be handed it too (D6).
+                "author_name": item.author.name,
                 "text": item.text,
                 "title": (source.title if (source := _video_source(item)) else None),
                 "video_transcript": _video_transcript(item),

--- a/src/xbrain/worksheet.py
+++ b/src/xbrain/worksheet.py
@@ -44,42 +44,50 @@ def _link_content_source(item: Item) -> ContentSourceSuccess | None:
     return None
 
 
-def _article_title(item: Item) -> str | None:
-    """The FETCHED linked article's title, or None.
+def _article_text(item: Item) -> str | None:
+    """First successfully-fetched LINKED article body, truncated, or None."""
+    return first_source_text(item, LINK_CONTENT_KINDS)
 
-    The summary rubric declares "the fetched article body and its title" as evidence, the
-    api prompt ships it and the judge's `_source_text` ships it — but the worksheet track,
-    the one that actually runs, shipped the body alone. The rubric was naming a surface the
-    running generator never received. Cost, measured: 8 summaries flagged ungrounded for a
-    name that sits in the article's TITLE.
+
+def _article_title(item: Item) -> str | None:
+    """The FETCHED linked article's title, or None — its own evidence surface.
+
+    The summary rubric declares "the fetched article body and its title" as evidence, and
+    the judge's `_source_text` ships it — but the worksheet track, the one that actually
+    runs, shipped the body alone. The rubric was naming a surface the running generator
+    never received. Cost, measured: 8 summaries flagged ungrounded for a name that sits in
+    the article's TITLE.
     """
-    if not item.content:
+    source = _link_content_source(item)
+    return source.title if source else None
+
+
+def _video_source(item: Item) -> ContentSourceSuccess | None:
+    """The item's first `x_video` content source, or None when it has none.
+
+    Lives here, with the other source readers, because `video_digest` imports this module
+    — defining it there and reading it here would make the two import each other.
+    `video_digest` re-exports it, so every existing `from xbrain.video_digest import
+    _video_source` keeps working.
+    """
+    if item.content is None:
         return None
     for source in item.content.sources:
-        if isinstance(source, ContentSourceSuccess) and source.kind in LINK_CONTENT_KINDS:
-            return source.title
+        if isinstance(source, ContentSourceSuccess) and source.kind == "x_video":
+            return source
     return None
 
 
 def _video_title(item: Item) -> str | None:
-    """The `x_video` source's title, or None.
+    """The `x_video` source's title, or None — an evidence surface for BOTH targets.
 
-    The judge's `_source_text` carries `[Video title]` (#86), and the summary rubric
-    admits it as evidence — so the generator must be handed it too, or the rubric names a
-    surface the generator was never given. Defined locally: importing `video_digest`
-    would be circular (it imports `_video_transcript` from here).
+    The digest worksheet has shipped it since #44 and the judge reads it since #86; the
+    enrich track was the odd one out, so the rubric named a surface its generator never
+    received. (Reading it through `_video_source`, which lives here now — the circular
+    import that once forced a hand-rolled copy is gone.)
     """
-    if not item.content:
-        return None
-    for source in item.content.sources:
-        if isinstance(source, ContentSourceSuccess) and source.kind == "x_video":
-            return source.title
-    return None
-
-
-def _article_text(item: Item) -> str | None:
-    """First successfully-fetched LINKED article body, truncated, or None."""
-    return first_source_text(item, LINK_CONTENT_KINDS)
+    source = _video_source(item)
+    return source.title if source else None
 
 
 def _video_transcript(item: Item) -> str | None:
@@ -152,8 +160,10 @@ def export_worksheet(
                 "text": it.text,
                 "bookmark_folder": it.bookmark_folder,
                 "links": [{"url": ln.url, "domain": ln.domain} for ln in it.links],
-                "article": _article_text(it),
+                # The article's TITLE is its own evidence surface: a summary naming the
+                # publication is grounded in the title, never in the link's domain.
                 "article_title": _article_title(it),
+                "article": _article_text(it),
                 # The poster's OWN expanded thread — real signal, but NOT a fetched
                 # linked page. It ships in its own field so the agent never reads the
                 # author's own words as the body of an article nobody downloaded.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3592,3 +3592,79 @@ def test_verify_audit_write_verdicts_drops_a_record_whose_worksheet_stamp_was_ta
             written=1, skipped=[("7", "summary", "fingerprint-missing")]
         ).summary()
     )
+
+
+# ---------------------------------------------------------------- PR-D: the contract fingerprint
+
+
+def test_verify_write_verdicts_stores_the_contract_it_was_judged_under(tmp_path: Path, monkeypatch):
+    """The verdict binds to the whole judging contract — the output, the source the judge
+    read, and the rubrics it applied — not just to the output text."""
+    from xbrain.store import load_store
+    from xbrain.verification import contract_fingerprint
+
+    _setup_repo(tmp_path, monkeypatch)
+    items_path = tmp_path / "data" / "items.json"
+    item = _verify_video_item("7")
+    save_store({"7": item}, items_path)
+    ws = _export_summary_worksheet(tmp_path)
+    _fill_summary_judgment(ws)
+
+    result = runner.invoke(app, ["verify", "--apply", str(ws), "--write-verdicts"])
+    assert result.exit_code == 0, result.output
+
+    stored = load_store(items_path)["7"].verification["summary"]
+    assert stored.contract_fingerprint == contract_fingerprint(item, "summary", "English")
+
+
+def test_verify_reports_how_many_verdicts_the_contract_change_invalidated(
+    tmp_path: Path, monkeypatch
+):
+    """The number IS the point: it says how much of the stored verification a contract
+    change has retired. A verdict stored under the old contract (no contract fingerprint)
+    is counted, never silently kept alive."""
+    from xbrain.models import VerificationVerdict
+    from xbrain.verification import fingerprint_output
+
+    _setup_repo(tmp_path, monkeypatch)
+    items_path = tmp_path / "data" / "items.json"
+    item = _verify_video_item("7")
+    item.verification["summary"] = VerificationVerdict(
+        verdict="FAIL",
+        faithfulness="FAIL",
+        output_fingerprint=fingerprint_output(item, "summary"),
+        verified_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        flags=["unsupported"],
+    )  # judged under the OLD contract: no contract fingerprint
+    save_store({"7": item}, items_path)
+
+    result = runner.invoke(app, ["verify"])
+    assert result.exit_code == 0, result.output
+    assert "OBSOLETOS" in result.stdout
+    assert "1 de 1" in result.stdout
+
+
+def test_verify_refuses_to_write_a_verdict_from_a_pre_contract_worksheet(
+    tmp_path: Path, monkeypatch
+):
+    """A worksheet judged before the contract stamp existed cannot say WHAT its verdict was
+    judged against. It is skipped (`contract-missing`), never written with a guessed
+    contract — the exact lie this closes."""
+    from xbrain.store import load_store
+
+    _setup_repo(tmp_path, monkeypatch)
+    items_path = tmp_path / "data" / "items.json"
+    save_store({"7": _verify_video_item("7")}, items_path)
+    ws = _export_summary_worksheet(tmp_path)
+    _fill_summary_judgment(ws)
+
+    # Strip the contract stamp: this is what a worksheet exported by the old code looks like.
+    data = json.loads(ws.read_text(encoding="utf-8"))
+    for entry in data["items"]:
+        entry.pop("contract_fingerprint", None)
+    ws.write_text(json.dumps(data), encoding="utf-8")
+
+    result = runner.invoke(app, ["verify", "--apply", str(ws), "--write-verdicts"])
+    assert result.exit_code == 0, result.output
+    assert "contract-missing" in result.stdout
+    assert "summary" not in load_store(items_path)["7"].verification  # nothing written

--- a/tests/test_contract_fingerprint.py
+++ b/tests/test_contract_fingerprint.py
@@ -1,0 +1,205 @@
+# tests/test_contract_fingerprint.py
+"""A verdict binds to the CONTRACT it was judged under — not just to the output text.
+
+A verdict is not a property of the output alone. It is the result of judging THAT output
+against THAT source under THAT rubric. `fingerprint_output` hashed only the output, so
+#86 could change what the judge reads (author metadata, thread, quoted-post markers,
+images, titles) and rewrite `rubric-verify.md` + `rubric-summary.md` — **without touching
+a single output character** — and every stored verdict still matched, still looked
+current, and still painted its badge. Including the verdicts issued under the contract
+that was measured letting a false attribution through 8 times out of 8.
+
+`fingerprint_contract` binds all three arms. Each arm gets a test here: change the
+output → stale; change the source → stale; change the rubric → stale; change nothing →
+fresh, and the badge paints.
+"""
+
+from datetime import datetime, timezone
+
+
+from xbrain.models import (
+    Author,
+    Content,
+    ContentSourceSuccess,
+    Enrichment,
+    Item,
+    VerificationVerdict,
+    VideoFrame,
+)
+from xbrain.verification import (
+    contract_fingerprint,
+    count_invalidated_verdicts,
+    fingerprint_output,
+    rubric_digest,
+)
+
+
+def _item(*, summary: str = "A crisp summary.", frames: tuple[str, ...] = ("A chart.",)) -> Item:
+    return Item(
+        id="7",
+        source="bookmark",
+        url="https://x.com/a/status/7",
+        author=Author(handle="a", name="A"),
+        text="watch this",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        enriched=Enrichment(
+            enriched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+            executor="claude-code",
+            summary=summary,
+            primary_topic="ai-coding",
+            topics=["ai-coding"],
+        ),
+        content=Content(
+            fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video",
+                    url="https://x.com/v",
+                    title="A talk",
+                    text="the transcript body",
+                    has_speech=True,
+                    frames=[
+                        VideoFrame(
+                            timestamp=float(i), local_path=f"7/frames/{i}.png", description=d
+                        )
+                        for i, d in enumerate(frames)
+                    ],
+                    digest="A long digest.",
+                )
+            ],
+        ),
+    )
+
+
+# ------------------------------------------------------------------ the three arms
+
+
+def test_the_fingerprint_changes_when_the_OUTPUT_changes():
+    before = contract_fingerprint(_item(), "summary", "English")
+    after = contract_fingerprint(_item(summary="A different summary."), "summary", "English")
+    assert before is not None and before != after
+
+
+def test_the_fingerprint_changes_when_the_SOURCE_changes():
+    """The judge read a source. Enrich adds a frame description, `describe` adds an image,
+    a fetch lands the article — the output is untouched, but what supports it is not the
+    same evidence any more. The verdict must not survive that."""
+    before = contract_fingerprint(_item(), "summary", "English")
+    after = contract_fingerprint(_item(frames=("A chart.", "A new slide.")), "summary", "English")
+    assert before is not None and before != after
+
+
+def test_the_fingerprint_changes_when_the_RUBRIC_changes(tmp_path, monkeypatch):
+    """The rules the judge applied are part of the verdict. #86 rewrote them and every
+    stored verdict still matched — this is the arm that closes that."""
+    from xbrain import rubrics as rubrics_mod
+
+    before = contract_fingerprint(_item(), "summary", "English")
+
+    original = rubrics_mod._RUBRICS_DIR
+    shadow = tmp_path / "rubrics"
+    shadow.mkdir()
+    for rubric in original.glob("*.md"):
+        shadow.joinpath(rubric.name).write_text(
+            rubric.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    verify = shadow / "rubric-verify.md"
+    verify.write_text(verify.read_text(encoding="utf-8") + "\nA NEW RULE.\n", encoding="utf-8")
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", shadow)
+    rubric_digest.cache_clear()  # the digest is cached per run; a rubric edit must invalidate
+
+    after = contract_fingerprint(_item(), "summary", "English")
+    rubric_digest.cache_clear()
+    assert before is not None and before != after
+
+
+def test_the_fingerprint_is_stable_when_NOTHING_changes():
+    """The negative arm: a hash that changed on every call would invalidate everything and
+    teach the reader to ignore the badge."""
+    assert contract_fingerprint(_item(), "summary", "English") == contract_fingerprint(
+        _item(), "summary", "English"
+    )
+
+
+def test_each_target_gets_its_own_contract():
+    """A digest is judged against a different source AND a different generation rubric than
+    a summary, so their contracts cannot collide."""
+    item = _item()
+    assert contract_fingerprint(item, "summary", "English") != contract_fingerprint(
+        item, "digest", "English"
+    )
+
+
+def test_the_language_is_part_of_the_contract():
+    """The rubric is language-substituted; a judge given the Spanish rubric applied a
+    different text."""
+    assert contract_fingerprint(_item(), "summary", "English") != contract_fingerprint(
+        _item(), "summary", "Spanish"
+    )
+
+
+def test_no_output_no_fingerprint():
+    item = _item()
+    item.enriched = None
+    assert contract_fingerprint(item, "summary", "English") is None
+
+
+def test_the_contract_hash_is_not_the_output_hash():
+    """Guard against a refactor collapsing the two: the whole defect was a fingerprint that
+    saw only the output."""
+    item = _item()
+    assert contract_fingerprint(item, "summary", "English") != fingerprint_output(item, "summary")
+
+
+# ------------------------------------------------------------------ migration
+
+
+def _verdict(contract: str | None) -> VerificationVerdict:
+    return VerificationVerdict(
+        verdict="FAIL",
+        faithfulness="FAIL",
+        output_fingerprint="a" * 64,
+        contract_fingerprint=contract,
+        verified_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        flags=["unsupported"],
+    )
+
+
+def test_a_legacy_verdict_loads_and_is_stale():
+    """Every verdict stored before this change was judged under the OLD contract. It must
+    load (never crash on the old shape), and it must evaluate STALE — not be grandfathered
+    in, because we cannot honestly say what it was judged against."""
+    legacy = VerificationVerdict.model_validate(
+        {
+            "verdict": "FAIL",
+            "faithfulness": "FAIL",
+            "adherence": "PASS",
+            "output_fingerprint": "b" * 64,
+            "verified_at": "2026-06-01T00:00:00Z",
+            "flags": ["unsupported"],
+        }
+    )
+    assert legacy.contract_fingerprint is None  # the old shape carries none
+
+
+def test_count_invalidated_verdicts_counts_every_stale_stored_verdict():
+    """The CLI reports the number, because the number IS the point: it says how much of the
+    stored verification the contract change just retired."""
+    fresh_item = _item()
+    fresh = _verdict(contract_fingerprint(fresh_item, "summary", "English"))
+    fresh_item.verification["summary"] = fresh
+
+    legacy_item = _item()
+    legacy_item.id = "8"
+    legacy_item.verification["summary"] = _verdict(None)  # judged under the old contract
+
+    changed_item = _item(summary="regenerated since it was judged")
+    changed_item.id = "9"
+    changed_item.verification["summary"] = _verdict(
+        contract_fingerprint(_item(), "summary", "English")
+    )
+
+    store = {"7": fresh_item, "8": legacy_item, "9": changed_item}
+    invalidated, total = count_invalidated_verdicts(store, "English")
+    assert (invalidated, total) == (2, 3)

--- a/tests/test_contract_fingerprint.py
+++ b/tests/test_contract_fingerprint.py
@@ -90,28 +90,60 @@ def test_the_fingerprint_changes_when_the_SOURCE_changes():
     assert before is not None and before != after
 
 
-def test_the_fingerprint_changes_when_the_RUBRIC_changes(tmp_path, monkeypatch):
-    """The rules the judge applied are part of the verdict. #86 rewrote them and every
-    stored verdict still matched — this is the arm that closes that."""
+def _shadow_rubrics(tmp_path, monkeypatch, edited: str) -> None:
+    """Copy the rubrics to a temp dir, append a line to `edited`, and point the loader there.
+
+    The digest is cached per run (the rubrics do not change mid-run), so an on-disk edit must
+    clear it — exactly what a test has to do and production never does.
+    """
     from xbrain import rubrics as rubrics_mod
 
-    before = contract_fingerprint(_item(), "summary", "English")
-
-    original = rubrics_mod._RUBRICS_DIR
     shadow = tmp_path / "rubrics"
     shadow.mkdir()
-    for rubric in original.glob("*.md"):
+    for rubric in rubrics_mod._RUBRICS_DIR.glob("*.md"):
         shadow.joinpath(rubric.name).write_text(
             rubric.read_text(encoding="utf-8"), encoding="utf-8"
         )
-    verify = shadow / "rubric-verify.md"
-    verify.write_text(verify.read_text(encoding="utf-8") + "\nA NEW RULE.\n", encoding="utf-8")
+    target = shadow / edited
+    target.write_text(target.read_text(encoding="utf-8") + "\nA NEW RULE.\n", encoding="utf-8")
     monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", shadow)
-    rubric_digest.cache_clear()  # the digest is cached per run; a rubric edit must invalidate
+    rubric_digest.cache_clear()
 
+
+def test_the_fingerprint_changes_when_the_JUDGE_RUBRIC_changes(tmp_path, monkeypatch):
+    """The rules the judge applied are part of the verdict. #86 rewrote `rubric-verify.md`
+    and every stored verdict still matched — this is the arm that closes that."""
+    before = contract_fingerprint(_item(), "summary", "English")
+    _shadow_rubrics(tmp_path, monkeypatch, "rubric-verify.md")
     after = contract_fingerprint(_item(), "summary", "English")
     rubric_digest.cache_clear()
     assert before is not None and before != after
+
+
+def test_the_fingerprint_changes_when_the_GENERATION_RUBRIC_changes(tmp_path, monkeypatch):
+    """The judge reads TWO rubrics: how to judge (`rubric-verify`) and what the output was
+    supposed to obey (the target's generation rubric — the adherence axis is judged against
+    it, and #91 rewrote exactly that one). Hashing only the judge's rubric would let a
+    generation-rubric rewrite leave every adherence verdict standing."""
+    before = contract_fingerprint(_item(), "summary", "English")
+    _shadow_rubrics(tmp_path, monkeypatch, "rubric-summary.md")
+    after = contract_fingerprint(_item(), "summary", "English")
+    rubric_digest.cache_clear()
+    assert before is not None and before != after
+
+
+def test_a_generation_rubric_only_invalidates_ITS_target(tmp_path, monkeypatch):
+    """A rewrite of `rubric-video-digest` retires the DIGEST verdicts, not the summaries —
+    or every rubric edit would invalidate the whole corpus and the badge would mean nothing."""
+    item = _item()
+    summary_before = contract_fingerprint(item, "summary", "English")
+    digest_before = contract_fingerprint(item, "digest", "English")
+    _shadow_rubrics(tmp_path, monkeypatch, "rubric-video-digest.md")
+    summary_after = contract_fingerprint(item, "summary", "English")
+    digest_after = contract_fingerprint(item, "digest", "English")
+    rubric_digest.cache_clear()
+    assert digest_before != digest_after  # the digest's rules changed
+    assert summary_before == summary_after  # the summary's did not
 
 
 def test_the_fingerprint_is_stable_when_NOTHING_changes():
@@ -129,6 +161,33 @@ def test_each_target_gets_its_own_contract():
     assert contract_fingerprint(item, "summary", "English") != contract_fingerprint(
         item, "digest", "English"
     )
+
+
+def test_the_target_itself_separates_two_otherwise_identical_contracts(monkeypatch):
+    """The TARGET is hashed in its own right, not merely implied by the generation rubric.
+
+    Today each target happens to have a distinct rubric and a distinct output, so the target
+    arm looks redundant — a mutation dropping it survives every other test. It is not
+    redundant: it is what stops a verdict crossing targets if two of them ever share a
+    generation rubric. Pinned by making that world exist — same output, same source, same
+    rubric — so ONLY the target differs.
+    """
+    from xbrain import verification
+
+    item = _item()
+    item.content.sources[0].digest = item.enriched.summary  # same OUTPUT for both targets
+    monkeypatch.setitem(verification._TARGET_RUBRIC, "digest", "summary")  # same RUBRIC
+    rubric_digest.cache_clear()
+    try:
+        # This item carries no article/thread/images, so the two targets' SOURCES coincide too.
+        assert verification._source_text(item, "summary") == verification._source_text(
+            item, "digest"
+        )
+        assert contract_fingerprint(item, "summary", "English") != contract_fingerprint(
+            item, "digest", "English"
+        )
+    finally:
+        rubric_digest.cache_clear()
 
 
 def test_the_language_is_part_of_the_contract():

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -1,0 +1,170 @@
+# tests/test_evidence.py
+"""The ONE definition of what counts as evidence — its own spec.
+
+The cross-component binding (generator ⊇ rubric == judge == checker) lives in
+`test_evidence_contract.py`. This file pins the function itself: which surfaces each
+target admits, and that an absent surface contributes nothing.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from xbrain.evidence import SURFACE_KEYS, evidence_surfaces, evidence_text
+from xbrain.models import (
+    Author,
+    Content,
+    ContentSourceSuccess,
+    Item,
+    Link,
+    MediaPhotoDescribed,
+    VideoFrame,
+)
+
+
+def _item(*, video: bool = True, article: bool = True, thread: bool = True) -> Item:
+    sources: list[ContentSourceSuccess] = []
+    if video:
+        sources.append(
+            ContentSourceSuccess(
+                kind="x_video",
+                url="https://x.com/v",
+                title="The scaling-laws talk",
+                text="the transcript body",
+                has_speech=True,
+                frames=[
+                    VideoFrame(timestamp=0.0, local_path="7/frames/0.png", description="A chart.")
+                ],
+            )
+        )
+    if article:
+        sources.append(
+            ContentSourceSuccess(
+                kind="external_article",
+                url="https://example.com/a",
+                title="The TIME piece",
+                text="the fetched article body",
+            )
+        )
+    if thread:
+        sources.append(
+            ContentSourceSuccess(
+                kind="thread",
+                url="https://x.com/a/status/7",
+                text="1/ the poster's own thread",
+            )
+        )
+    return Item(
+        id="7",
+        source="bookmark",
+        url="https://x.com/a/status/7",
+        author=Author(handle="emollick", name="Ethan Mollick"),
+        text="watch this",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url="https://example.com/a", domain="example.com")],
+        media=[
+            MediaPhotoDescribed(
+                url="https://pbs.twimg.com/media/X.jpg",
+                local_path="7/0.jpg",
+                width=4,
+                height=3,
+                bytes_size=512,
+                downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+                is_decorative=False,
+                description="A bar chart of GPU prices.",
+                description_lang="English",
+                description_version="v1",
+                described_at=datetime(2026, 5, 24, 12, tzinfo=timezone.utc),
+            )
+        ],
+        content=Content(fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc), sources=sources),
+    )
+
+
+# What each target's GENERATOR is actually handed — the whole point of the module.
+DIGEST_KEYS = ("author", "video_title", "video_transcript", "video_frames", "tweet")
+ENRICH_KEYS = DIGEST_KEYS + ("images", "article_title", "article", "thread")
+
+
+def test_digest_evidence_is_the_video_and_the_post_only():
+    """`export_video_digest_worksheet` hands the digest generator the transcript, the
+    frames, the video title, the author and the tweet text — and NOTHING else. The
+    article, the thread and the images are not on that worksheet, so they cannot be
+    evidence for a digest: judging a digest against them excuses an invention the
+    generator had no way to source."""
+    keys = [s.key for s in evidence_surfaces(_item(), "digest")]
+    assert set(keys) == set(DIGEST_KEYS)
+    assert "article" not in keys
+    assert "thread" not in keys
+    assert "images" not in keys
+
+
+@pytest.mark.parametrize("target", ["summary", "topics"])
+def test_enrich_evidence_adds_what_the_enrich_worksheet_ships(target):
+    """The enrich worksheet DOES ship the article, the thread and the image
+    descriptions, and its rubric says to summarise the article's substance — so for a
+    summary they are evidence. Checking a summary against the digest's narrower set
+    would flag the generator for using evidence it was correctly given."""
+    keys = {s.key for s in evidence_surfaces(_item(), target)}
+    assert keys == set(ENRICH_KEYS)
+
+
+def test_surface_keys_are_declared_per_target_without_an_item():
+    """The declared set is a property of the TARGET, not of one item — the fingerprint
+    (PR-D) and the rubric binding need it before any item is in hand."""
+    assert set(SURFACE_KEYS["digest"]) == set(DIGEST_KEYS)
+    assert set(SURFACE_KEYS["summary"]) == set(ENRICH_KEYS)
+    assert SURFACE_KEYS["summary"] == SURFACE_KEYS["topics"]
+
+
+def test_surfaces_carry_the_items_text_under_a_label():
+    surfaces = {s.key: s for s in evidence_surfaces(_item(), "summary")}
+    assert surfaces["author"].text == "@emollick (Ethan Mollick)"
+    assert surfaces["video_title"].text == "The scaling-laws talk"
+    assert surfaces["video_transcript"].text == "the transcript body"
+    assert "A chart." in surfaces["video_frames"].text
+    assert surfaces["article_title"].text == "The TIME piece"
+    assert surfaces["article"].text == "the fetched article body"
+    assert surfaces["thread"].text == "1/ the poster's own thread"
+    assert "A bar chart of GPU prices." in surfaces["images"].text
+    assert surfaces["tweet"].text == "watch this"
+    assert surfaces["video_transcript"].label == "[Video transcript]"
+
+
+def test_an_absent_surface_is_omitted_entirely():
+    """No video, no article, no thread → those surfaces do not appear at all. An empty
+    labelled block would tell the judge evidence exists where there is none."""
+    item = _item(video=False, article=False, thread=False)
+    keys = {s.key for s in evidence_surfaces(item, "summary")}
+    assert keys == {"author", "tweet", "images"}
+
+
+def test_a_handleless_author_contributes_no_author_surface():
+    """The rubric calls the author block TRUSTED metadata; an empty one would present a
+    garbage anchor as trustworthy (see #92)."""
+    item = _item()
+    item.author = Author(handle="", name="")
+    assert "author" not in {s.key for s in evidence_surfaces(item, "summary")}
+
+
+def test_evidence_text_is_the_flat_join_the_checker_reads():
+    """The deterministic entity checker asks one question — does this name appear on ANY
+    evidence surface? — so it needs the surfaces as one blob, from the SAME source of
+    truth the judge and the generators use."""
+    text = evidence_text(_item(), "digest")
+    assert "the transcript body" in text
+    assert "Ethan Mollick" in text  # the display name IS evidence (the rubric promises it)
+    assert "The scaling-laws talk" in text  # the video title, which the worksheet ships
+    assert "the fetched article body" not in text  # …but the article is not digest evidence
+    assert "the fetched article body" in evidence_text(_item(), "summary")
+
+
+def test_a_links_url_is_never_evidence_on_any_surface():
+    """D1: the domain is topic signal, never a name and never content. `axios.com` must
+    not be able to ground the name "Axios" — which is exactly how a summary in the
+    corpus reconstructed a whole article from a URL slug."""
+    for target in ("digest", "summary", "topics"):
+        text = evidence_text(_item(), target)
+        assert "example.com" not in text
+        assert "https://" not in text

--- a/tests/test_evidence_contract.py
+++ b/tests/test_evidence_contract.py
@@ -1,0 +1,247 @@
+# tests/test_evidence_contract.py
+"""The cross-component guard: four components, ONE definition of evidence.
+
+Four components each need to know what counts as evidence for a generated output:
+
+  1. the GENERATOR  — what the worksheet actually hands the agent
+  2. the RUBRIC     — what the judge is told may support a claim
+  3. the JUDGE      — what `_source_text` actually puts in front of it
+  4. the CHECKER    — what the deterministic entity check searches for a name
+
+Before `xbrain.evidence`, each maintained its own hand-written list, and 1,306 tests
+passed while the four contradicted one another — because every PR tested only its own
+side. The contradictions were not theoretical: the judge was handed the linked article
+for a DIGEST whose generator never saw it (so it excused inventions it could not have
+sourced), and neither generator shipped the author display name its rubric promised.
+
+This file binds them. It asserts, per target:
+
+    generator fields  ⊇  evidence_surfaces(item, target)
+    judge source      ==  evidence_surfaces(item, target)
+    checker evidence  ==  evidence_surfaces(item, target)
+    verify rubric     declares every surface in evidence_surfaces(item, target)
+
+Identity against the shared function — never a substring, and never a hand-written list
+repeated here (a list repeated in the test is a fifth copy of the bug). Add a surface to
+one component and forget the others, and this file goes red.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from xbrain.evidence import (
+    SURFACE_KEYS,
+    SURFACE_RUBRIC_PHRASES,
+    evidence_surfaces,
+    evidence_text,
+)
+from xbrain.executors.api import _user_prompt
+from xbrain.models import (
+    Author,
+    Content,
+    ContentSourceSuccess,
+    Item,
+    Link,
+    MediaPhotoDescribed,
+    Topic,
+    VideoFrame,
+)
+from xbrain.rubrics import load_rubric
+from xbrain.verification import _source_text
+from xbrain.video_digest import export_video_digest_worksheet
+from xbrain.worksheet import export_worksheet
+
+VOCAB = [Topic(slug="misc", description="Noise.")]
+
+# Every surface carries a UNIQUE sentinel, so "is this surface present?" is answerable
+# by substring on the rendered payload without a header or another surface satisfying it
+# by accident.
+AUTHOR_HANDLE = "emollick"
+AUTHOR_NAME = "Ethan Mollick"
+TWEET = "SENTINEL-tweet-text"
+VIDEO_TITLE = "SENTINEL-video-title"
+TRANSCRIPT = "SENTINEL-transcript"
+FRAME = "SENTINEL-frame-description"
+ARTICLE_TITLE = "SENTINEL-article-title"
+ARTICLE = "SENTINEL-article-body"
+THREAD = "SENTINEL-thread-text"
+IMAGE = "SENTINEL-image-description"
+
+
+def _full_item() -> Item:
+    """One item that carries EVERY surface at once — so a surface missing from a
+    component is a missing sentinel, not an accident of the fixture."""
+    return Item(
+        id="7",
+        source="bookmark",
+        url="https://x.com/a/status/7",
+        author=Author(handle=AUTHOR_HANDLE, name=AUTHOR_NAME),
+        text=TWEET,
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        links=[Link(url="https://example.com/a", domain="example.com")],
+        media=[
+            MediaPhotoDescribed(
+                url="https://pbs.twimg.com/media/X.jpg",
+                local_path="7/0.jpg",
+                width=4,
+                height=3,
+                bytes_size=512,
+                downloaded_at=datetime(2026, 5, 24, tzinfo=timezone.utc),
+                is_decorative=False,
+                description=IMAGE,
+                description_lang="English",
+                description_version="v1",
+                described_at=datetime(2026, 5, 24, 12, tzinfo=timezone.utc),
+            )
+        ],
+        content=Content(
+            fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video",
+                    url="https://x.com/v",
+                    title=VIDEO_TITLE,
+                    text=TRANSCRIPT,
+                    has_speech=True,
+                    frames=[
+                        VideoFrame(timestamp=0.0, local_path="7/frames/0.png", description=FRAME)
+                    ],
+                ),
+                ContentSourceSuccess(
+                    kind="external_article",
+                    url="https://example.com/a",
+                    title=ARTICLE_TITLE,
+                    text=ARTICLE,
+                ),
+                ContentSourceSuccess(
+                    kind="thread",
+                    url="https://x.com/a/status/7",
+                    text=THREAD,
+                ),
+            ],
+        ),
+    )
+
+
+def _generator_payload(target: str, tmp_path) -> str:
+    """What the target's GENERATOR actually hands its agent, as raw text.
+
+    `digest` → the video-digest worksheet. `summary`/`topics` → the enrich worksheet AND
+    the `api` executor's prompt; both are generators for those targets, so both must
+    carry every surface.
+    """
+    item = _full_item()
+    path = tmp_path / "ws.json"
+    if target == "digest":
+        export_video_digest_worksheet([item], path, "claude-code", "English")
+        return path.read_text(encoding="utf-8")
+    export_worksheet([item], VOCAB, path, "claude-code", "English")
+    return path.read_text(encoding="utf-8") + "\n" + _user_prompt(item, VOCAB)
+
+
+@pytest.mark.parametrize("target", ["digest", "summary", "topics"])
+def test_the_generator_ships_every_surface_the_judge_will_check(target, tmp_path):
+    """generator ⊇ surfaces. A surface the judge treats as evidence but the generator
+    never shipped is a FALSE FAIL waiting to happen: the output could not have used it,
+    and an output that does use it (because a DIFFERENT surface carried the fact) gets
+    judged against a source the generator never saw."""
+    payload = _generator_payload(target, tmp_path)
+    for surface in evidence_surfaces(_full_item(), target):
+        for value in surface.values:
+            assert value in payload, (
+                f"generator for {target!r} never ships {value!r} "
+                f"(surface {surface.key!r}) — the judge would check the output against "
+                "evidence the generator was not handed"
+            )
+
+
+@pytest.mark.parametrize("target", ["digest", "summary", "topics"])
+def test_the_judge_source_is_exactly_the_evidence_surfaces(target):
+    """judge == surfaces, in BOTH directions.
+
+    Missing a surface → the judge flags a claim the generator was entitled to make (the
+    36+ false author flags). Carrying an EXTRA one → the judge excuses an invention the
+    generator could not have sourced (the digest judged against a linked article its
+    generator never received). Both directions are pinned."""
+    item = _full_item()
+    source = _source_text(item, target)
+    admitted = evidence_surfaces(item, target)
+    for surface in admitted:
+        assert surface.label in source
+        for value in surface.values:
+            assert value in source, f"judge source for {target!r} omits {surface.key!r}"
+
+    admitted_keys = {s.key for s in admitted}
+    # Every surface this target does NOT admit must be absent from the judge's source —
+    # by its sentinel, so a shared label cannot hide it.
+    for surface in evidence_surfaces(item, "summary"):  # the widest set
+        if surface.key not in admitted_keys:
+            for value in surface.values:
+                assert value not in source, (
+                    f"judge source for {target!r} carries {surface.key!r}, "
+                    "which that target's generator never sees"
+                )
+
+
+@pytest.mark.parametrize("target", ["digest", "summary", "topics"])
+def test_the_checker_searches_exactly_the_evidence_surfaces(target):
+    """checker == surfaces. The deterministic entity check asks "does this name appear on
+    ANY evidence surface?" — if its notion of evidence drifts from the judge's, it either
+    manufactures false positives or inherits the blind spot it exists to cover."""
+    item = _full_item()
+    evidence = evidence_text(item, target)
+    admitted = evidence_surfaces(item, target)
+    for surface in admitted:
+        for value in surface.values:
+            assert value in evidence
+    admitted_keys = {s.key for s in admitted}
+    for surface in evidence_surfaces(item, "summary"):
+        if surface.key not in admitted_keys:
+            for value in surface.values:
+                assert value not in evidence
+
+
+@pytest.mark.parametrize("target", ["digest", "summary", "topics"])
+def test_the_verify_rubric_declares_every_surface_it_admits(target):
+    """rubric == surfaces. The judge is TOLD what may support a claim; if the rubric's
+    list and `_source_text` disagree, the judge either flags what it was handed or
+    accepts what it was not."""
+    rubric = load_rubric("verify", language="English")
+    for key in SURFACE_KEYS[target]:
+        phrase = SURFACE_RUBRIC_PHRASES[key]
+        assert phrase in rubric, f"rubric-verify never declares the {key!r} surface ({phrase!r})"
+
+
+def test_every_declared_surface_has_a_rubric_phrase():
+    """No surface may exist without the rubric having a word for it — otherwise the
+    binding above is vacuous for that surface."""
+    for keys in SURFACE_KEYS.values():
+        for key in keys:
+            assert SURFACE_RUBRIC_PHRASES.get(key), f"surface {key!r} has no rubric phrase"
+
+
+def test_a_url_is_evidence_for_no_target(tmp_path):
+    """D1, the deepest one: the judge's source shows the links (topic signal), but a URL
+    is NOT an evidence surface — so naming the publication it belongs to can never be
+    grounded. `axios.com` must not ground "Axios"."""
+    for target in ("digest", "summary", "topics"):
+        assert "example.com" not in evidence_text(_full_item(), target)
+    assert not any(
+        s.key == "links" for s in evidence_surfaces(_full_item(), "summary")
+    )  # no such surface exists
+
+
+def test_the_contract_survives_a_json_round_trip(tmp_path):
+    """The worksheet is JSON on disk; a surface must survive serialisation to reach the
+    agent (a `None` field ships nothing)."""
+    item = _full_item()
+    path = tmp_path / "ws.json"
+    export_worksheet([item], VOCAB, path, "claude-code", "English")
+    entry = json.loads(path.read_text(encoding="utf-8"))["items"][0]
+    serialised = json.dumps(entry, ensure_ascii=False)
+    for surface in evidence_surfaces(item, "summary"):
+        for value in surface.values:
+            assert value in serialised

--- a/tests/test_executors_api.py
+++ b/tests/test_executors_api.py
@@ -593,3 +593,14 @@ def test_user_prompt_marks_an_unfetched_quoted_post():
 
 def test_user_prompt_has_no_quoted_marker_without_a_quote():
     assert "Quoted post" not in _user_prompt(_item("1"), VOCAB)
+
+
+def test_user_prompt_ships_the_author_display_name(tmp_path):
+    """D6: the rubric promises the judge "@handle and display name" as author metadata,
+    but the api prompt only ever shipped the handle — so a summary naming the poster by
+    their display name was judged against evidence the generator never had."""
+    item = _item("1")
+    item.author = Author(handle="emollick", name="Ethan Mollick")
+    prompt = _user_prompt(item, VOCAB)
+    assert "@emollick" in prompt
+    assert "Ethan Mollick" in prompt

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1236,18 +1236,29 @@ def _badge_item(item_id: str = "9", *, summary: str = "A crisp summary.") -> Ite
     )
 
 
-def _stamp(item: Item, target: str, verdict: str, *, flags: list[str] | None = None) -> None:
-    """Stamp a CURRENT verification verdict (matching fingerprint) onto `item`."""
+def _stamp(
+    item: Item,
+    target: str,
+    verdict: str,
+    *,
+    flags: list[str] | None = None,
+    language: str = "English",
+) -> None:
+    """Stamp a CURRENT verification verdict onto `item` — current under the whole judging
+    CONTRACT (the output it judged, the source it read, the rubric it applied), not just
+    the output text."""
     from xbrain.models import VerificationVerdict
-    from xbrain.verification import fingerprint_output
+    from xbrain.verification import contract_fingerprint, fingerprint_output
 
     fp = fingerprint_output(item, target)
-    assert fp is not None
+    contract = contract_fingerprint(item, target, language)
+    assert fp is not None and contract is not None
     item.verification[target] = VerificationVerdict(
         verdict=verdict,
         faithfulness="FAIL" if verdict == "FAIL" else "PASS",
         adherence="REVIEW" if verdict == "REVIEW" else "PASS",
         output_fingerprint=fp,
+        contract_fingerprint=contract,
         verified_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
         flags=flags or [],
     )
@@ -1331,7 +1342,7 @@ def test_generate_badges_digest_verdict_near_video_header(tmp_path: Path):
 
 def test_generate_spanish_badge_label_is_localized(tmp_path: Path):
     item = _badge_item()
-    _stamp(item, "summary", "FAIL", flags=["número no soportado"])
+    _stamp(item, "summary", "FAIL", flags=["número no soportado"], language="Spanish")
     generate({item.id: item}, tmp_path, output_language="Spanish")
     body = _note_body(tmp_path)
     assert "Verificación: FALLA" in body
@@ -1353,10 +1364,15 @@ def test_generate_no_badge_when_output_fixed_before_write(tmp_path: Path):
     """End-to-end (#79): a FAIL judged on summary "A", the summary regenerated to "B" BEFORE
     `--write-verdicts`, must never badge "B" — the stored (judged) fingerprint is of "A", so
     `generate` on "B" finds a mismatch. Uses the real write path with a judged fingerprint."""
-    from xbrain.verification import apply_verdicts_to_store, fingerprint_output
+    from xbrain.verification import (
+        apply_verdicts_to_store,
+        contract_fingerprint,
+        fingerprint_output,
+    )
 
     item = _badge_item(summary="A - judged and FAILED.")
     judged_fp = fingerprint_output(item, "summary")
+    judged_contract = contract_fingerprint(item, "summary", "English")
     item.enriched.summary = "B - fixed before the write."  # regenerated in the window
     store = {item.id: item}
     result = apply_verdicts_to_store(
@@ -1372,6 +1388,7 @@ def test_generate_no_badge_when_output_fixed_before_write(tmp_path: Path):
             }
         ],
         {(item.id, "summary"): judged_fp},
+        {(item.id, "summary"): judged_contract},
     )
     assert result.written == 1
     assert store[item.id].verification["summary"].output_fingerprint == judged_fp
@@ -1379,3 +1396,88 @@ def test_generate_no_badge_when_output_fixed_before_write(tmp_path: Path):
     body = _note_body(tmp_path)
     assert "❌" not in body and "Verification: FAIL" not in body
     assert "B - fixed before the write." in body  # the current output still renders
+
+
+def test_generate_does_not_badge_a_verdict_judged_against_a_DIFFERENT_SOURCE(tmp_path: Path):
+    """The output is untouched, but the evidence under it changed (a new frame description
+    landed). The judge never saw that source, so its verdict says nothing about this
+    output-plus-source pair. No badge."""
+    from xbrain.models import Content, ContentSourceSuccess, VideoFrame
+
+    item = _badge_item()
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        sources=[
+            ContentSourceSuccess(
+                kind="x_video",
+                url="https://x.com/v",
+                title="A talk",
+                text="the transcript body",
+                has_speech=True,
+                frames=[
+                    VideoFrame(timestamp=0.0, local_path="9/frames/0.png", description="A chart.")
+                ],
+            )
+        ],
+    )
+    _stamp(item, "summary", "FAIL", flags=["unsupported number"])
+    source = item.content.sources[0]
+    source.frames = [
+        *source.frames,
+        VideoFrame(timestamp=9.0, local_path="9/frames/9.png", description="A brand-new slide."),
+    ]
+    generate({item.id: item}, tmp_path)
+    body = _note_body(tmp_path)
+    assert "❌" not in body
+    assert "Verification: FAIL" not in body
+
+
+def test_generate_does_not_badge_a_verdict_judged_under_an_OLD_RUBRIC(tmp_path: Path, monkeypatch):
+    """#86 rewrote `rubric-verify.md` without touching one output character, and every
+    stored verdict still painted. This is the arm that closes it."""
+    from xbrain import rubrics as rubrics_mod
+    from xbrain.verification import rubric_digest
+
+    item = _badge_item()
+    _stamp(item, "summary", "FAIL", flags=["unsupported number"])
+
+    original = rubrics_mod._RUBRICS_DIR
+    shadow = tmp_path / "rubrics"
+    shadow.mkdir()
+    for rubric in original.glob("*.md"):
+        shadow.joinpath(rubric.name).write_text(
+            rubric.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    verify = shadow / "rubric-verify.md"
+    verify.write_text(
+        verify.read_text(encoding="utf-8") + "\nA RULE THE JUDGE NEVER SAW.\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", shadow)
+    rubric_digest.cache_clear()
+    try:
+        generate({item.id: item}, tmp_path / "out")
+        body = next((tmp_path / "out" / "items").glob("*.md")).read_text(encoding="utf-8")
+    finally:
+        rubric_digest.cache_clear()
+    assert "❌" not in body
+    assert "Verification: FAIL" not in body
+
+
+def test_generate_does_not_badge_a_LEGACY_verdict_with_no_contract(tmp_path: Path):
+    """Every verdict stored before this change was judged under a contract we cannot
+    reconstruct. It is not grandfathered in: it paints NOTHING."""
+    from xbrain.models import VerificationVerdict
+    from xbrain.verification import fingerprint_output
+
+    item = _badge_item()
+    item.verification["summary"] = VerificationVerdict(
+        verdict="FAIL",
+        faithfulness="FAIL",
+        output_fingerprint=fingerprint_output(item, "summary"),
+        verified_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        flags=["unsupported number"],
+    )  # no contract_fingerprint — the old shape
+    generate({item.id: item}, tmp_path)
+    body = _note_body(tmp_path)
+    assert "❌" not in body
+    assert "Verification: FAIL" not in body

--- a/tests/test_guardrail_contract.py
+++ b/tests/test_guardrail_contract.py
@@ -85,7 +85,7 @@ def test_every_surface_carries_the_identical_unfetched_links_note(links, article
     assert note is not None
     assert note in _user_prompt(item, VOCAB)  # generator: api prompt
     assert _worksheet_entry(item, tmp_path)["unfetched_links_note"] == note  # generator: worksheet
-    assert note in _source_text(item)  # judge: verify source
+    assert note in _source_text(item, "summary")  # judge: verify source
 
 
 def test_every_surface_carries_the_identical_quoted_note(tmp_path):
@@ -93,7 +93,7 @@ def test_every_surface_carries_the_identical_quoted_note(tmp_path):
     item = _item(quoted=True)
     assert QUOTED_CONTENT_UNFETCHED_NOTE in _user_prompt(item, VOCAB)
     assert _worksheet_entry(item, tmp_path)["quoted_content_note"] == QUOTED_CONTENT_UNFETCHED_NOTE
-    assert QUOTED_CONTENT_UNFETCHED_NOTE in _source_text(item)
+    assert QUOTED_CONTENT_UNFETCHED_NOTE in _source_text(item, "summary")
 
 
 def test_the_judge_source_carries_the_note_not_merely_the_header():
@@ -101,7 +101,7 @@ def test_the_judge_source_carries_the_note_not_merely_the_header():
     NOT fetched]` heading. Deleting the note while keeping the header is the mutation
     that survived review: the header alone satisfies a `"NOT fetched"` substring."""
     item = _item(links=1)
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     header = "[Links — content NOT fetched]"
     assert header in text
     assert text.replace(header, "").count("NOT fetched") >= 1  # the note survives header removal
@@ -110,7 +110,7 @@ def test_the_judge_source_carries_the_note_not_merely_the_header():
 
 def test_the_judge_source_carries_the_quoted_note_not_merely_the_header():
     item = _item(quoted=True)
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     header = "[Quoted post — content NOT fetched]"
     assert header in text
     assert QUOTED_CONTENT_UNFETCHED_NOTE in text.replace(header, "")

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -37,6 +37,7 @@ def test_strings_dataclass_has_exactly_the_expected_fields() -> None:
     """If a field is added or removed, every translation must be updated."""
     field_names = {f.name for f in dataclasses.fields(Strings)}
     assert field_names == {
+        "language",
         "topics_label",
         "content_header",
         "summary_header",

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -219,3 +219,29 @@ def test_summary_rubric_keeps_the_86_attribution_and_unfetched_guardrails():
     assert "posted" in text
     assert "not fetched" in text or "never fetched" in text
     assert "reconstruct" in text
+
+
+def test_verify_rubric_treats_a_url_as_topic_signal_never_as_a_name():
+    """D1 — the deepest defect on the board. `rubric-verify` used to carve out the URL
+    ("unsupported ... beyond the URL/domain itself"), which made the domain EVIDENCE:
+    the judge was structurally unable to flag `Axios` reconstructed from
+    `axios.com/2025/05/28/ai-jobs...`, or `Nature` from `nature.com`. The generator's
+    rubric says the opposite — a domain is topic signal, never a name. Both must now say
+    the same thing, or the judge licenses exactly what the generator is forbidden."""
+    text = load_rubric("verify", language="English")
+    assert "beyond the URL/domain itself" not in text  # the carve-out that excused it
+    lowered = text.lower()
+    assert "topic signal" in lowered
+    # naming the publication/company a link belongs to is UNSUPPORTED
+    assert "publication" in lowered
+    assert "never a name" in lowered or "not a name" in lowered
+
+
+def test_verify_rubric_declares_the_evidence_surfaces_per_target():
+    """The judge must be told WHICH surfaces support a claim, and they differ by target:
+    a digest is judged against the video, a summary also against the article/thread/
+    images its generator was handed."""
+    text = load_rubric("verify", language="English")
+    assert "digest" in text and "summary" in text
+    assert "video transcript" in text.lower()
+    assert "fetched article body" in text.lower()

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -493,7 +493,7 @@ def test_source_text_includes_author():
     to its own author must be verifiable from the source, not world knowledge."""
     from xbrain.verification import _source_text
 
-    text = _source_text(_item())
+    text = _source_text(_item(), "summary")
     assert "[Author]" in text
     assert "@a (A)" in text
 
@@ -509,7 +509,7 @@ def test_source_text_marks_unfetched_links():
     item = _item()
     item.links = [Link(url="https://t.co/x", domain="time.com")]
     # the only content source is the x_video transcript — no fetched article
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     # Identity, not a substring: `"NOT fetched" in text` is already satisfied by the
     # `[Links — content NOT fetched]` HEADER, so it would pass with the instruction gone.
     assert unfetched_links_note(item) in text
@@ -530,7 +530,7 @@ def test_source_text_no_unfetched_marker_when_article_fetched():
             text="the fetched article body",
         )
     )
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     assert "NOT fetched" not in text
     assert "[Linked article" in text
     assert "the fetched article body" in text
@@ -565,7 +565,7 @@ def test_source_text_labels_thread_text_as_thread_not_a_fetched_article():
             text="1/ my thread about agents",
         )
     )
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     assert "1/ my thread about agents" in text  # not dropped — a thread is real evidence
     assert _label_of(text, "1/ my thread about agents") == "[Thread — full text, same author]"
     assert "[Linked article" not in text
@@ -591,7 +591,7 @@ def test_source_text_partial_fetch_marks_the_unfetched_link_with_counts():
             text="the fetched article body",
         )
     )
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     assert "the fetched article body" in text
     assert "[Links — content NOT fetched]" in text
     assert "1 of 2" in text
@@ -604,7 +604,7 @@ def test_source_text_marks_an_unfetched_quoted_post():
 
     item = _item()
     item.quoted_id = "999"
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     assert "[Quoted post — content NOT fetched]" in text
 
 
@@ -640,7 +640,7 @@ def test_source_text_carries_images_and_titles_the_generators_ship():
             text="the fetched article body",
         )
     )
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     assert _label_of(text, "A bar chart of GPU prices.") == "[Images in the post]"
     assert "The TIME piece" in text  # the article title the api prompt already ships
     assert _label_of(text, "A talk") == "[Video title]"  # the video title the digest ships
@@ -650,7 +650,7 @@ def test_source_text_omits_decorative_image_descriptions():
     """A decorative photo carries no description — it must not add an empty bullet."""
     from xbrain.verification import _source_text
 
-    assert "[Images in the post]" not in _source_text(_item())
+    assert "[Images in the post]" not in _source_text(_item(), "summary")
 
 
 def test_cross_check_fingerprints_never_introduces_a_key_the_primary_lacks():
@@ -697,7 +697,7 @@ def test_source_text_omits_the_author_block_without_a_handle():
 
     item = _item()
     item.author = Author(handle="", name="")
-    text = _source_text(item)
+    text = _source_text(item, "summary")
     assert "[Author]" not in text
     assert "@ ()" not in text
     assert "[Video transcript]" in text  # the rest of the source is unaffected

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -29,6 +29,20 @@ from xbrain.verification import (
 )
 
 
+def _contracts(store: dict) -> dict[tuple[str, str], str]:
+    """The contract stamps `export_verify_worksheet` would put on every (item, target) —
+    what the writer threads through when the judging was done under the current contract."""
+    from xbrain.verification import ALL_TARGETS, contract_fingerprint
+
+    stamps: dict[tuple[str, str], str] = {}
+    for item_id, item in store.items():
+        for target in ALL_TARGETS:
+            contract = contract_fingerprint(item, target, "English")
+            if contract is not None:
+                stamps[(item_id, target)] = contract
+    return stamps
+
+
 def test_parse_targets_resolves_and_validates():
     assert parse_targets("all") == ALL_TARGETS
     assert parse_targets("digest") == ("digest",)
@@ -367,7 +381,7 @@ def test_import_verify_fingerprints_drops_conflicting_stamps(tmp_path):
     # Consequence: the dropped key is not written (fingerprint-missing); the agreed key is.
     store = {"7": _item()}
     aggregated = [_j("FAIL", target="summary"), _j("FAIL", target="digest")]
-    result = apply_verdicts_to_store(store, aggregated, fingerprints)
+    result = apply_verdicts_to_store(store, aggregated, fingerprints, _contracts(store))
     assert "summary" not in store["7"].verification  # dropped → no verdict, no badge
     assert store["7"].verification["digest"].output_fingerprint == "c" * 64
     assert ("7", "summary", "fingerprint-missing") in result.skipped
@@ -379,7 +393,9 @@ def test_apply_verdicts_writes_verdict_with_the_judged_fingerprint():
     aggregated = aggregate_verify_judgments(
         [[_j("FAIL", faithfulness="FAIL", flags=[{"claim": "€150M", "issue": "unsupported"}])]]
     )
-    result = apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp})
+    result = apply_verdicts_to_store(
+        store, aggregated, {("7", "summary"): judged_fp}, _contracts(store)
+    )
     assert result.written == 1 and result.skipped == []
     verdict = store["7"].verification["summary"]
     assert verdict.verdict == "FAIL"
@@ -399,7 +415,9 @@ def test_apply_verdicts_stores_judged_fingerprint_not_live_recompute():
     live_fp = fingerprint_output(store["7"], "summary")
     assert live_fp != judged_fp
 
-    result = apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp})
+    result = apply_verdicts_to_store(
+        store, aggregated, {("7", "summary"): judged_fp}, _contracts(store)
+    )
     assert result.written == 1
     stored = store["7"].verification["summary"].output_fingerprint
     assert stored == judged_fp  # the JUDGED output's fingerprint
@@ -437,7 +455,7 @@ def test_apply_verdicts_tallies_every_skip_reason_and_never_crashes_the_write():
         ("8", "summary"): "nope",
     }
 
-    result = apply_verdicts_to_store(store, aggregated, fingerprints)
+    result = apply_verdicts_to_store(store, aggregated, fingerprints, _contracts(store))
 
     assert result.written == 1 and result.attempted == 7
     assert {reason for _, _, reason in result.skipped} == {
@@ -684,7 +702,7 @@ def test_apply_verdicts_refuses_duplicate_records_so_a_pass_cannot_overwrite_a_f
     ]
 
     with pytest.raises(ValueError, match="duplicate"):
-        apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp})
+        apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp}, _contracts(store))
     assert store["7"].verification == {}  # nothing partially written
 
 


### PR DESCRIPTION
> **Apilado sobre PR-F (#94)** — necesita `_source_text(item, target)` y `evidence_surfaces`. Antes de #94, este fingerprint habría hasheado la fuente EQUIVOCADA para los digests.

Un verdict no es una propiedad del output. Es el resultado de juzgar **ese output**, contra **esa fuente**, bajo **esas rúbricas**. `fingerprint_output` hasheaba solo lo primero — así que **#86 pudo reescribir lo que el juez lee** (autor, hilo, marcadores de quote, imágenes, títulos) **y reescribir las rúbricas, sin tocar un solo carácter de output**, y *todos* los verdicts almacenados seguían haciendo match, seguían pareciendo frescos y seguían pintando su badge. Incluidos los emitidos bajo el contrato que medimos dejando pasar una atribución falsa **8 de 8 veces**.

## El fingerprint del contrato

```python
contract_fingerprint(item, target, language)   # sha256 de TRES brazos
```
1. **OUTPUT** — la afirmación que se juzga.
2. **SOURCE** — `_source_text(item, target)`: la evidencia que el juez leyó **para ESE target** (las `evidence_surfaces` de #94 + los marcadores de "no descargado"). Un digest y un summary se juzgan contra fuentes distintas.
3. **RÚBRICAS** — `rubric_digest`: **las dos** que el juez recibe — `rubric-verify` (cómo juzgar) y la rúbrica de generación del target (el eje de *adherence* se juzga contra ella; #91 reescribió justo esa). El **idioma** también entra: la rúbrica se sustituye por idioma.

**Barato:** `rubric_digest` va con `lru_cache` por `(target, language)`. `generate` corre el check por ítem sobre miles de notas y las rúbricas no cambian dentro de un run — se hashea una vez, no una vez por nota.

## La migración tampoco miente

`contract_fingerprint` es un campo **nuevo y opcional al lado** de `output_fingerprint`, no en su lugar: `output_fingerprint` es **requerido**, así que sustituirlo haría **crashear al cargar** cada verdict legacy — y además sigue siendo el binding output↔juez que necesita el write path de #79/#88.

Todo verdict almacenado antes de esto: **carga** (nunca crashea con la forma vieja), **no lleva contrato**, luego evalúa **STALE** → **no pinta NADA** → vuelve a estar disponible para re-juicio. **No se le hace grandfathering**: no podemos decir honestamente contra qué se juzgó.

**Medido sobre el store real (read-only, 2.168 ítems): 69 verdicts almacenados, 69 invalidados (100%)** — todos se juzgaron antes de que el contrato existiera. Ese es exactamente el número que `verify` ahora reporta por CLI:

```
⚠️  69 de 69 verdicts almacenados quedaron OBSOLETOS: se juzgaron bajo otro contrato
    (otro output, otra fuente u otra rúbrica). No pintan badge; hay que re-verificarlos.
```

El writer **rechaza** un verdict que venga de un worksheet pre-contrato (`contract-missing`) en vez de escribirlo con un contrato adivinado. Los dos sellos comparten **una sola** fontanería (el lector recibe la clave del sello), así que el sello de contrato hereda la misma semántica fail-safe: un sello discrepante **tira la clave**, y un record sin sellar sigue siendo no-escribible.

## Los cuatro brazos, probados — y las dos mutaciones que sobrevivieron a la primera

**7/7 mutaciones cazadas, 0 supervivientes** (tras arreglar las dos que sobrevivieron):

| Mutación | 1ª pasada | Ahora |
|---|---|---|
| `K1` el hash ignora el **output** | 🔴 | 🔴 |
| `K2` el hash ignora la **fuente** | 🔴 | 🔴 |
| `K3` el hash ignora la **rúbrica** | 🔴 | 🔴 |
| `K4` `rubric_digest` ignora la **rúbrica de GENERACIÓN** | 🟢 **sobrevivía** | 🔴 |
| `K5` el hash ignora el **target** | 🟢 **sobrevivía** | 🔴 |
| `K6` un verdict legacy se trata como **vigente** | 🔴 | 🔴 |
| `K7` el badge vuelve a mirar **solo el output** | 🔴 | 🔴 |

- **K4 era un agujero real**: mi test de rúbrica editaba solo `rubric-verify.md`, así que hashear únicamente la rúbrica del juez dejaba en pie todo verdict de *adherence* ante una reescritura de la rúbrica de generación. Pinchado — más el converso: editar `rubric-video-digest` retira los verdicts de **digest** y **no** los de summary (si no, cada edición de rúbrica invalidaría el corpus entero y el badge dejaría de significar nada).
- **K5 sobrevivía porque el target es redundante POR CASUALIDAD** (hoy cada target tiene output y rúbrica distintos). No es redundante por diseño: es lo que impide que un verdict cruce de target si dos llegaran a compartir rúbrica de generación. Pinchado construyendo ese mundo — mismo output, misma fuente, misma rúbrica, solo cambia el target.

## Tests, uno por brazo
- output cambia → stale · **fuente** cambia (aterriza una descripción de frame) → stale · **rúbrica del juez** cambia → stale · **rúbrica de generación** cambia → stale · **nada** cambia → fresco, **el badge pinta** · legacy sin contrato → **no pinta nada** · el CLI cuenta los invalidados · un worksheet pre-contrato **no se escribe**.

## Estado
1.348 tests verdes · `poe check` completo en verde (ruff, format, mypy, radon A/B, bandit, vulture, interrogate, detect-secrets, deptry, cobertura 95%). El store **no se tocó** (la medición es read-only; mtime intacto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)