### PR TITLE
style: fix the format break merged with #96

### DIFF
--- a/tests/test_payloads.py
+++ b/tests/test_payloads.py
@@ -205,6 +205,8 @@ def test_recapture_history_persists_payloads(monkeypatch, tmp_path: Path):
     assert seen["payload_dir"] == tmp_path / "payloads", (
         "the full-history scroll must persist payloads — it is the cheapest backfill we have"
     )
+
+
 # --- Review #96: every one of these was reproduced by running the code -----------------
 
 


### PR DESCRIPTION
## Qué

`develop` está rojo: **#96 se mergeó con `quality: fail`** (`Critical issues in: Format`). Dos líneas en blanco que faltaban en `tests/test_payloads.py`.

## Cómo pasó

Verifiqué los checks con `gh pr checks 96 && gh pr merge 96`. **`gh pr checks` sale con código 0 aunque el check haya fallado** — imprime `fail` y devuelve éxito. El `&&` encadenado ejecutó el merge sobre rojo.

Es la segunda vez hoy que mergeo en rojo, y la causa raíz es la misma: **verificar que el comando de checks se ejecutó, en vez de verificar su conclusión.**

## Guardarraíl

Antes de cualquier `gh pr merge`, comprobar la **conclusión**, no el exit code:

```bash
gh pr view <N> --json statusCheckRollup --jq '[.statusCheckRollup[].conclusion] | all(. == "SUCCESS")'
```

Sin tests nuevos: es un arreglo de formato puro, sin cambio de comportamiento.