### PR TITLE
fix(test): develop is RED — #97's surface test predates #94's target-scoped judge

### DIFF
--- a/tests/test_guardrail_contract.py
+++ b/tests/test_guardrail_contract.py
@@ -237,7 +237,10 @@ def test_the_reason_reaches_every_surface_identically(tmp_path):
     assert note is not None and "no longer exists" in note
     assert note in _user_prompt(item, VOCAB)  # generator: api prompt
     assert _worksheet_entry(item, tmp_path)["unfetched_links_note"] == note  # generator: worksheet
-    assert note in _source_text(item)  # judge: verify source
+    # The judge's source is TARGET-scoped since #94 (a digest is judged against different
+    # evidence than a summary). This surface check is about the ENRICH targets, whose
+    # generators ship the links.
+    assert note in _source_text(item, "summary")  # judge: verify source
 
 
 def test_an_unfetched_link_with_no_recorded_failure_still_gets_the_rule():


### PR DESCRIPTION
**`develop` (1209094) está en ROJO ahora mismo: 1 failed, 1490 passed.** Verificado sobre `origin/develop` limpio, en un worktree aparte.

## Qué pasó

- **#97** añadió `test_the_reason_reaches_every_surface_identically`, que llama `_source_text(item)`.
- **#94** hizo el juez **target-scoped**: `_source_text(item, target)` — un digest se juzga contra evidencia distinta que un summary.

Cada PR estaba **verde en su rama**. El **merge** está rojo, y nadie ejecutó el árbol mergeado. Es exactamente la misma clase de defecto que llevamos todo el día cerrando, un nivel más arriba: **los componentes estaban testeados; su composición, no.**

## El fix

Una línea. El sujeto del test (la nota de links llegando a todas las superficies) es una preocupación de los targets de **enrich**, así que pide el source de `summary`.

Tras el fix: **1491 passed**, `poe check` completo en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)