### PR TITLE
feat(verify): bind a verdict to the CONTRACT it was judged under, not just the output

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -110,6 +110,7 @@ from xbrain.vocab import (
 from xbrain.verification import (
     aggregate_verify_judgments,
     apply_verdicts_to_store,
+    count_invalidated_verdicts,
     cross_check_fingerprints,
     export_verify_worksheet,
     import_verify_fingerprints,
@@ -1721,7 +1722,10 @@ def _write_verify_report(cfg: Config, json_report: str, md_report: str) -> None:
 
 
 def _verify_write_verdicts(
-    cfg: Config, records: list[dict], fingerprints: dict[tuple[str, str], str]
+    cfg: Config,
+    records: list[dict],
+    fingerprints: dict[tuple[str, str], str],
+    contracts: dict[tuple[str, str], str],
 ) -> None:
     """Opt-in write path for `verify --apply --write-verdicts` (and its post-audit twin,
     `verify --audit --apply --write-verdicts`): persist each FINAL verdict onto its item with
@@ -1738,12 +1742,33 @@ def _verify_write_verdicts(
     """
     _auto_snapshot(cfg, "verify-write-verdicts")
     store = load_store(cfg.items_path)
-    result = apply_verdicts_to_store(store, records, fingerprints)
+    result = apply_verdicts_to_store(store, records, fingerprints, contracts)
     save_store(store, cfg.items_path)
     typer.echo(f"{result.summary()} → {cfg.items_path}")
 
 
-def _audit_write_fingerprints(records: list[dict], apply: list[Path]) -> dict[tuple[str, str], str]:
+def _echo_invalidated_verdicts(cfg: Config, store: dict[str, Item]) -> None:
+    """Say how many STORED verdicts the current contract has retired, before exporting a
+    fresh worksheet.
+
+    The number is the point. A contract change (a rubric rewrite, a new evidence surface,
+    a re-fetched article) silently retires verdicts that were perfectly valid under the old
+    rules — they paint no badge and must be re-judged. Reporting it is the difference
+    between "the verification layer covers the corpus" and knowing how much of it actually
+    does right now.
+    """
+    invalidated, stored = count_invalidated_verdicts(store, cfg.output_language)
+    if invalidated:
+        typer.echo(
+            f"⚠️  {invalidated} de {stored} verdicts almacenados quedaron OBSOLETOS: se "
+            "juzgaron bajo otro contrato (otro output, otra fuente u otra rúbrica). No "
+            "pintan badge; hay que re-verificarlos."
+        )
+
+
+def _audit_write_fingerprints(
+    records: list[dict], apply: list[Path], stamp: str = "output_fingerprint"
+) -> dict[tuple[str, str], str]:
     """The JUDGED fingerprints for the post-audit write.
 
     The MERGED RECORDS are the authority — they are what the report being written describes,
@@ -1753,7 +1778,9 @@ def _audit_write_fingerprints(records: list[dict], apply: list[Path]) -> dict[tu
     one the record lacks. Nothing here recomputes a fingerprint from the live store — that is
     the invariant the whole plumbing exists to protect (#79).
     """
-    return cross_check_fingerprints(record_fingerprints(records), import_verify_fingerprints(apply))
+    return cross_check_fingerprints(
+        record_fingerprints(records, stamp), import_verify_fingerprints(apply, stamp)
+    )
 
 
 def _verify_audit_apply(
@@ -1791,7 +1818,12 @@ def _verify_audit_apply(
     _echo_audit_log(audit_log)
     if write_verdicts:
         _reject_unaudited_write(aggregated, audit_log)
-        _verify_write_verdicts(cfg, records, _audit_write_fingerprints(records, apply))
+        _verify_write_verdicts(
+            cfg,
+            records,
+            _audit_write_fingerprints(records, apply),
+            _audit_write_fingerprints(records, apply, "contract_fingerprint"),
+        )
     # The report is written LAST, and only once the store write has succeeded. It is the report
     # that carries `audited: True`, which the guard above reads to refuse a second audit — so
     # marking it before a write that then dies would block the retry behind `--force`, which
@@ -1925,15 +1957,18 @@ def verify_command(
         # so a verdict binds to the output the judge saw — never a live recompute. They are
         # stamped onto the records too, carrying them into verify-report.json → the audit.
         fingerprints = import_verify_fingerprints(apply)
+        contracts = import_verify_fingerprints(apply, "contract_fingerprint")
         aggregated = aggregate_verify_judgments([import_verify_judgments(path) for path in apply])
         stamp_record_fingerprints(aggregated, fingerprints)
+        stamp_record_fingerprints(aggregated, contracts, "contract_fingerprint")
         _write_verify_report(cfg, *render_verify_report(aggregated))
         if write_verdicts:
-            _verify_write_verdicts(cfg, aggregated, fingerprints)
+            _verify_write_verdicts(cfg, aggregated, fingerprints, contracts)
         return
 
     chosen = _resolve_verify_executor(executor, cfg)
     store = load_store(cfg.items_path)
+    _echo_invalidated_verdicts(cfg, store)
     pairs = items_for_verification(store, parse_targets(target))
     if not pairs:
         typer.echo("No hay outputs que verificar.")

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -32,7 +32,7 @@ from xbrain.models import (
     VideoFrame,
 )
 from xbrain.notes_io import DEFAULT_TAIL, note_filename, slugify, title_of, user_tail, wrap
-from xbrain.verification import ALL_TARGETS, VerifyTarget, fingerprint_output
+from xbrain.verification import ALL_TARGETS, VerifyTarget, verdict_is_current
 from xbrain.video_digest import _video_source
 
 logger = logging.getLogger(__name__)
@@ -323,8 +323,13 @@ def _verdict_badge(item: Item, target: str, strings: Strings) -> str | None:
     verdict = item.verification.get(target)
     if verdict is None or verdict.verdict not in _VERDICT_BADGE_EMOJI:
         return None
-    if fingerprint_output(item, cast(VerifyTarget, target)) != verdict.output_fingerprint:
-        return None  # stale: the judged output changed since the verdict was stored
+    if not verdict_is_current(item, cast(VerifyTarget, target), strings.language):
+        # STALE — the verdict was reached under a different contract than the one in force
+        # now: the output was re-generated, or the SOURCE the judge read changed (a frame
+        # description landed, an article got fetched), or the RUBRICS were rewritten. It
+        # says nothing about what a reader sees today, so it paints NOTHING. A verdict with
+        # no contract fingerprint at all (stored before #PR-D) is stale by construction.
+        return None
     label = strings.verify_badge_fail if verdict.verdict == "FAIL" else strings.verify_badge_review
     issue = next((flag for flag in verdict.flags if flag), None)
     suffix = f" — {' '.join(issue.splitlines())}" if issue else ""

--- a/src/xbrain/i18n.py
+++ b/src/xbrain/i18n.py
@@ -25,6 +25,8 @@ class Strings:
     suggest variance that does not exist.
     """
 
+    language: str  # the output language these strings belong to — the rubric the judge
+    # was handed is language-substituted, so the verdict's contract hash needs it (PR-D).
     topics_label: str  # "Temas" / "Topics"
     content_header: str  # "Contenido" / "Content"
     summary_header: str  # "Resumen" / "Summary"
@@ -49,6 +51,7 @@ class Strings:
 
 _STRINGS: dict[str, Strings] = {
     "English": Strings(
+        language="English",
         topics_label="Topics",
         content_header="Content",
         summary_header="Summary",
@@ -66,6 +69,7 @@ _STRINGS: dict[str, Strings] = {
         quoted_unavailable_unknown="X served no content for it",
     ),
     "Spanish": Strings(
+        language="Spanish",
         topics_label="Temas",
         content_header="Contenido",
         summary_header="Resumen",

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -904,6 +904,12 @@ class VerificationVerdict(BaseModel):
     faithfulness: Verdict = "PASS"
     adherence: Verdict = "PASS"
     output_fingerprint: str = Field(pattern=r"^[0-9a-f]{64}$")
+    # The FULL judging contract: the output + the source the judge read for this target +
+    # the rubrics it applied (see `verification.contract_fingerprint`). This — not
+    # `output_fingerprint` — is what decides whether a badge may paint. Optional, so a
+    # verdict stored before it existed still LOADS; None means "judged under a contract we
+    # cannot reconstruct" → permanently stale, never grandfathered in.
+    contract_fingerprint: str | None = Field(default=None, pattern=r"^[0-9a-f]{64}$")
     verified_at: datetime
     flags: list[str] = Field(default_factory=list)
 

--- a/src/xbrain/verification.py
+++ b/src/xbrain/verification.py
@@ -22,6 +22,7 @@ from collections import Counter
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import cast
 
@@ -104,6 +105,101 @@ def fingerprint_output(item: Item, target: VerifyTarget) -> str | None:
     if output is None:
         return None
     return hashlib.sha256(output.encode("utf-8")).hexdigest()
+
+
+# Bumped ONLY when the composition of the contract hash itself changes (not when a rubric
+# or a source changes — those are hashed). It makes the retirement of every previously
+# stored fingerprint explicit and greppable, instead of an accident of collision-freedom.
+_CONTRACT_VERSION = "xbrain-verify-contract/v1"
+
+
+@lru_cache(maxsize=None)
+def rubric_digest(target: VerifyTarget, language: str) -> str:
+    """The sha256 of BOTH rubrics the judge was handed for `target`, rendered in `language`.
+
+    The judge reads two: `rubric-verify` (how to judge) and the target's generation rubric
+    (what the output was supposed to obey — the adherence axis is judged against it). A
+    change to EITHER changes the rules the verdict was reached under, so both are hashed.
+
+    CACHED per `(target, language)`: `generate` runs the staleness check once per item over
+    thousands of notes, and the rubrics do not change inside a run. Re-reading and re-hashing
+    two files per item would make the badge check O(corpus) file I/O for no information.
+    A test that edits a rubric on disk must call `rubric_digest.cache_clear()`.
+    """
+    verify = load_rubric("verify", language=language)
+    generation = load_rubric(_TARGET_RUBRIC[target], language=language)
+    return hashlib.sha256(f"{verify}\0{generation}".encode()).hexdigest()
+
+
+def contract_fingerprint(item: Item, target: VerifyTarget, language: str) -> str | None:
+    """The sha256 binding a verdict to the FULL contract it was judged under, or None when
+    there is no output for `target`.
+
+    A verdict is not a property of the output alone: it is the result of judging THAT
+    output, against THAT source, under THOSE rubrics. `fingerprint_output` hashed only the
+    first, so #86 could rewrite what the judge reads (author metadata, thread, quoted-post
+    markers, images, titles) AND rewrite the rubrics, without touching one output
+    character — and every stored verdict still matched, still looked current, and still
+    painted its badge. Including verdicts issued under the contract that was measured
+    letting a false attribution through 8 times out of 8. A verdict that lies is the one
+    thing this layer exists to prevent.
+
+    THREE ARMS, all hashed:
+    * the OUTPUT text (`_output_for`) — the claim under judgment;
+    * the SOURCE the judge actually read for THIS target (`_source_text(item, target)`,
+      i.e. `evidence_surfaces` + the not-fetched markers) — the evidence it was checked
+      against. Target-scoped: a digest and a summary are judged against different sources;
+    * the RUBRICS (`rubric_digest`) — the rules it was checked by.
+
+    Any change to any arm changes the fingerprint, so the verdict goes stale automatically,
+    with nobody having to remember. The hash is a content hash, not a security primitive;
+    the NUL separators just keep two arms from concatenating into a third value.
+    """
+    output = _output_for(item, target)
+    if output is None:
+        return None
+    blob = "\0".join(
+        [
+            _CONTRACT_VERSION,
+            target,
+            output,
+            _source_text(item, target),
+            rubric_digest(target, language),
+        ]
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def verdict_is_current(item: Item, target: VerifyTarget, language: str) -> bool:
+    """True when the item's stored verdict for `target` was judged under the CURRENT
+    contract — the only condition under which a badge may paint.
+
+    A verdict with no `contract_fingerprint` (stored before this existed) is NOT current:
+    we cannot reconstruct what it was judged against, so we do not get to claim it still
+    holds. It is retired, not grandfathered.
+    """
+    verdict = item.verification.get(target)
+    if verdict is None or verdict.contract_fingerprint is None:
+        return False
+    return verdict.contract_fingerprint == contract_fingerprint(item, target, language)
+
+
+def count_invalidated_verdicts(store: dict[str, Item], language: str) -> tuple[int, int]:
+    """`(invalidated, total)` stored verdicts across the store, under the current contract.
+
+    The CLI reports it because the number IS the point: it says how much of the stored
+    verification a contract change has just retired, instead of letting stale verdicts keep
+    painting badges nobody re-earned.
+    """
+    invalidated = total = 0
+    for item in store.values():
+        for target in item.verification:
+            if target not in ALL_TARGETS:
+                continue
+            total += 1
+            if not verdict_is_current(item, cast(VerifyTarget, target), language):
+                invalidated += 1
+    return invalidated, total
 
 
 def _unfetched_parts(item: Item, target: VerifyTarget) -> list[str]:
@@ -202,6 +298,11 @@ def export_verify_worksheet(
                 # verdict binds to the JUDGED text, not to whatever the store holds at write
                 # time (#79). Threaded through the filled worksheet to `apply_verdicts_to_store`.
                 "output_fingerprint": fingerprint_output(item, target),
+                # The contract the judge is being handed RIGHT NOW: this output, this
+                # source, these rubrics. Threaded through the filled worksheet to the
+                # writer, so the stored verdict is bound to what was actually judged —
+                # never to a contract that changed while the judging was in flight.
+                "contract_fingerprint": contract_fingerprint(item, target, output_language),
                 "source": _source_text(item, target),
                 "generation_rubric": load_rubric(_TARGET_RUBRIC[target], language=output_language),
             }
@@ -249,16 +350,20 @@ def _fold_fingerprints(stamps: Iterable[tuple[tuple[str, str], str]]) -> dict[tu
     return fingerprints
 
 
-def _entry_stamps(entries: Iterable[object]) -> Iterator[tuple[tuple[str, str], str]]:
-    """Every valid judged-fingerprint stamp carried by `entries` (worksheet items or report
-    records — both key it the same way), skipping the missing/garbage ones."""
+def _entry_stamps(
+    entries: Iterable[object], stamp: str = "output_fingerprint"
+) -> Iterator[tuple[tuple[str, str], str]]:
+    """Every valid `stamp` carried by `entries` (worksheet items or report records — both key
+    it the same way), skipping the missing/garbage ones."""
     for entry in entries:
-        resolved = _entry_fingerprint(entry)
+        resolved = _entry_fingerprint(entry, stamp)
         if resolved is not None:
             yield resolved
 
 
-def import_verify_fingerprints(paths: list[Path]) -> dict[tuple[str, str], str]:
+def import_verify_fingerprints(
+    paths: list[Path], stamp: str = "output_fingerprint"
+) -> dict[tuple[str, str], str]:
     """Map every `(item_id, target)` to the fingerprint of the output that was JUDGED, read
     from the worksheet(s) `items` block (stamped by `export_verify_worksheet`, and carried
     through to the audit worksheet by `export_audit_worksheet`).
@@ -271,11 +376,13 @@ def import_verify_fingerprints(paths: list[Path]) -> dict[tuple[str, str], str]:
     Conflicting stamps drop the key (see `_fold_fingerprints`).
     """
     return _fold_fingerprints(
-        stamp for path in paths for stamp in _entry_stamps(_worksheet_items(path))
+        found for path in paths for found in _entry_stamps(_worksheet_items(path), stamp)
     )
 
 
-def record_fingerprints(records: Iterable[object]) -> dict[tuple[str, str], str]:
+def record_fingerprints(
+    records: Iterable[object], stamp: str = "output_fingerprint"
+) -> dict[tuple[str, str], str]:
     """The judged fingerprints carried BY the aggregated records themselves (stamped into
     `verify-report.json` by `stamp_record_fingerprints`).
 
@@ -284,7 +391,7 @@ def record_fingerprints(records: Iterable[object]) -> dict[tuple[str, str], str]
     including the ones the auditor never saw (the clean passes outside the consequential set).
     A record with no stamp, or a hand-edited one, resolves to nothing → `fingerprint-missing`.
     """
-    return _fold_fingerprints(_entry_stamps(records))
+    return _fold_fingerprints(_entry_stamps(records, stamp))
 
 
 def cross_check_fingerprints(
@@ -316,7 +423,9 @@ def cross_check_fingerprints(
 
 
 def stamp_record_fingerprints(
-    aggregated: list[dict], fingerprints: dict[tuple[str, str], str]
+    aggregated: list[dict],
+    fingerprints: dict[tuple[str, str], str],
+    stamp: str = "output_fingerprint",
 ) -> None:
     """Stamp each aggregated record with the JUDGED fingerprint of its output, in place.
 
@@ -328,7 +437,7 @@ def stamp_record_fingerprints(
     for record in aggregated:
         fingerprint = fingerprints.get((str(record.get("item_id")), str(record.get("target"))))
         if fingerprint is not None:
-            record["output_fingerprint"] = fingerprint
+            record[stamp] = fingerprint
 
 
 def _worksheet_items(path: Path) -> list:
@@ -340,16 +449,22 @@ def _worksheet_items(path: Path) -> list:
     return items if isinstance(items, list) else []
 
 
-def _entry_fingerprint(entry: object) -> tuple[tuple[str, str], str] | None:
-    """`((item_id, target), fingerprint)` for a worksheet entry carrying a valid stamped
-    fingerprint, else None (a non-dict entry or a missing/garbage hash)."""
+def _entry_fingerprint(
+    entry: object, stamp: str = "output_fingerprint"
+) -> tuple[tuple[str, str], str] | None:
+    """`((item_id, target), fingerprint)` for a worksheet entry carrying a valid `stamp`,
+    else None (a non-dict entry or a missing/garbage hash).
+
+    `stamp` selects WHICH fingerprint: `output_fingerprint` (the judged text) or
+    `contract_fingerprint` (the whole judging contract). One reader, so both stamps inherit
+    the same validation and the same fail-safe conflict handling."""
     if not isinstance(entry, dict):
         return None
-    fingerprint = entry.get("output_fingerprint")
+    fingerprint = entry.get(stamp)
     key = (str(entry.get("item_id")), str(entry.get("target")))
     if isinstance(fingerprint, str) and _FINGERPRINT_RE.match(fingerprint):
         return key, fingerprint
-    logger.debug("worksheet entry %s carries no valid output_fingerprint", key)
+    logger.debug("worksheet entry %s carries no valid %s", key, stamp)
     return None
 
 
@@ -607,7 +722,10 @@ class VerdictWriteResult:
 
 
 def _verdict_skip_reason(
-    record: object, store: dict[str, Item], fingerprints: dict[tuple[str, str], str]
+    record: object,
+    store: dict[str, Item],
+    fingerprints: dict[tuple[str, str], str],
+    contracts: dict[tuple[str, str], str],
 ) -> str | None:
     """Why this aggregated record cannot be written as a verdict, or None if it can.
 
@@ -630,16 +748,28 @@ def _verdict_skip_reason(
         return "fingerprint-missing"
     if not _FINGERPRINT_RE.match(fingerprint):
         return "fingerprint-invalid"
+    contract = contracts.get((item_id, target))
+    if contract is None:
+        # A worksheet from before the contract stamp existed. The verdict may be perfectly
+        # good, but we cannot say WHAT it was judged against — and a verdict we cannot bind
+        # to a contract is exactly the lie this closes. Skip it; re-verify to write it.
+        return "contract-missing"
+    if not _FINGERPRINT_RE.match(contract):
+        return "contract-invalid"
     return None
 
 
-def _build_verdict(record: dict, output_fingerprint: str) -> VerificationVerdict:
-    """Assemble one `VerificationVerdict` from an aggregated record + its JUDGED fingerprint."""
+def _build_verdict(
+    record: dict, output_fingerprint: str, contract_fingerprint_: str
+) -> VerificationVerdict:
+    """Assemble one `VerificationVerdict` from an aggregated record + the JUDGED fingerprints:
+    the output the judges read, and the CONTRACT they judged it under."""
     return VerificationVerdict(
         verdict=cast(Verdict, _verdict_of(record, "verdict")),
         faithfulness=_axis(record.get("faithfulness")),
         adherence=_axis(record.get("adherence")),
         output_fingerprint=output_fingerprint,
+        contract_fingerprint=contract_fingerprint_,
         verified_at=datetime.now(timezone.utc),
         flags=_flag_issues(record.get("flags") or []),
     )
@@ -665,6 +795,7 @@ def apply_verdicts_to_store(
     store: dict[str, Item],
     aggregated: list[dict],
     fingerprints: dict[tuple[str, str], str],
+    contracts: dict[tuple[str, str], str],
 ) -> VerdictWriteResult:
     """Persist each aggregated verdict onto its item as a `VerificationVerdict`, keyed by
     target, storing the JUDGED output fingerprint from `fingerprints` (opt-in
@@ -688,14 +819,14 @@ def apply_verdicts_to_store(
     written = 0
     skipped: list[tuple[str, str, str]] = []
     for record in aggregated:
-        reason = _verdict_skip_reason(record, store, fingerprints)
+        reason = _verdict_skip_reason(record, store, fingerprints, contracts)
         if reason is not None:
             as_dict = record if isinstance(record, dict) else {}
             skipped.append((str(as_dict.get("item_id")), str(as_dict.get("target")), reason))
             continue
         item_id, target = str(record["item_id"]), str(record["target"])
         store[item_id].verification[target] = _build_verdict(
-            record, fingerprints[(item_id, target)]
+            record, fingerprints[(item_id, target)], contracts[(item_id, target)]
         )
         written += 1
     return VerdictWriteResult(written=written, skipped=skipped)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3836,3 +3836,79 @@ def test_fetch_revalidate_is_report_only_until_write(tmp_path: Path, monkeypatch
     stored = json.loads(items_path.read_text(encoding="utf-8"))["7"]["content"]["sources"][0]
     assert stored["outcome"] == "failure"
     assert stored["failure_reason"] == "blocked_interstitial"
+
+
+# ---------------------------------------------------------------- PR-D: the contract fingerprint
+
+
+def test_verify_write_verdicts_stores_the_contract_it_was_judged_under(tmp_path: Path, monkeypatch):
+    """The verdict binds to the whole judging contract — the output, the source the judge
+    read, and the rubrics it applied — not just to the output text."""
+    from xbrain.store import load_store
+    from xbrain.verification import contract_fingerprint
+
+    _setup_repo(tmp_path, monkeypatch)
+    items_path = tmp_path / "data" / "items.json"
+    item = _verify_video_item("7")
+    save_store({"7": item}, items_path)
+    ws = _export_summary_worksheet(tmp_path)
+    _fill_summary_judgment(ws)
+
+    result = runner.invoke(app, ["verify", "--apply", str(ws), "--write-verdicts"])
+    assert result.exit_code == 0, result.output
+
+    stored = load_store(items_path)["7"].verification["summary"]
+    assert stored.contract_fingerprint == contract_fingerprint(item, "summary", "English")
+
+
+def test_verify_reports_how_many_verdicts_the_contract_change_invalidated(
+    tmp_path: Path, monkeypatch
+):
+    """The number IS the point: it says how much of the stored verification a contract
+    change has retired. A verdict stored under the old contract (no contract fingerprint)
+    is counted, never silently kept alive."""
+    from xbrain.models import VerificationVerdict
+    from xbrain.verification import fingerprint_output
+
+    _setup_repo(tmp_path, monkeypatch)
+    items_path = tmp_path / "data" / "items.json"
+    item = _verify_video_item("7")
+    item.verification["summary"] = VerificationVerdict(
+        verdict="FAIL",
+        faithfulness="FAIL",
+        output_fingerprint=fingerprint_output(item, "summary"),
+        verified_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        flags=["unsupported"],
+    )  # judged under the OLD contract: no contract fingerprint
+    save_store({"7": item}, items_path)
+
+    result = runner.invoke(app, ["verify"])
+    assert result.exit_code == 0, result.output
+    assert "OBSOLETOS" in result.stdout
+    assert "1 de 1" in result.stdout
+
+
+def test_verify_refuses_to_write_a_verdict_from_a_pre_contract_worksheet(
+    tmp_path: Path, monkeypatch
+):
+    """A worksheet judged before the contract stamp existed cannot say WHAT its verdict was
+    judged against. It is skipped (`contract-missing`), never written with a guessed
+    contract — the exact lie this closes."""
+    from xbrain.store import load_store
+
+    _setup_repo(tmp_path, monkeypatch)
+    items_path = tmp_path / "data" / "items.json"
+    save_store({"7": _verify_video_item("7")}, items_path)
+    ws = _export_summary_worksheet(tmp_path)
+    _fill_summary_judgment(ws)
+
+    # Strip the contract stamp: this is what a worksheet exported by the old code looks like.
+    data = json.loads(ws.read_text(encoding="utf-8"))
+    for entry in data["items"]:
+        entry.pop("contract_fingerprint", None)
+    ws.write_text(json.dumps(data), encoding="utf-8")
+
+    result = runner.invoke(app, ["verify", "--apply", str(ws), "--write-verdicts"])
+    assert result.exit_code == 0, result.output
+    assert "contract-missing" in result.stdout
+    assert "summary" not in load_store(items_path)["7"].verification  # nothing written

--- a/tests/test_contract_fingerprint.py
+++ b/tests/test_contract_fingerprint.py
@@ -1,0 +1,205 @@
+# tests/test_contract_fingerprint.py
+"""A verdict binds to the CONTRACT it was judged under — not just to the output text.
+
+A verdict is not a property of the output alone. It is the result of judging THAT output
+against THAT source under THAT rubric. `fingerprint_output` hashed only the output, so
+#86 could change what the judge reads (author metadata, thread, quoted-post markers,
+images, titles) and rewrite `rubric-verify.md` + `rubric-summary.md` — **without touching
+a single output character** — and every stored verdict still matched, still looked
+current, and still painted its badge. Including the verdicts issued under the contract
+that was measured letting a false attribution through 8 times out of 8.
+
+`fingerprint_contract` binds all three arms. Each arm gets a test here: change the
+output → stale; change the source → stale; change the rubric → stale; change nothing →
+fresh, and the badge paints.
+"""
+
+from datetime import datetime, timezone
+
+
+from xbrain.models import (
+    Author,
+    Content,
+    ContentSourceSuccess,
+    Enrichment,
+    Item,
+    VerificationVerdict,
+    VideoFrame,
+)
+from xbrain.verification import (
+    contract_fingerprint,
+    count_invalidated_verdicts,
+    fingerprint_output,
+    rubric_digest,
+)
+
+
+def _item(*, summary: str = "A crisp summary.", frames: tuple[str, ...] = ("A chart.",)) -> Item:
+    return Item(
+        id="7",
+        source="bookmark",
+        url="https://x.com/a/status/7",
+        author=Author(handle="a", name="A"),
+        text="watch this",
+        created_at=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        enriched=Enrichment(
+            enriched_at=datetime(2026, 5, 17, tzinfo=timezone.utc),
+            executor="claude-code",
+            summary=summary,
+            primary_topic="ai-coding",
+            topics=["ai-coding"],
+        ),
+        content=Content(
+            fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video",
+                    url="https://x.com/v",
+                    title="A talk",
+                    text="the transcript body",
+                    has_speech=True,
+                    frames=[
+                        VideoFrame(
+                            timestamp=float(i), local_path=f"7/frames/{i}.png", description=d
+                        )
+                        for i, d in enumerate(frames)
+                    ],
+                    digest="A long digest.",
+                )
+            ],
+        ),
+    )
+
+
+# ------------------------------------------------------------------ the three arms
+
+
+def test_the_fingerprint_changes_when_the_OUTPUT_changes():
+    before = contract_fingerprint(_item(), "summary", "English")
+    after = contract_fingerprint(_item(summary="A different summary."), "summary", "English")
+    assert before is not None and before != after
+
+
+def test_the_fingerprint_changes_when_the_SOURCE_changes():
+    """The judge read a source. Enrich adds a frame description, `describe` adds an image,
+    a fetch lands the article — the output is untouched, but what supports it is not the
+    same evidence any more. The verdict must not survive that."""
+    before = contract_fingerprint(_item(), "summary", "English")
+    after = contract_fingerprint(_item(frames=("A chart.", "A new slide.")), "summary", "English")
+    assert before is not None and before != after
+
+
+def test_the_fingerprint_changes_when_the_RUBRIC_changes(tmp_path, monkeypatch):
+    """The rules the judge applied are part of the verdict. #86 rewrote them and every
+    stored verdict still matched — this is the arm that closes that."""
+    from xbrain import rubrics as rubrics_mod
+
+    before = contract_fingerprint(_item(), "summary", "English")
+
+    original = rubrics_mod._RUBRICS_DIR
+    shadow = tmp_path / "rubrics"
+    shadow.mkdir()
+    for rubric in original.glob("*.md"):
+        shadow.joinpath(rubric.name).write_text(
+            rubric.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    verify = shadow / "rubric-verify.md"
+    verify.write_text(verify.read_text(encoding="utf-8") + "\nA NEW RULE.\n", encoding="utf-8")
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", shadow)
+    rubric_digest.cache_clear()  # the digest is cached per run; a rubric edit must invalidate
+
+    after = contract_fingerprint(_item(), "summary", "English")
+    rubric_digest.cache_clear()
+    assert before is not None and before != after
+
+
+def test_the_fingerprint_is_stable_when_NOTHING_changes():
+    """The negative arm: a hash that changed on every call would invalidate everything and
+    teach the reader to ignore the badge."""
+    assert contract_fingerprint(_item(), "summary", "English") == contract_fingerprint(
+        _item(), "summary", "English"
+    )
+
+
+def test_each_target_gets_its_own_contract():
+    """A digest is judged against a different source AND a different generation rubric than
+    a summary, so their contracts cannot collide."""
+    item = _item()
+    assert contract_fingerprint(item, "summary", "English") != contract_fingerprint(
+        item, "digest", "English"
+    )
+
+
+def test_the_language_is_part_of_the_contract():
+    """The rubric is language-substituted; a judge given the Spanish rubric applied a
+    different text."""
+    assert contract_fingerprint(_item(), "summary", "English") != contract_fingerprint(
+        _item(), "summary", "Spanish"
+    )
+
+
+def test_no_output_no_fingerprint():
+    item = _item()
+    item.enriched = None
+    assert contract_fingerprint(item, "summary", "English") is None
+
+
+def test_the_contract_hash_is_not_the_output_hash():
+    """Guard against a refactor collapsing the two: the whole defect was a fingerprint that
+    saw only the output."""
+    item = _item()
+    assert contract_fingerprint(item, "summary", "English") != fingerprint_output(item, "summary")
+
+
+# ------------------------------------------------------------------ migration
+
+
+def _verdict(contract: str | None) -> VerificationVerdict:
+    return VerificationVerdict(
+        verdict="FAIL",
+        faithfulness="FAIL",
+        output_fingerprint="a" * 64,
+        contract_fingerprint=contract,
+        verified_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        flags=["unsupported"],
+    )
+
+
+def test_a_legacy_verdict_loads_and_is_stale():
+    """Every verdict stored before this change was judged under the OLD contract. It must
+    load (never crash on the old shape), and it must evaluate STALE — not be grandfathered
+    in, because we cannot honestly say what it was judged against."""
+    legacy = VerificationVerdict.model_validate(
+        {
+            "verdict": "FAIL",
+            "faithfulness": "FAIL",
+            "adherence": "PASS",
+            "output_fingerprint": "b" * 64,
+            "verified_at": "2026-06-01T00:00:00Z",
+            "flags": ["unsupported"],
+        }
+    )
+    assert legacy.contract_fingerprint is None  # the old shape carries none
+
+
+def test_count_invalidated_verdicts_counts_every_stale_stored_verdict():
+    """The CLI reports the number, because the number IS the point: it says how much of the
+    stored verification the contract change just retired."""
+    fresh_item = _item()
+    fresh = _verdict(contract_fingerprint(fresh_item, "summary", "English"))
+    fresh_item.verification["summary"] = fresh
+
+    legacy_item = _item()
+    legacy_item.id = "8"
+    legacy_item.verification["summary"] = _verdict(None)  # judged under the old contract
+
+    changed_item = _item(summary="regenerated since it was judged")
+    changed_item.id = "9"
+    changed_item.verification["summary"] = _verdict(
+        contract_fingerprint(_item(), "summary", "English")
+    )
+
+    store = {"7": fresh_item, "8": legacy_item, "9": changed_item}
+    invalidated, total = count_invalidated_verdicts(store, "English")
+    assert (invalidated, total) == (2, 3)

--- a/tests/test_contract_fingerprint.py
+++ b/tests/test_contract_fingerprint.py
@@ -90,28 +90,60 @@ def test_the_fingerprint_changes_when_the_SOURCE_changes():
     assert before is not None and before != after
 
 
-def test_the_fingerprint_changes_when_the_RUBRIC_changes(tmp_path, monkeypatch):
-    """The rules the judge applied are part of the verdict. #86 rewrote them and every
-    stored verdict still matched — this is the arm that closes that."""
+def _shadow_rubrics(tmp_path, monkeypatch, edited: str) -> None:
+    """Copy the rubrics to a temp dir, append a line to `edited`, and point the loader there.
+
+    The digest is cached per run (the rubrics do not change mid-run), so an on-disk edit must
+    clear it — exactly what a test has to do and production never does.
+    """
     from xbrain import rubrics as rubrics_mod
 
-    before = contract_fingerprint(_item(), "summary", "English")
-
-    original = rubrics_mod._RUBRICS_DIR
     shadow = tmp_path / "rubrics"
     shadow.mkdir()
-    for rubric in original.glob("*.md"):
+    for rubric in rubrics_mod._RUBRICS_DIR.glob("*.md"):
         shadow.joinpath(rubric.name).write_text(
             rubric.read_text(encoding="utf-8"), encoding="utf-8"
         )
-    verify = shadow / "rubric-verify.md"
-    verify.write_text(verify.read_text(encoding="utf-8") + "\nA NEW RULE.\n", encoding="utf-8")
+    target = shadow / edited
+    target.write_text(target.read_text(encoding="utf-8") + "\nA NEW RULE.\n", encoding="utf-8")
     monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", shadow)
-    rubric_digest.cache_clear()  # the digest is cached per run; a rubric edit must invalidate
+    rubric_digest.cache_clear()
 
+
+def test_the_fingerprint_changes_when_the_JUDGE_RUBRIC_changes(tmp_path, monkeypatch):
+    """The rules the judge applied are part of the verdict. #86 rewrote `rubric-verify.md`
+    and every stored verdict still matched — this is the arm that closes that."""
+    before = contract_fingerprint(_item(), "summary", "English")
+    _shadow_rubrics(tmp_path, monkeypatch, "rubric-verify.md")
     after = contract_fingerprint(_item(), "summary", "English")
     rubric_digest.cache_clear()
     assert before is not None and before != after
+
+
+def test_the_fingerprint_changes_when_the_GENERATION_RUBRIC_changes(tmp_path, monkeypatch):
+    """The judge reads TWO rubrics: how to judge (`rubric-verify`) and what the output was
+    supposed to obey (the target's generation rubric — the adherence axis is judged against
+    it, and #91 rewrote exactly that one). Hashing only the judge's rubric would let a
+    generation-rubric rewrite leave every adherence verdict standing."""
+    before = contract_fingerprint(_item(), "summary", "English")
+    _shadow_rubrics(tmp_path, monkeypatch, "rubric-summary.md")
+    after = contract_fingerprint(_item(), "summary", "English")
+    rubric_digest.cache_clear()
+    assert before is not None and before != after
+
+
+def test_a_generation_rubric_only_invalidates_ITS_target(tmp_path, monkeypatch):
+    """A rewrite of `rubric-video-digest` retires the DIGEST verdicts, not the summaries —
+    or every rubric edit would invalidate the whole corpus and the badge would mean nothing."""
+    item = _item()
+    summary_before = contract_fingerprint(item, "summary", "English")
+    digest_before = contract_fingerprint(item, "digest", "English")
+    _shadow_rubrics(tmp_path, monkeypatch, "rubric-video-digest.md")
+    summary_after = contract_fingerprint(item, "summary", "English")
+    digest_after = contract_fingerprint(item, "digest", "English")
+    rubric_digest.cache_clear()
+    assert digest_before != digest_after  # the digest's rules changed
+    assert summary_before == summary_after  # the summary's did not
 
 
 def test_the_fingerprint_is_stable_when_NOTHING_changes():
@@ -129,6 +161,33 @@ def test_each_target_gets_its_own_contract():
     assert contract_fingerprint(item, "summary", "English") != contract_fingerprint(
         item, "digest", "English"
     )
+
+
+def test_the_target_itself_separates_two_otherwise_identical_contracts(monkeypatch):
+    """The TARGET is hashed in its own right, not merely implied by the generation rubric.
+
+    Today each target happens to have a distinct rubric and a distinct output, so the target
+    arm looks redundant — a mutation dropping it survives every other test. It is not
+    redundant: it is what stops a verdict crossing targets if two of them ever share a
+    generation rubric. Pinned by making that world exist — same output, same source, same
+    rubric — so ONLY the target differs.
+    """
+    from xbrain import verification
+
+    item = _item()
+    item.content.sources[0].digest = item.enriched.summary  # same OUTPUT for both targets
+    monkeypatch.setitem(verification._TARGET_RUBRIC, "digest", "summary")  # same RUBRIC
+    rubric_digest.cache_clear()
+    try:
+        # This item carries no article/thread/images, so the two targets' SOURCES coincide too.
+        assert verification._source_text(item, "summary") == verification._source_text(
+            item, "digest"
+        )
+        assert contract_fingerprint(item, "summary", "English") != contract_fingerprint(
+            item, "digest", "English"
+        )
+    finally:
+        rubric_digest.cache_clear()
 
 
 def test_the_language_is_part_of_the_contract():

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1236,18 +1236,29 @@ def _badge_item(item_id: str = "9", *, summary: str = "A crisp summary.") -> Ite
     )
 
 
-def _stamp(item: Item, target: str, verdict: str, *, flags: list[str] | None = None) -> None:
-    """Stamp a CURRENT verification verdict (matching fingerprint) onto `item`."""
+def _stamp(
+    item: Item,
+    target: str,
+    verdict: str,
+    *,
+    flags: list[str] | None = None,
+    language: str = "English",
+) -> None:
+    """Stamp a CURRENT verification verdict onto `item` — current under the whole judging
+    CONTRACT (the output it judged, the source it read, the rubric it applied), not just
+    the output text."""
     from xbrain.models import VerificationVerdict
-    from xbrain.verification import fingerprint_output
+    from xbrain.verification import contract_fingerprint, fingerprint_output
 
     fp = fingerprint_output(item, target)
-    assert fp is not None
+    contract = contract_fingerprint(item, target, language)
+    assert fp is not None and contract is not None
     item.verification[target] = VerificationVerdict(
         verdict=verdict,
         faithfulness="FAIL" if verdict == "FAIL" else "PASS",
         adherence="REVIEW" if verdict == "REVIEW" else "PASS",
         output_fingerprint=fp,
+        contract_fingerprint=contract,
         verified_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
         flags=flags or [],
     )
@@ -1331,7 +1342,7 @@ def test_generate_badges_digest_verdict_near_video_header(tmp_path: Path):
 
 def test_generate_spanish_badge_label_is_localized(tmp_path: Path):
     item = _badge_item()
-    _stamp(item, "summary", "FAIL", flags=["número no soportado"])
+    _stamp(item, "summary", "FAIL", flags=["número no soportado"], language="Spanish")
     generate({item.id: item}, tmp_path, output_language="Spanish")
     body = _note_body(tmp_path)
     assert "Verificación: FALLA" in body
@@ -1353,10 +1364,15 @@ def test_generate_no_badge_when_output_fixed_before_write(tmp_path: Path):
     """End-to-end (#79): a FAIL judged on summary "A", the summary regenerated to "B" BEFORE
     `--write-verdicts`, must never badge "B" — the stored (judged) fingerprint is of "A", so
     `generate` on "B" finds a mismatch. Uses the real write path with a judged fingerprint."""
-    from xbrain.verification import apply_verdicts_to_store, fingerprint_output
+    from xbrain.verification import (
+        apply_verdicts_to_store,
+        contract_fingerprint,
+        fingerprint_output,
+    )
 
     item = _badge_item(summary="A - judged and FAILED.")
     judged_fp = fingerprint_output(item, "summary")
+    judged_contract = contract_fingerprint(item, "summary", "English")
     item.enriched.summary = "B - fixed before the write."  # regenerated in the window
     store = {item.id: item}
     result = apply_verdicts_to_store(
@@ -1372,6 +1388,7 @@ def test_generate_no_badge_when_output_fixed_before_write(tmp_path: Path):
             }
         ],
         {(item.id, "summary"): judged_fp},
+        {(item.id, "summary"): judged_contract},
     )
     assert result.written == 1
     assert store[item.id].verification["summary"].output_fingerprint == judged_fp
@@ -1566,3 +1583,88 @@ def test_the_quoted_kind_is_selected_by_the_shared_frozenset(tmp_path: Path):
     """Guards the drift this whole workstream is about: the renderer must not grow its
     own private notion of what a quoted post is."""
     assert _readable_quote().kind in QUOTED_CONTENT_KINDS
+
+
+def test_generate_does_not_badge_a_verdict_judged_against_a_DIFFERENT_SOURCE(tmp_path: Path):
+    """The output is untouched, but the evidence under it changed (a new frame description
+    landed). The judge never saw that source, so its verdict says nothing about this
+    output-plus-source pair. No badge."""
+    from xbrain.models import Content, ContentSourceSuccess, VideoFrame
+
+    item = _badge_item()
+    item.content = Content(
+        fetched_at=datetime(2026, 5, 16, tzinfo=timezone.utc),
+        sources=[
+            ContentSourceSuccess(
+                kind="x_video",
+                url="https://x.com/v",
+                title="A talk",
+                text="the transcript body",
+                has_speech=True,
+                frames=[
+                    VideoFrame(timestamp=0.0, local_path="9/frames/0.png", description="A chart.")
+                ],
+            )
+        ],
+    )
+    _stamp(item, "summary", "FAIL", flags=["unsupported number"])
+    source = item.content.sources[0]
+    source.frames = [
+        *source.frames,
+        VideoFrame(timestamp=9.0, local_path="9/frames/9.png", description="A brand-new slide."),
+    ]
+    generate({item.id: item}, tmp_path)
+    body = _note_body(tmp_path)
+    assert "❌" not in body
+    assert "Verification: FAIL" not in body
+
+
+def test_generate_does_not_badge_a_verdict_judged_under_an_OLD_RUBRIC(tmp_path: Path, monkeypatch):
+    """#86 rewrote `rubric-verify.md` without touching one output character, and every
+    stored verdict still painted. This is the arm that closes it."""
+    from xbrain import rubrics as rubrics_mod
+    from xbrain.verification import rubric_digest
+
+    item = _badge_item()
+    _stamp(item, "summary", "FAIL", flags=["unsupported number"])
+
+    original = rubrics_mod._RUBRICS_DIR
+    shadow = tmp_path / "rubrics"
+    shadow.mkdir()
+    for rubric in original.glob("*.md"):
+        shadow.joinpath(rubric.name).write_text(
+            rubric.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    verify = shadow / "rubric-verify.md"
+    verify.write_text(
+        verify.read_text(encoding="utf-8") + "\nA RULE THE JUDGE NEVER SAW.\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", shadow)
+    rubric_digest.cache_clear()
+    try:
+        generate({item.id: item}, tmp_path / "out")
+        body = next((tmp_path / "out" / "items").glob("*.md")).read_text(encoding="utf-8")
+    finally:
+        rubric_digest.cache_clear()
+    assert "❌" not in body
+    assert "Verification: FAIL" not in body
+
+
+def test_generate_does_not_badge_a_LEGACY_verdict_with_no_contract(tmp_path: Path):
+    """Every verdict stored before this change was judged under a contract we cannot
+    reconstruct. It is not grandfathered in: it paints NOTHING."""
+    from xbrain.models import VerificationVerdict
+    from xbrain.verification import fingerprint_output
+
+    item = _badge_item()
+    item.verification["summary"] = VerificationVerdict(
+        verdict="FAIL",
+        faithfulness="FAIL",
+        output_fingerprint=fingerprint_output(item, "summary"),
+        verified_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        flags=["unsupported number"],
+    )  # no contract_fingerprint — the old shape
+    generate({item.id: item}, tmp_path)
+    body = _note_body(tmp_path)
+    assert "❌" not in body
+    assert "Verification: FAIL" not in body

--- a/tests/test_i18n.py
+++ b/tests/test_i18n.py
@@ -37,6 +37,7 @@ def test_strings_dataclass_has_exactly_the_expected_fields() -> None:
     """If a field is added or removed, every translation must be updated."""
     field_names = {f.name for f in dataclasses.fields(Strings)}
     assert field_names == {
+        "language",
         "topics_label",
         "content_header",
         "summary_header",

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -29,6 +29,20 @@ from xbrain.verification import (
 )
 
 
+def _contracts(store: dict) -> dict[tuple[str, str], str]:
+    """The contract stamps `export_verify_worksheet` would put on every (item, target) —
+    what the writer threads through when the judging was done under the current contract."""
+    from xbrain.verification import ALL_TARGETS, contract_fingerprint
+
+    stamps: dict[tuple[str, str], str] = {}
+    for item_id, item in store.items():
+        for target in ALL_TARGETS:
+            contract = contract_fingerprint(item, target, "English")
+            if contract is not None:
+                stamps[(item_id, target)] = contract
+    return stamps
+
+
 def test_parse_targets_resolves_and_validates():
     assert parse_targets("all") == ALL_TARGETS
     assert parse_targets("digest") == ("digest",)
@@ -367,7 +381,7 @@ def test_import_verify_fingerprints_drops_conflicting_stamps(tmp_path):
     # Consequence: the dropped key is not written (fingerprint-missing); the agreed key is.
     store = {"7": _item()}
     aggregated = [_j("FAIL", target="summary"), _j("FAIL", target="digest")]
-    result = apply_verdicts_to_store(store, aggregated, fingerprints)
+    result = apply_verdicts_to_store(store, aggregated, fingerprints, _contracts(store))
     assert "summary" not in store["7"].verification  # dropped → no verdict, no badge
     assert store["7"].verification["digest"].output_fingerprint == "c" * 64
     assert ("7", "summary", "fingerprint-missing") in result.skipped
@@ -379,7 +393,9 @@ def test_apply_verdicts_writes_verdict_with_the_judged_fingerprint():
     aggregated = aggregate_verify_judgments(
         [[_j("FAIL", faithfulness="FAIL", flags=[{"claim": "€150M", "issue": "unsupported"}])]]
     )
-    result = apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp})
+    result = apply_verdicts_to_store(
+        store, aggregated, {("7", "summary"): judged_fp}, _contracts(store)
+    )
     assert result.written == 1 and result.skipped == []
     verdict = store["7"].verification["summary"]
     assert verdict.verdict == "FAIL"
@@ -399,7 +415,9 @@ def test_apply_verdicts_stores_judged_fingerprint_not_live_recompute():
     live_fp = fingerprint_output(store["7"], "summary")
     assert live_fp != judged_fp
 
-    result = apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp})
+    result = apply_verdicts_to_store(
+        store, aggregated, {("7", "summary"): judged_fp}, _contracts(store)
+    )
     assert result.written == 1
     stored = store["7"].verification["summary"].output_fingerprint
     assert stored == judged_fp  # the JUDGED output's fingerprint
@@ -437,7 +455,7 @@ def test_apply_verdicts_tallies_every_skip_reason_and_never_crashes_the_write():
         ("8", "summary"): "nope",
     }
 
-    result = apply_verdicts_to_store(store, aggregated, fingerprints)
+    result = apply_verdicts_to_store(store, aggregated, fingerprints, _contracts(store))
 
     assert result.written == 1 and result.attempted == 7
     assert {reason for _, _, reason in result.skipped} == {
@@ -684,7 +702,7 @@ def test_apply_verdicts_refuses_duplicate_records_so_a_pass_cannot_overwrite_a_f
     ]
 
     with pytest.raises(ValueError, match="duplicate"):
-        apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp})
+        apply_verdicts_to_store(store, aggregated, {("7", "summary"): judged_fp}, _contracts(store))
     assert store["7"].verification == {}  # nothing partially written
 
 


### PR DESCRIPTION
> Reemplaza a #100 (estaba apilado sobre la rama de PR-F, ya mergeada en #94). Mismo contenido, rebasado sobre el `develop` actual.
> **Incluye el fix de `develop` en rojo** (ver #102): `test_the_reason_reaches_every_surface_identically` de #97 llama `_source_text(item)`, y #94 hizo el juez target-scoped. Cada PR verde en su rama; el merge, rojo.

Un verdict no es una propiedad del output. Es el resultado de juzgar **ese output**, contra **esa fuente**, bajo **esas rúbricas**. `fingerprint_output` hasheaba solo lo primero — así que **#86 pudo reescribir lo que el juez lee y reescribir las rúbricas sin tocar un solo carácter de output**, y todos los verdicts almacenados seguían haciendo match, seguían pareciendo frescos y seguían pintando badge. Incluidos los emitidos bajo el contrato que medimos dejando pasar una atribución falsa **8 de 8 veces**.

## `contract_fingerprint(item, target, language)` — tres brazos

1. **OUTPUT** — la afirmación que se juzga.
2. **SOURCE** — `_source_text(item, target)`: la evidencia que el juez leyó **para ESE target** (las `evidence_surfaces` de #94 + los marcadores de "no descargado"). Antes de #94 este brazo habría hasheado la fuente **equivocada** para los digests.
3. **RÚBRICAS** — `rubric_digest`: **las dos** — `rubric-verify` (cómo juzgar) y la rúbrica de generación del target (el eje de *adherence* se juzga contra ella; #91 y #87 reescribieron justo esas). El **idioma** entra también: la rúbrica se sustituye por idioma.

**Barato:** `rubric_digest` con `lru_cache` por `(target, language)` — `generate` corre el check por ítem sobre miles de notas; las rúbricas no cambian dentro de un run.

## La migración tampoco miente

Campo **nuevo y opcional al lado** de `output_fingerprint`, no en su lugar: `output_fingerprint` es **requerido**, así que sustituirlo **crashearía al cargar** cada verdict legacy — y sigue siendo el binding output↔juez del write path (#79/#88).

Todo verdict anterior: **carga**, no lleva contrato, luego evalúa **STALE** → **no pinta NADA** → vuelve al pool de re-juicio. Sin grandfathering: no podemos decir honestamente contra qué se juzgó. **Medido read-only sobre el store real: 69 verdicts, 69 invalidados (100%).** `verify` lo reporta por CLI. El writer **rechaza** (`contract-missing`) un verdict de worksheet pre-contrato en vez de escribirlo con un contrato adivinado.

## 7/7 mutaciones cazadas — y **dos sobrevivieron a la primera**

| Mutación | 1ª pasada | Ahora |
|---|---|---|
| `K1` el hash ignora el **output** · `K2` la **fuente** · `K3` la **rúbrica** | 🔴 | 🔴 |
| `K4` `rubric_digest` ignora la **rúbrica de GENERACIÓN** | 🟢 **sobrevivía** | 🔴 |
| `K5` el hash ignora el **target** | 🟢 **sobrevivía** | 🔴 |
| `K6` un verdict legacy se trata como **vigente** · `K7` el badge mira **solo el output** | 🔴 | 🔴 |

- **K4 era un agujero real**: mi test de rúbrica editaba solo `rubric-verify.md`, así que hashear únicamente la rúbrica del juez dejaba en pie **todo verdict de adherence** ante una reescritura de la rúbrica de generación — que es literalmente lo que hicieron #91 y #87. Pinchado, **más el converso**: editar `rubric-video-digest` retira los verdicts de **digest** y **no** los de summary (si no, cada edición invalidaría el corpus entero y el badge dejaría de significar nada).
- **K5 sobrevivía porque el target es redundante POR CASUALIDAD** (hoy cada target tiene output y rúbrica distintos). No es redundante por diseño: impide que un verdict cruce de target si dos llegaran a compartir rúbrica. Pinchado construyendo ese mundo — mismo output, misma fuente, misma rúbrica, solo cambia el target.

## Estado
**1.510 tests verdes** · `poe check` completo en verde (ruff, format, mypy, radon A/B, bandit, vulture, interrogate, detect-secrets, deptry, cobertura 94%). Store **no tocado**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)