### PR TITLE
docs: rule 6 cites 620 / 526 / 1,551 — each re-derived, each with its definition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,10 +335,20 @@ the judge read **and** the rubrics it applied).
 
 And check the invalidation signal actually **reaches the population being repaired**. The
 usual lever is `content.fetched_at` — and it cannot reach an item whose `content` is
-`None`, because there is nothing to stamp. Measured on the real store: **1,551 of 2,168
-items (72%) have no `content` at all**, and **686 of them quote a post** — the exact
-population a quoted-post repair exists to fix. A repair whose staleness signal lives on
-the object it is creating reaches nobody.
+`None`, because there is nothing to stamp.
+
+Measured on the real store, each number with the definition it was measured under:
+
+- **620** items are truncated (`looks_truncated`);
+- of those, **526** have the truncated tweet as their **only** evidence — no article, no
+  transcript, no thread. Repairing their text changes everything downstream;
+- and **1,551 of 2,168 (72%)** carry **no `content` block at all**, so a `fetched_at`
+  lever reaches none of them.
+
+A repair whose staleness signal lives on the object it is *creating* reaches nobody. (The
+figure originally quoted here — "432" — was stale: it predated a fix that moved detection
+from 535 to 620, and nobody re-derived it when the population moved. Both numbers above
+were re-derived from the store before being written down. That is the whole of rule 2.)
 
 ### 7. The cheapest verification layer is showing the user the evidence next to the claim
 


### PR DESCRIPTION
Último retoque a las *Rules paid for in blood*. La regla 6 ya cita los números que **sobreviven a la re-derivación**, cada uno con la definición bajo la que se midió.

Los re-derivé yo desde el store real (read-only) **antes** de escribirlos, en vez de copiar los del brief:

| | |
|---|---|
| **620** | ítems truncados (`looks_truncated`) |
| **526** | …cuyo tweet truncado es su **ÚNICA** evidencia — sin artículo, sin transcript, sin hilo. Reparar su texto cambia todo lo derivado. |
| **1.551** | de 2.168 (**72%**) **no tienen bloque `content` en absoluto** — así que una palanca de staleness tipo `fetched_at` **no alcanza a ninguno**. |

El tercero es el que hace morder la regla: *una reparación cuya señal de invalidación vive en el objeto que está creando no llega a nadie.*

## Sobre el 432

El número que citaba antes (**432**) **estaba stale**: era anterior al fix de los dos puntos que subió la detección de truncados de 535 a 620, y **nadie lo re-derivó cuando la población se movió**. Se arrastró durante horas — hasta dentro del propio brief que encargaba escribir una regla contra exactamente eso.

**El doc lo nombra, no lo entierra en silencio.** Una regla contra los números sin verificar es más convincente con su propia retractación impresa debajo.

## Estado
`poe check` completo en verde · 1.582 tests. Solo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)