### PR TITLE
fix(test): develop is RED — one call site missed `_source_text`'s new target arg

### DIFF
--- a/tests/test_guardrail_contract.py
+++ b/tests/test_guardrail_contract.py
@@ -237,7 +237,7 @@ def test_the_reason_reaches_every_surface_identically(tmp_path):
     assert note is not None and "no longer exists" in note
     assert note in _user_prompt(item, VOCAB)  # generator: api prompt
     assert _worksheet_entry(item, tmp_path)["unfetched_links_note"] == note  # generator: worksheet
-    assert note in _source_text(item)  # judge: verify source
+    assert note in _source_text(item, "summary")  # judge: verify source
 
 
 def test_an_unfetched_link_with_no_recorded_failure_still_gets_the_rule():


### PR DESCRIPTION
## `develop` is red right now. This is the one-line fix.

`tests/test_guardrail_contract.py::test_the_reason_reaches_every_surface_identically` fails on `origin/develop` as of `1209094`.

**A semantic conflict — and neither PR was wrong alone.**

- **#97** added the test, which calls `_source_text(item)`.
- **#94** made the judge's source **target-aware**: `_source_text(item, target)` — because judging a `digest` against the linked article excuses inventions its generator never saw.

Git merged them with **no textual conflict**, and each was green against the `develop` it was tested against. The **merge** is what broke. CI never ran the combination, because neither PR changed after the other landed.

That is exactly the class of failure the evidence contract exists to catch — arriving one level up, in the **tests**, where no contract binds two PRs that never met.

## The fix

One call site, pinned to `"summary"` (the target that test is about).

**Full suite: 1491 passed.** No source change.