### PR TITLE
fix(ci): run the gate on the merge result, not just the PR head

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,15 +1,38 @@
 name: Quality
 on:
-  # `pull_request` tests the PR head; `push` tests the MERGE RESULT. Both are needed:
-  # two PRs can each be green in isolation, merge with no textual conflict, and leave
-  # `develop` red (#103). Only a run on the pushed merge commit catches that.
+  # `pull_request` ALREADY tests a merge result: GitHub builds `refs/pull/N/merge` — the PR
+  # head merged into the base — and checks THAT out, not the bare PR head. The defect is not
+  # that the merge goes untested. It is that the merge ref is computed when the run is
+  # TRIGGERED, and is never recomputed when the base moves underneath it.
+  #
+  # #103, to the second: #94's green was measured against a base that did not yet contain
+  # #97. #97 landed at 14:01:08Z. #94 merged at 14:04:08Z on that now-stale green. Merging
+  # #97 does not re-trigger #94's checks, so nothing ever ran the two together — and
+  # `develop` went red with no textual conflict anywhere for git to complain about.
+  #
+  # `push` is therefore a DETECTOR: every push to develop/main IS the true merge result, and
+  # this run tests it — after the fact. The PREVENTER is branch protection's `strict`
+  # (require branches up to date before merging), which forces the merge ref to be
+  # recomputed against the current base first. They are complementary: `strict` stops the
+  # stale merge landing; `push` catches whatever lands anyway. Neither replaces the other.
   push:
     branches: [develop, main]
   pull_request:
     branches: [develop, main]
 jobs:
+  # The job id IS the required status check name on develop/main. Renaming it (or giving it
+  # a `name:`) makes the required check never appear, and GitHub then waits for it forever:
+  # every merge blocks, permanently. Change the branch-protection setting FIRST if you ever
+  # must rename it. Guarded by tests/test_ci_workflow.py.
   quality:
     runs-on: ubuntu-latest
+    permissions:
+      # A `permissions:` block sets every scope NOT listed to `none` — `contents: read` is
+      # what lets actions/checkout clone the repo, so it is load-bearing, not boilerplate.
+      contents: read
+      # Lets the built-in GITHUB_TOKEN (`github-actions[bot]`) file the red-branch issue
+      # below. No PAT and no bot account, so no second identity to manage.
+      issues: write
     env:
       # Pin the Python hash seed so the gate is byte-reproducible run-to-run
       # (determinism; check.sh pins the same default for local runs).
@@ -26,3 +49,28 @@ jobs:
           uv pip install -e ".[dev]"
       - name: Quality gate
         run: bash scripts/check.sh
+
+      # A red PUSH run blocks nothing — the commit has already landed — so it must speak, or
+      # it is detecting into a void. Scoped to `push`: a red PR is already in front of its
+      # author, and alerting on it would file one issue per pushed commit.
+      - name: Announce a red branch
+        if: failure() && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/announce_red_branch.sh open
+
+      # A green push on the true merge result disproves the alert, so close it. An alert that
+      # is routinely stale is one people learn to scroll past.
+      - name: Resolve the red-branch alert
+        if: success() && github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.ref_name }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/announce_red_branch.sh close

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,5 +1,10 @@
 name: Quality
 on:
+  # `pull_request` tests the PR head; `push` tests the MERGE RESULT. Both are needed:
+  # two PRs can each be green in isolation, merge with no textual conflict, and leave
+  # `develop` red (#103). Only a run on the pushed merge commit catches that.
+  push:
+    branches: [develop, main]
   pull_request:
     branches: [develop, main]
 jobs:

--- a/scripts/announce_red_branch.sh
+++ b/scripts/announce_red_branch.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Announce (or resolve) a RED gated branch by filing a GitHub issue.
+#
+# WHY THIS EXISTS
+#
+# A `push`-triggered gate run that goes red blocks nothing: the commit is already ON the
+# branch. Branch protection guards the door, and this run happens after the horse has left.
+# So if the red run does not SPEAK, it detects into a void.
+#
+# It did exactly that on 2026-07-14. `develop` was red for 9m15s; three commits took the red
+# commit as their parent; and two agents opened DUPLICATE hotfix PRs 31 seconds apart, each
+# having rediscovered the same breakage by hand. Nobody was watching the Actions tab, because
+# watching the Actions tab is not a control.
+#
+# IDENTITY: uses the built-in GITHUB_TOKEN (`github-actions[bot]`) with `issues: write`.
+# No PAT, no bot account, no second human. Do not "upgrade" this to a PAT.
+#
+# IDEMPOTENCY: one open issue per gated branch, keyed by the label `ci-red-<branch>`. If the
+# branch is red across three pushes that is ONE issue with three comments, not three issues.
+#
+# Getting that right is harder than it looks, and the naive version was WRONG. Every GitHub
+# issue LIST endpoint — label filter, search, and the plain REST list alike — is EVENTUALLY
+# consistent. Measured on this repo: an issue created and then listed immediately does not
+# appear for several seconds, while fetching it by number returns it at once. So a bare
+# list-then-create races against its own write: two runs inside the lag window both conclude
+# "no issue exists" and both file one. This is not hypothetical — the first version of this
+# script filed issues #113 AND #114 for a single branch when `open` ran twice.
+#
+# Hence two defences, because neither alone suffices:
+#   1. RETRY the lookup with a bounded backoff (open mode only), which absorbs the ordinary
+#      index lag — the common case.
+#   2. RECONCILE on every run: if more than one open issue carries the key, keep the oldest
+#      and close the rest as duplicates. A true race can still slip past the retry; this
+#      makes the state CONVERGE on the next run instead of compounding. Note the shape of
+#      the fix — the system heals itself rather than trusting a check to have been right.
+#
+# Usage:  announce_red_branch.sh open|close
+#   open  - branch is red: file the issue, or add a comment if it is already open
+#   close - branch is green again: comment the fixing sha and close the issue, if any
+#
+# Env (all supplied by the workflow from trusted `github.*` context, never user input):
+#   GH_TOKEN, REPO, BRANCH, SHA, RUN_URL
+
+set -euo pipefail
+
+MODE="${1:?usage: announce_red_branch.sh open|close}"
+# Validate the mode BEFORE touching the API: a typo should fail instantly and loudly, not
+# after two network round-trips, and certainly not by falling through to a no-op that leaves
+# a red branch unannounced.
+case "$MODE" in
+open | close) ;;
+*)
+    echo "Unknown mode '${MODE}' (expected 'open' or 'close')" >&2
+    exit 2
+    ;;
+esac
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${BRANCH:?BRANCH is required}"
+: "${SHA:?SHA is required}"
+: "${RUN_URL:?RUN_URL is required}"
+
+SHORT_SHA="${SHA:0:8}"
+LABEL="ci-red-${BRANCH}"
+COMMIT_URL="https://github.com/${REPO}/commit/${SHA}"
+
+# The label is the idempotency key, so it must exist before it can be filtered on. Creating
+# it is safe to repeat; it already existing is the normal case, not an error.
+gh label create "$LABEL" \
+    --repo "$REPO" \
+    --color B60205 \
+    --description "The ${BRANCH} branch is failing its quality gate" \
+    >/dev/null 2>&1 || true
+
+# Every open issue carrying the key, oldest first. Oldest-first matters: the oldest is the
+# canonical one, so reconciliation is deterministic no matter which run observes the mess.
+open_issues() {
+    gh issue list \
+        --repo "$REPO" \
+        --label "$LABEL" \
+        --state open \
+        --limit 50 \
+        --json number \
+        --jq '[.[].number] | sort | .[]'
+}
+
+# Lookup that tolerates the list-endpoint lag. Only used by `open`, where a false "none"
+# costs a duplicate issue. `close` skips it: by the time a branch goes green, the red run
+# that filed the issue is a full gate-run (~73s) in the past, so the index has long settled,
+# and paying 10s of backoff on every green push to learn "nothing to close" is pure waste.
+open_issues_with_retry() {
+    local found attempt
+    for attempt in 1 2 3 4 5; do
+        found=$(open_issues || true)
+        if [ -n "$found" ]; then
+            echo "$found"
+            return 0
+        fi
+        [ "$attempt" -lt 5 ] && sleep 2
+    done
+    return 0 # genuinely none: the retries expired without ever seeing one
+}
+
+case "$MODE" in
+open)
+    EXISTING=$(open_issues_with_retry)
+    if [ -n "$EXISTING" ]; then
+        # Still red, on a new commit. Update the canonical issue — never open a second one.
+        CANONICAL=$(echo "$EXISTING" | head -1)
+        gh issue comment "$CANONICAL" --repo "$REPO" --body \
+            "Still RED after [\`${SHORT_SHA}\`](${COMMIT_URL}) — [failing run](${RUN_URL})"
+        echo "Updated existing red-${BRANCH} issue #${CANONICAL}"
+
+        # RECONCILE: a race (or an older buggy run) may have left duplicates. Fold them into
+        # the canonical issue so the branch converges on exactly one open alert.
+        echo "$EXISTING" | tail -n +2 | while read -r dup; do
+            [ -z "$dup" ] && continue
+            gh issue comment "$dup" --repo "$REPO" --body \
+                "Duplicate of #${CANONICAL}, which tracks this red \`${BRANCH}\`. Closing."
+            gh issue close "$dup" --repo "$REPO" --reason "not planned"
+            echo "Closed duplicate red-${BRANCH} issue #${dup}"
+        done
+        exit 0
+    fi
+
+    BODY=$(
+        cat <<EOF
+\`${BRANCH}\` is failing its quality gate.
+
+| | |
+|---|---|
+| **Commit** | [\`${SHORT_SHA}\`](${COMMIT_URL}) |
+| **Failing run** | [Quality gate](${RUN_URL}) |
+
+This commit is **already on \`${BRANCH}\`**. Every commit branched from here inherits the
+breakage, so this is urgent in a way a red PR is not.
+
+**Before you fix it, comment here to claim it.** On 2026-07-14 two agents opened duplicate
+hotfix PRs 31 seconds apart because neither knew the other had started. This issue is the
+coordination point.
+
+Then either revert the offending commit or fix forward. A green push to \`${BRANCH}\` closes
+this issue automatically.
+
+<sub>Filed automatically by the quality gate. Root cause of this class of failure:
+[CLAUDE.md rule 4](https://github.com/${REPO}/blob/${BRANCH}/CLAUDE.md).</sub>
+EOF
+    )
+
+    gh issue create \
+        --repo "$REPO" \
+        --title "🔴 \`${BRANCH}\` is RED at ${SHORT_SHA}" \
+        --label "$LABEL" \
+        --body "$BODY"
+    echo "Filed a new red-${BRANCH} issue"
+    ;;
+
+close)
+    # Auto-close on green. The issue asserts a live fact — "this branch is red RIGHT NOW" —
+    # and a green push disproves it: the gate has just passed on the true merge result, which
+    # IS the definition of the branch being green. Leaving it open after the fact would train
+    # everyone to scroll past an alert that is usually stale, which is how the Actions tab
+    # stopped being read in the first place. The audit trail survives in the closed issue.
+    EXISTING=$(open_issues)
+    if [ -z "$EXISTING" ]; then
+        echo "No open red-${BRANCH} issue; nothing to close"
+        exit 0
+    fi
+    # Close ALL of them, not just the canonical one: if a race ever left a duplicate behind,
+    # a green branch must not leave a stale "branch is RED" issue open. An alert that is
+    # sometimes wrong is an alert people learn to ignore.
+    echo "$EXISTING" | while read -r issue; do
+        [ -z "$issue" ] && continue
+        gh issue comment "$issue" --repo "$REPO" --body \
+            "✅ Green again as of [\`${SHORT_SHA}\`](${COMMIT_URL}) — [passing run](${RUN_URL})"
+        gh issue close "$issue" --repo "$REPO" --reason completed
+        echo "Closed red-${BRANCH} issue #${issue}"
+    done
+    ;;
+esac

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -5,11 +5,24 @@ That sentence — not "the workflow declares a push trigger" — is the property
 exists to defend. Two things depend on it:
 
 1. **Detection.** CLAUDE.md rule 4 ("A green PR against a moving `develop` is not a green
-   `develop`") was paid for in blood on 2026-07-14. PR #94 changed `_source_text(item)` to
-   `_source_text(item, target)`; PR #97 added a test calling `_source_text(item)`. Both
-   green on their own branches, zero textual conflict, so git merged both happily — and
-   `develop` was RED. CI never said a word: it only ran on `pull_request`, so the one
-   commit nobody ever tested was the merge commit itself. A human found it by hand (#103).
+   `develop`") was paid for in blood on 2026-07-14 (#103). PR #94 changed
+   `_source_text(item)` to `_source_text(item, target)`; PR #97 added a test calling
+   `_source_text(item)`. Both were green, there was zero textual conflict, git merged both
+   happily — and `develop` was RED.
+
+   Be precise about WHY, because the obvious explanation is wrong: it is **not** that the
+   merge went untested. `pull_request` already tests a merge — GitHub builds
+   `refs/pull/N/merge` (the PR head merged into the base) and checks THAT out. The defect
+   is that the merge ref is computed when the run is **triggered** and is never recomputed
+   when the base moves under it. #97 landed at 14:01:08Z; #94 merged at 14:04:08Z on a
+   green measured against a base that did not contain #97. Merging #97 does not re-trigger
+   #94. So the merge that was *tested* was not the merge that *landed*. The failure mode is
+   **staleness, not absence** — and nothing caught it, because nothing ran on the branch
+   afterwards. A human found it by hand.
+
+   Hence: `push` is the **detector** (every push to a gated branch IS the true merge
+   result), and branch protection's `strict` is the **preventer** (it forces the merge ref
+   to be recomputed against the current base before merging). Complementary, not redundant.
 
 2. **Branch protection.** `develop` and `main` require a status check named exactly
    `quality`. GitHub derives that name from the job's `name:` if it declares one, else
@@ -17,6 +30,11 @@ exists to defend. Two things depend on it:
    it and the required check never appears, GitHub waits for it forever, and **every merge
    is blocked permanently**. That deadlock is strictly worse than the bug this file was
    written to catch.
+
+3. **Alerting.** A red push run blocks nothing — the commit has already landed — so it must
+   raise an alarm or it is detecting into a void. On 2026-07-14 `develop` sat red for
+   9m15s, three commits took the red commit as their parent, and two agents opened
+   duplicate hotfix PRs 31 seconds apart. Watching the Actions tab is not a control.
 
 An earlier version of this file asserted only that a `push:` key existed with the right
 `branches:`. Four independent edits killed the gate while it stayed green:
@@ -60,6 +78,17 @@ _GATING_EVENTS = ("push", "pull_request")
 # GitHub's defaults for `pull_request`; narrowing `types:` away from them silently drops
 # the PR-head runs.
 _REQUIRED_PR_TYPES = ("opened", "synchronize")
+
+# The script that files/updates/closes the "branch is RED" issue. A push-triggered red run
+# blocks nothing — the commit has already landed — so if it does not SPEAK, it detects into
+# a void. On 2026-07-14 `develop` was red for 9m15s and three commits took the red commit as
+# their parent, including two duplicate hotfixes opened 31s apart by two agents who each
+# rediscovered the breakage by hand.
+_ALERT_SCRIPT = "scripts/announce_red_branch.sh"
+
+# The alert steps must be scoped to `push`: a failing PR run must NOT open issues (the PR's
+# own red check is already visible to its author, and one issue per pushed PR commit is spam).
+_PUSH_GUARD = "github.event_name == 'push'"
 
 
 def _workflow() -> dict[Any, Any]:
@@ -271,4 +300,88 @@ def test_gate_step_actually_runs_and_is_not_conditional() -> None:
         f"skipped, the job still SUCCEEDS and the required `{_REQUIRED_CHECK}` check "
         f"reports GREEN having run none of the quality checks. Branch protection would "
         f"then be waving through completely unverified code."
+    )
+
+
+def _alert_steps() -> list[dict[str, Any]]:
+    """Every step that runs the red-branch alert script."""
+    steps = _gate_job().get("steps") or []
+    return [s for s in steps if _ALERT_SCRIPT in str(s.get("run", ""))]
+
+
+def test_red_branch_failure_is_announced() -> None:
+    """A red `develop` must SPEAK. Detecting into a void is not detecting.
+
+    A push run that goes red blocks nothing — the commit has already landed. If it does not
+    raise an alarm, the only thing standing between a red `develop` and the next twenty
+    commits built on top of it is somebody happening to look at the Actions tab. On
+    2026-07-14 nobody did, for 9m15s.
+    """
+    on_failure = [s for s in _alert_steps() if "failure()" in str(s.get("if", ""))]
+    assert on_failure, (
+        f"The `{_REQUIRED_CHECK}` job has no step running `{_ALERT_SCRIPT}` under "
+        f"`if: failure()`. A red push run would then block nothing and tell nobody: the bad "
+        f"commit is already on the branch, and the next commits will take it as their "
+        f"parent. That is exactly how 2026-07-14 produced two duplicate hotfixes, opened 31 "
+        f"seconds apart by two agents who each rediscovered the same breakage by hand."
+    )
+
+
+def test_red_branch_alert_only_fires_on_push() -> None:
+    """The alert must be scoped to `push` — a failing PR must not open issues.
+
+    A PR's red check is already in front of its author, and a PR that is pushed to five
+    times would file five issues. The alert exists for the one case where nothing else
+    speaks: a merge result that is already on the branch.
+    """
+    steps = _alert_steps()
+    # Assert the steps EXIST before asserting a property of them. `all(... for s in [])` is
+    # vacuously true: without this line the test would pass on a workflow with no alert at
+    # all — a green test for a feature that had been deleted (CLAUDE.md rule 1).
+    assert steps, f"No step runs `{_ALERT_SCRIPT}`, so there is nothing to scope to `push`."
+    unguarded = [s for s in steps if _PUSH_GUARD not in str(s.get("if", ""))]
+    assert not unguarded, (
+        f"An alert step is not guarded by `{_PUSH_GUARD}`: "
+        f"{[s.get('name', s.get('run')) for s in unguarded]}. Without that guard a failing "
+        f"PULL REQUEST run also files issues — spamming one per pushed commit for a failure "
+        f"its author is already looking at."
+    )
+
+
+def test_red_branch_alert_is_resolved_when_the_branch_goes_green() -> None:
+    """A green push must close the alert. A stale alert is a training exercise in ignoring it.
+
+    The issue asserts a live fact — "this branch is red RIGHT NOW" — and a green push on the
+    true merge result disproves it. Leaving it open would teach everyone that the alert is
+    usually out of date, which is exactly how the Actions tab stopped being read.
+    """
+    on_success = [s for s in _alert_steps() if "success()" in str(s.get("if", ""))]
+    assert on_success, (
+        f"No step runs `{_ALERT_SCRIPT}` under `if: success()`, so the red-branch issue is "
+        f"never closed when the branch recovers. The alert would stay open after the fix "
+        f"landed — and an alert that is routinely stale is one nobody reads."
+    )
+
+
+def test_gate_job_may_file_the_red_branch_issue() -> None:
+    """The job needs `issues: write` to alert, and `contents: read` to exist at all.
+
+    Declaring a `permissions:` block sets every scope NOT listed to `none` — so omitting
+    `contents: read` does not merely narrow the token, it stops `actions/checkout` cloning
+    the repo and the gate cannot run at all. The two entries are asserted together because
+    adding the first without the second bricks the job.
+
+    `issues: write` on the built-in `GITHUB_TOKEN` is what lets `github-actions[bot]` file
+    the alert with no PAT, no bot account, and no second human in the loop.
+    """
+    permissions = _gate_job().get("permissions") or {}
+    assert permissions.get("issues") == "write", (
+        f"The `{_REQUIRED_CHECK}` job does not declare `permissions: issues: write`, so the "
+        f"built-in GITHUB_TOKEN cannot file the red-branch issue and the alert step fails "
+        f"with 403 exactly when it is needed most — on a red `develop`."
+    )
+    assert permissions.get("contents") == "read", (
+        f"The `{_REQUIRED_CHECK}` job declares a `permissions:` block without "
+        f"`contents: read`. A permissions block sets every unlisted scope to `none`, so "
+        f"`actions/checkout` can no longer clone the repo and the gate cannot run AT ALL."
     )

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,89 @@
+# tests/test_ci_workflow.py
+"""The quality gate must run on the MERGE RESULT, not only on the PR head.
+
+CLAUDE.md rule 4 — "A green PR against a moving `develop` is not a green `develop`" — was
+paid for in blood on 2026-07-14. PR #94 changed `_source_text(item)` to
+`_source_text(item, target)`; PR #97 added a test calling `_source_text(item)`. Both were
+green on their own branches, and there was zero textual conflict, so git merged both
+happily — and `develop` was RED. CI never said a word, because CI only ran on
+`pull_request`: the one commit nobody ever tested was the merge commit itself. A human
+found it by hand, hours later (PR #103).
+
+Until this test existed, rule 4 lived only as prose that a human had to remember to obey.
+This is the machine enforcing it. Every push to `develop`/`main` IS a merge result, so the
+workflow must fire on `push` to both — while KEEPING the `pull_request` runs that catch a
+bad branch before it ever lands.
+
+The assertions are on the RULE, not on the file's wording: they ask "would the gate
+actually run on a push to develop?". Reformatting the YAML while preserving the behaviour
+stays green; any edit that stops the gate running on a merge result goes red.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "quality.yml"
+
+# The branches that are merged INTO. A push to one of these is a merge result.
+_GATED_BRANCHES = ("develop", "main")
+
+
+def _triggers() -> Any:
+    """Return the workflow's trigger block, surviving YAML's Norway problem.
+
+    In YAML 1.1 the bare key `on:` is the BOOLEAN `True`, not the string `"on"` — so
+    `yaml.safe_load(...)["on"]` raises `KeyError` on a perfectly valid workflow. Quoting
+    the key in the file (`"on":`) would make it a string instead. GitHub Actions accepts
+    both spellings, so this looks the key up under both and the test will not silently
+    break the day someone quotes — or unquotes — it.
+    """
+    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    for key in (True, "on"):
+        if key in workflow:
+            return workflow[key]
+    raise AssertionError(f"{_WORKFLOW.name} declares no trigger block at all")
+
+
+def _runs_on(event: str, branch: str) -> bool:
+    """Would the gate actually run for `event` on `branch`?
+
+    Handles every shape GitHub accepts for the trigger block: a bare string (`on: push`),
+    a list (`on: [push, pull_request]`), or a mapping with optional filters. An absent
+    `branches:` filter means GitHub runs the event on EVERY branch — which covers `branch`
+    too, so that is a pass, not a miss. Asserting the effect rather than the syntax is what
+    keeps this a rule test instead of a spelling test.
+    """
+    triggers = _triggers()
+    if isinstance(triggers, str):  # `on: push`
+        return triggers == event
+    if isinstance(triggers, list):  # `on: [push, ...]` — no branch filter possible
+        return event in triggers
+    if event not in triggers:
+        return False
+    config = triggers[event] or {}  # `push:` with no body == run on every branch
+    branches = config.get("branches")
+    return branches is None or branch in branches
+
+
+@pytest.mark.parametrize("branch", _GATED_BRANCHES)
+def test_gate_runs_on_push_to_gated_branch(branch: str) -> None:
+    """A push to develop/main IS a merge result — the gate must run on it (rule 4)."""
+    assert _runs_on("push", branch), (
+        f"quality.yml does not run on `push` to `{branch}`, so the merge commit is never "
+        f"tested. Two PRs, each green on its own branch and with zero textual conflict, "
+        f"can still merge into a RED `{branch}` while CI stays silent — this is exactly "
+        f"how #103 happened. See CLAUDE.md rule 4."
+    )
+
+
+@pytest.mark.parametrize("branch", _GATED_BRANCHES)
+def test_gate_still_runs_on_pull_request(branch: str) -> None:
+    """Merge-result coverage is ADDED to PR coverage, never swapped for it."""
+    assert _runs_on("pull_request", branch), (
+        f"quality.yml no longer runs on `pull_request` to `{branch}`. Testing the merge "
+        f"result does not replace testing the PR head: without this, a broken branch is "
+        f"only caught AFTER it has already landed on `{branch}`."
+    )

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -50,8 +50,34 @@ So the assertions below model the *effect*, not the spelling: would a normal mer
 pushed to `develop` actually produce a check run named `quality` that actually executes the
 gate? Reformatting the YAML while preserving that behaviour stays green; any edit that
 breaks it goes red, and says why in the failure message.
+
+THE ASYMMETRY THAT SHAPES THIS WHOLE FILE
+-----------------------------------------
+A gate can die in two opposite directions, and they need opposite assertions. This is the
+single fact most worth knowing here, and it is not intuitive:
+
+* **A skipped JOB reports SUCCESS.** GitHub, verbatim: *"if a job within a workflow is
+  skipped due to a conditional, it will report its status as 'Success.'"* So `if: false` on
+  the job, or `continue-on-error: true`, or a `steps:` block gutted down to `echo ok`, all
+  publish a **green** `quality` check having verified nothing. Branch protection is
+  satisfied and merges the lot. This is SILENT GREEN — false confidence, worse than having
+  no gate, because a decoration is trusted.
+
+* **A skipped WORKFLOW hangs PENDING.** GitHub, verbatim: *"When a workflow is skipped due
+  to path filtering, branch filtering or a commit message, checks associated with that
+  workflow will remain in a 'Pending' state."* So a `paths:` filter that matches nothing, a
+  `branches-ignore` glob, or an invalid workflow file means the required `quality` check is
+  **never published at all**. Every PR waits on a check that will never report, forever —
+  and with `enforce_admins` nobody can override, *including the PR that would fix it*. This
+  is HARD LOCKOUT.
+
+Same intent ("stop this workflow running"), opposite consequences: one waves everything
+through, the other blocks everything permanently. Neither is detectable by asking "does the
+workflow declare a push trigger?", which is why the assertions here reach all the way down
+to the job's steps, its `continue-on-error`, its permissions, and its checkout `ref`.
 """
 
+import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -129,20 +155,50 @@ def _event(event: str) -> dict[str, Any] | None:
     return triggers[event] or {}  # `push:` with an empty body == every branch
 
 
+def _matches_any(patterns: list[str], branch: str) -> bool:
+    """Does `branch` match any GitHub branch-filter pattern?
+
+    GitHub's branch filters are GLOBS, not literals — so a membership test (`branch in
+    patterns`) is not merely imprecise, it is exploitable: `branches-ignore: ["**"]`
+    disables the trigger for every branch, and `"develop" in ["**"]` is False, so a
+    membership test concludes the gate still runs. Measured: that exact edit left an earlier
+    version of this file green with the gate dead.
+
+    `fnmatch` treats `*` as matching across `/` where GitHub does not, which makes this
+    slightly MORE eager to conclude "this branch is matched". For the two slash-free branch
+    names we gate that distinction cannot arise, and erring toward "matched" fails safe in
+    both directions here: an over-eager match on `branches` says the gate runs (it does), and
+    on `branches-ignore` says it does not (which raises the alarm rather than suppressing it).
+    """
+    return any(fnmatch.fnmatch(branch, str(pattern)) for pattern in patterns)
+
+
 def _fires_on_branch(event: str, branch: str) -> bool:
     """Would `event` on `branch` trigger the workflow, per the branch filters?
 
-    An absent `branches:` means GitHub runs the event on EVERY branch, which covers
-    `branch` too — that is a pass, not a miss. `branches-ignore` is the inverse filter and
-    is checked first: it is the other way to exclude a branch while `branches:` looks fine.
+    GitHub forbids `branches` and `branches-ignore` on the same event, so this is a genuine
+    three-way choice, not two independent filters:
+
+    * `branches-ignore` present -> the event fires on everything EXCEPT what it matches.
+    * `branches` present        -> the event fires ONLY on what it matches.
+    * neither                   -> the event fires on every branch.
+
+    The ordering is load-bearing. An earlier version read `branches`, found it absent, and
+    concluded "absent filter means every branch" — which is true ONLY when `branches-ignore`
+    is absent too. With `branches-ignore` present, an absent `branches` means the exact
+    OPPOSITE, and the helper cheerfully reported that a suppressed gate was running. That
+    latent bug is now fixed at the source rather than masked by the ban in
+    `test_gate_trigger_declares_no_path_filter` and friends, so this helper stays correct if
+    anyone ever relaxes those bans.
     """
     config = _event(event)
     if config is None:
         return False
-    if branch in (config.get("branches-ignore") or []):
-        return False
+    ignore = config.get("branches-ignore")
+    if ignore is not None:
+        return not _matches_any(ignore, branch)
     branches = config.get("branches")
-    return branches is None or branch in branches
+    return branches is None or _matches_any(branches, branch)
 
 
 def _gate_job() -> dict[str, Any]:
@@ -301,6 +357,84 @@ def test_gate_step_actually_runs_and_is_not_conditional() -> None:
         f"reports GREEN having run none of the quality checks. Branch protection would "
         f"then be waving through completely unverified code."
     )
+
+
+def test_gate_cannot_report_success_while_failing() -> None:
+    """`continue-on-error` must appear NOWHERE in the gate job. It manufactures a green lie.
+
+    This is the worst failure mode in this file's threat model, worse than any deadlock.
+    `continue-on-error: true` does not stop the gate running — it runs, it FAILS, and the
+    check run reports **success** anyway. Branch protection is satisfied, the merge sails
+    through, and the ✅ next to `quality` is now actively lying about code nobody verified.
+    A gate that cannot fail is not a gate; it is a decoration that costs 73 seconds.
+
+    Banned at BOTH levels, because either one alone produces the lie: on the job (its
+    conclusion is forced to success) and on any step (a failing step no longer fails the job).
+    """
+    job = _gate_job()
+    assert "continue-on-error" not in job, (
+        f"The `{_REQUIRED_CHECK}` job declares `continue-on-error: "
+        f"{job.get('continue-on-error')!r}`. The gate would still RUN, still FAIL — and the "
+        f"required check would report ✅ SUCCESS regardless. Every red merge sails through on "
+        f"a green light. Delete it."
+    )
+    offenders = [
+        step.get("name", step.get("run", "?"))
+        for step in (job.get("steps") or [])
+        if "continue-on-error" in step
+    ]
+    assert not offenders, (
+        f"These steps in the `{_REQUIRED_CHECK}` job declare `continue-on-error`: "
+        f"{offenders}. A failing step with `continue-on-error: true` does not fail its job, "
+        f"so the required check reports ✅ SUCCESS while the gate is red underneath it."
+    )
+
+
+def test_push_trigger_declares_no_activity_types() -> None:
+    """`types:` is not a valid key for `push` — it makes the whole workflow file invalid.
+
+    GitHub documents activity types as "Not applicable" to `push`. An invalid workflow does
+    not fail loudly; it simply never runs, so the required check is never published and every
+    PR hangs Pending. This is a typo away from a repo lockout — `pull_request` DOES take
+    `types:`, so copy-pasting the block up one event is an easy, silent mistake.
+    """
+    config = _event("push") or {}
+    assert "types" not in config, (
+        f"The `push` trigger declares `types: {config.get('types')!r}`, which GitHub does not "
+        f"accept for `push` ('Not applicable'). The workflow file is INVALID and will never "
+        f"run at all — so the `{_REQUIRED_CHECK}` check is never published and every PR to "
+        f"{list(_GATED_BRANCHES)} hangs Pending forever. `types:` belongs only on "
+        f"`pull_request`."
+    )
+
+
+def test_checkout_takes_no_explicit_ref() -> None:
+    """The gate must test the commit that triggered it — the merge result — not a fixed ref.
+
+    `actions/checkout` defaults to `GITHUB_SHA`, which on a `push` to `develop` IS the merge
+    commit. That default is the entire mechanism of this PR. Pin `ref:` to anything fixed
+    (`main`, a tag, a branch name) and the gate still runs, still reports honestly, still goes
+    green — while testing a tree that has nothing to do with what was just merged. Everything
+    looks healthy and the merge result is never examined, which is #103 with a green light on
+    top.
+    """
+    checkout = [
+        step
+        for step in (_gate_job().get("steps") or [])
+        if "actions/checkout" in str(step.get("uses", ""))
+    ]
+    assert checkout, (
+        f"The `{_REQUIRED_CHECK}` job never checks out the repository, so it cannot be "
+        f"running the gate against the merge result — or against anything."
+    )
+    for step in checkout:
+        ref = (step.get("with") or {}).get("ref")
+        assert ref is None, (
+            f"`actions/checkout` pins `ref: {ref!r}`. The gate would then test THAT tree "
+            f"instead of the commit that triggered the run. On a push to a gated branch the "
+            f"triggering commit IS the merge result — testing it is the whole point of this "
+            f"workflow. Remove the `ref:` and let checkout default to GITHUB_SHA."
+        )
 
 
 def _alert_steps() -> list[dict[str, Any]]:

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,22 +1,37 @@
 # tests/test_ci_workflow.py
-"""The quality gate must run on the MERGE RESULT, not only on the PR head.
+"""A push to `develop`/`main` must produce a passing-or-failing check run named `quality`.
 
-CLAUDE.md rule 4 — "A green PR against a moving `develop` is not a green `develop`" — was
-paid for in blood on 2026-07-14. PR #94 changed `_source_text(item)` to
-`_source_text(item, target)`; PR #97 added a test calling `_source_text(item)`. Both were
-green on their own branches, and there was zero textual conflict, so git merged both
-happily — and `develop` was RED. CI never said a word, because CI only ran on
-`pull_request`: the one commit nobody ever tested was the merge commit itself. A human
-found it by hand, hours later (PR #103).
+That sentence — not "the workflow declares a push trigger" — is the property this file
+exists to defend. Two things depend on it:
 
-Until this test existed, rule 4 lived only as prose that a human had to remember to obey.
-This is the machine enforcing it. Every push to `develop`/`main` IS a merge result, so the
-workflow must fire on `push` to both — while KEEPING the `pull_request` runs that catch a
-bad branch before it ever lands.
+1. **Detection.** CLAUDE.md rule 4 ("A green PR against a moving `develop` is not a green
+   `develop`") was paid for in blood on 2026-07-14. PR #94 changed `_source_text(item)` to
+   `_source_text(item, target)`; PR #97 added a test calling `_source_text(item)`. Both
+   green on their own branches, zero textual conflict, so git merged both happily — and
+   `develop` was RED. CI never said a word: it only ran on `pull_request`, so the one
+   commit nobody ever tested was the merge commit itself. A human found it by hand (#103).
 
-The assertions are on the RULE, not on the file's wording: they ask "would the gate
-actually run on a push to develop?". Reformatting the YAML while preserving the behaviour
-stays green; any edit that stops the gate running on a merge result goes red.
+2. **Branch protection.** `develop` and `main` require a status check named exactly
+   `quality`. GitHub derives that name from the job's `name:` if it declares one, else
+   from the **job id**. So the job's identity is load-bearing repo infrastructure: rename
+   it and the required check never appears, GitHub waits for it forever, and **every merge
+   is blocked permanently**. That deadlock is strictly worse than the bug this file was
+   written to catch.
+
+An earlier version of this file asserted only that a `push:` key existed with the right
+`branches:`. Four independent edits killed the gate while it stayed green:
+
+| Attack | Effect | Why the old test missed it |
+|---|---|---|
+| rename job `quality:` → `gate:` | required check never appears → **all merges deadlock** | never looked at `jobs` |
+| `paths-ignore: ["**"]` on push | gate runs on no push at all → #103 reopened | only read `branches` |
+| keep id, add `name: Gate` | check run is named `Gate` → **all merges deadlock** | job id alone is not the check name |
+| `if: false` on the gate step | check `quality` reports **GREEN having run nothing** | never looked at the steps |
+
+So the assertions below model the *effect*, not the spelling: would a normal merge commit
+pushed to `develop` actually produce a check run named `quality` that actually executes the
+gate? Reformatting the YAML while preserving that behaviour stays green; any edit that
+breaks it goes red, and says why in the failure message.
 """
 
 from pathlib import Path
@@ -27,8 +42,29 @@ import yaml
 
 _WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "quality.yml"
 
-# The branches that are merged INTO. A push to one of these is a merge result.
+# The branches that are merged INTO. A push to one of these IS a merge result.
 _GATED_BRANCHES = ("develop", "main")
+
+# The status check name that branch protection on develop/main requires. This string is
+# NOT cosmetic: it is a contract with the repo settings. See the module docstring.
+_REQUIRED_CHECK = "quality"
+
+# The script the gate job must actually execute. A check run named `quality` that runs
+# nothing is worse than no check at all — it reports green.
+_GATE_SCRIPT = "scripts/check.sh"
+
+# Events that must be able to produce the `quality` check run.
+_GATING_EVENTS = ("push", "pull_request")
+
+# A PR must be gated when it is opened and on every subsequent push to it. These are
+# GitHub's defaults for `pull_request`; narrowing `types:` away from them silently drops
+# the PR-head runs.
+_REQUIRED_PR_TYPES = ("opened", "synchronize")
+
+
+def _workflow() -> dict[Any, Any]:
+    """Parse the workflow file."""
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
 
 
 def _triggers() -> Any:
@@ -36,42 +72,112 @@ def _triggers() -> Any:
 
     In YAML 1.1 the bare key `on:` is the BOOLEAN `True`, not the string `"on"` — so
     `yaml.safe_load(...)["on"]` raises `KeyError` on a perfectly valid workflow. Quoting
-    the key in the file (`"on":`) would make it a string instead. GitHub Actions accepts
-    both spellings, so this looks the key up under both and the test will not silently
-    break the day someone quotes — or unquotes — it.
+    the key in the file (`"on":`) would make it a string instead. GitHub accepts both
+    spellings, so look the key up under both: the test must not break the day someone
+    quotes — or unquotes — it, because that edit changes no behaviour.
     """
-    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    workflow = _workflow()
     for key in (True, "on"):
         if key in workflow:
             return workflow[key]
     raise AssertionError(f"{_WORKFLOW.name} declares no trigger block at all")
 
 
-def _runs_on(event: str, branch: str) -> bool:
-    """Would the gate actually run for `event` on `branch`?
+def _event(event: str) -> dict[str, Any] | None:
+    """Config for `event`, or None if the workflow does not fire on it at all.
 
-    Handles every shape GitHub accepts for the trigger block: a bare string (`on: push`),
-    a list (`on: [push, pull_request]`), or a mapping with optional filters. An absent
-    `branches:` filter means GitHub runs the event on EVERY branch — which covers `branch`
-    too, so that is a pass, not a miss. Asserting the effect rather than the syntax is what
-    keeps this a rule test instead of a spelling test.
+    Normalises every shape GitHub accepts: a bare string (`on: push`), a list
+    (`on: [push, pull_request]`), or a mapping with filters. The first two carry no
+    filters, so they normalise to an empty config rather than to None.
     """
     triggers = _triggers()
-    if isinstance(triggers, str):  # `on: push`
-        return triggers == event
-    if isinstance(triggers, list):  # `on: [push, ...]` — no branch filter possible
-        return event in triggers
+    if isinstance(triggers, str):
+        return {} if triggers == event else None
+    if isinstance(triggers, list):
+        return {} if event in triggers else None
     if event not in triggers:
+        return None
+    return triggers[event] or {}  # `push:` with an empty body == every branch
+
+
+def _fires_on_branch(event: str, branch: str) -> bool:
+    """Would `event` on `branch` trigger the workflow, per the branch filters?
+
+    An absent `branches:` means GitHub runs the event on EVERY branch, which covers
+    `branch` too — that is a pass, not a miss. `branches-ignore` is the inverse filter and
+    is checked first: it is the other way to exclude a branch while `branches:` looks fine.
+    """
+    config = _event(event)
+    if config is None:
         return False
-    config = triggers[event] or {}  # `push:` with no body == run on every branch
+    if branch in (config.get("branches-ignore") or []):
+        return False
     branches = config.get("branches")
     return branches is None or branch in branches
+
+
+def _gate_job() -> dict[str, Any]:
+    """The job whose check run branch protection requires."""
+    jobs = _workflow().get("jobs") or {}
+    assert _REQUIRED_CHECK in jobs, (
+        f"No job with id `{_REQUIRED_CHECK}` in {_WORKFLOW.name} (found: {sorted(jobs)}).\n"
+        f"\n"
+        f"STOP — renaming this job BRICKS THE REPOSITORY. `develop` and `main` are "
+        f"protected by a required status check named exactly `{_REQUIRED_CHECK}`, and "
+        f"GitHub takes that name from this job. Rename the job and the required check "
+        f"never appears; GitHub waits for it forever and EVERY MERGE IS BLOCKED, "
+        f"permanently. If you really must rename it, change the required status check in "
+        f"the branch-protection settings FIRST, then this constant, then the job."
+    )
+    return jobs[_REQUIRED_CHECK] or {}
+
+
+def _check_run_name() -> str:
+    """The name GitHub will give this job's check run.
+
+    It is the job's `name:` when one is declared, and the job id otherwise. This
+    indirection is the subtle half of the deadlock: a job can keep the id
+    `quality` and still publish its check run as `Gate`.
+    """
+    return str(_gate_job().get("name", _REQUIRED_CHECK))
+
+
+def _gate_step() -> dict[str, Any]:
+    """The step that actually executes the quality gate."""
+    steps = _gate_job().get("steps") or []
+    for step in steps:
+        if _GATE_SCRIPT in str(step.get("run", "")):
+            return step
+    raise AssertionError(
+        f"No step in the `{_REQUIRED_CHECK}` job runs `{_GATE_SCRIPT}`.\n"
+        f"\n"
+        f"The check run named `{_REQUIRED_CHECK}` is what branch protection trusts. If it "
+        f"no longer runs the gate, it reports GREEN having verified nothing — a required "
+        f"check that always passes is worse than no required check at all."
+    )
+
+
+def test_gate_publishes_the_required_status_check_name() -> None:
+    """The check run must be named `quality` — branch protection requires that exact name.
+
+    Covers BOTH ways to break the name: renaming the job id (caught in `_gate_job`) and
+    keeping the id while overriding the display name with `name:` (caught here).
+    """
+    assert _check_run_name() == _REQUIRED_CHECK, (
+        f"The `{_REQUIRED_CHECK}` job declares `name: {_check_run_name()}`, so its check "
+        f"run is published as `{_check_run_name()}` — NOT `{_REQUIRED_CHECK}`.\n"
+        f"\n"
+        f"STOP — this BRICKS THE REPOSITORY. `develop` and `main` require a status check "
+        f"named exactly `{_REQUIRED_CHECK}`. Under this name it never appears, GitHub "
+        f"waits for it forever, and EVERY MERGE IS BLOCKED, permanently. The job id alone "
+        f"is not enough: GitHub names the check run after `name:` whenever one is set."
+    )
 
 
 @pytest.mark.parametrize("branch", _GATED_BRANCHES)
 def test_gate_runs_on_push_to_gated_branch(branch: str) -> None:
     """A push to develop/main IS a merge result — the gate must run on it (rule 4)."""
-    assert _runs_on("push", branch), (
+    assert _fires_on_branch("push", branch), (
         f"quality.yml does not run on `push` to `{branch}`, so the merge commit is never "
         f"tested. Two PRs, each green on its own branch and with zero textual conflict, "
         f"can still merge into a RED `{branch}` while CI stays silent — this is exactly "
@@ -82,8 +188,87 @@ def test_gate_runs_on_push_to_gated_branch(branch: str) -> None:
 @pytest.mark.parametrize("branch", _GATED_BRANCHES)
 def test_gate_still_runs_on_pull_request(branch: str) -> None:
     """Merge-result coverage is ADDED to PR coverage, never swapped for it."""
-    assert _runs_on("pull_request", branch), (
+    assert _fires_on_branch("pull_request", branch), (
         f"quality.yml no longer runs on `pull_request` to `{branch}`. Testing the merge "
         f"result does not replace testing the PR head: without this, a broken branch is "
         f"only caught AFTER it has already landed on `{branch}`."
+    )
+
+
+@pytest.mark.parametrize("event", _GATING_EVENTS)
+def test_gate_trigger_declares_no_path_filter(event: str) -> None:
+    """Neither trigger may carry a `paths` / `paths-ignore` filter.
+
+    A path filter is the quietest way to kill this gate: `paths-ignore: ["**"]` leaves a
+    perfectly innocent-looking `push:` block that fires on nothing.
+
+    The rule here is deliberately absolute — no path filter at all — rather than an attempt
+    to decide which globs are "safe". A merge commit may touch ANY set of files, including
+    a set that any given filter excludes, so no non-trivial path filter can guarantee the
+    gate runs on every merge result. Modelling glob semantics to prove otherwise would be
+    far more complexity than the property is worth. If a path filter is ever genuinely
+    wanted, that is a deliberate decision to weaken the gate, and it should be argued in a
+    PR that also changes this test — not slipped in under a green suite.
+
+    A skipped workflow is not a benign no-op either: the required `quality` check is never
+    created, so the PR sits blocked on a check that will never report.
+    """
+    config = _event(event) or {}
+    offenders = [key for key in ("paths", "paths-ignore") if key in config]
+    assert not offenders, (
+        f"The `{event}` trigger declares {offenders}. A path filter can exclude a merge "
+        f'commit from the gate entirely — `paths-ignore: ["**"]` silently disables it '
+        f"while the `branches:` list still looks correct, reopening #103. The gate must run "
+        f"on EVERY {event} to {list(_GATED_BRANCHES)}, whatever files it touches."
+    )
+
+
+def test_pull_request_trigger_covers_normal_pr_activity() -> None:
+    """A narrowed `types:` is another way to stop the PR-head runs without touching branches.
+
+    GitHub's default `pull_request` types are opened/synchronize/reopened. Declaring
+    `types: [labeled]` (or similar) leaves `branches:` intact while the gate stops running
+    when a PR is opened or updated. An absent `types:` is the correct, default state.
+    """
+    types = (_event("pull_request") or {}).get("types")
+    if types is None:
+        return  # defaults already include the events we need
+    missing = [t for t in _REQUIRED_PR_TYPES if t not in types]
+    assert not missing, (
+        f"The `pull_request` trigger narrows `types:` to {types}, dropping {missing}. The "
+        f"gate would stop running when a PR is opened or pushed to, so the PR head goes "
+        f"untested while `branches:` still looks correct."
+    )
+
+
+def test_gate_job_is_not_conditional() -> None:
+    """The gate job must carry no `if:`.
+
+    An `if:` on the job is a way to neuter the gate while the trigger block above it looks
+    completely healthy — `if: github.event_name == 'pull_request'` would undo this entire
+    PR. Worse, a job skipped by `if:` does not run the gate yet still resolves its check
+    run, so branch protection can be satisfied by a check that verified nothing.
+    """
+    assert "if" not in _gate_job(), (
+        f"The `{_REQUIRED_CHECK}` job declares `if: {_gate_job().get('if')!r}`. A condition "
+        f"here can stop the gate running while the `on:` block still looks correct, and a "
+        f"skipped job can still satisfy the required check — a green light for code nobody "
+        f"tested."
+    )
+
+
+def test_gate_step_actually_runs_and_is_not_conditional() -> None:
+    """The step running the gate must exist and must not be skippable.
+
+    `if: false` on this one step is the most dangerous edit in this file's threat model:
+    the job still succeeds, so the required `quality` check goes GREEN — having executed
+    none of the 11 checks. A required check that cannot fail is worse than none, because
+    it is trusted.
+    """
+    step = _gate_step()  # raises with an explanation if the gate script is not run at all
+    assert "if" not in step, (
+        f"The step running `{_GATE_SCRIPT}` declares `if: {step.get('if')!r}`. If it is "
+        f"skipped, the job still SUCCEEDS and the required `{_REQUIRED_CHECK}` check "
+        f"reports GREEN having run none of the quality checks. Branch protection would "
+        f"then be waving through completely unverified code."
     )


### PR DESCRIPTION
## The hole

`.github/workflows/quality.yml` triggered **only** on `pull_request`. There was no `push` trigger, so `develop` was never tested *after* a merge. The only commit CI never ran on was the one that actually ships: the merge commit.

## The incident (#103)

Not theoretical — it cost us a red `develop` today:

- **PR #94** changed the signature `_source_text(item)` → `_source_text(item, target)`.
- **PR #97** added a test calling `_source_text(item)`.
- Both were **green on their own branches**.
- **Zero textual conflict**, so git merged both happily.
- `develop` was **RED**. CI said nothing — it does not run on `develop`.
- A **human found it by hand**, hours later.

`CLAUDE.md` rule 4 already names this: **"A green PR against a moving `develop` is not a green `develop`."** But it lived only as prose that a human had to remember to obey. This PR makes the machine enforce it.

## What this does

Adds the `push` trigger on `develop` and `main`. Every push to those branches *is* a merge result, so the gate now runs on the merged code. `pull_request` stays exactly as it was — testing the merge result does not replace testing the PR head; you want both.

```diff
 on:
+  push:
+    branches: [develop, main]
   pull_request:
     branches: [develop, main]
```

## What this does NOT do

It **detects** a red `develop` within minutes of the merge. It does **not prevent** the bad merge from landing — that needs a **required status check** on the branch, which is being handled separately at the repo-settings level. This PR closes the detection gap only.

## The guardrail test

`tests/test_ci_workflow.py` parses the workflow and asserts the **rule**, not a string: *"would the gate actually run on a push to `develop`?"* Reformatting the YAML while preserving behaviour stays green; deleting merge-result coverage goes red. It also pins the existing `pull_request` runs so push coverage can never be silently swapped in for PR coverage.

Per rule 1 ("a test that passes before you write the fix is not a test"), it was **watched going red first**, before the workflow was touched:

```
FAILED tests/test_ci_workflow.py::test_gate_runs_on_push_to_gated_branch[develop]
FAILED tests/test_ci_workflow.py::test_gate_runs_on_push_to_gated_branch[main]
E  AssertionError: quality.yml does not run on `push` to `develop`, so the merge
   commit is never tested. ...
========================= 2 failed, 2 passed in 0.32s ==========================
```

(The 2 that passed are the `pull_request` regression guards — correct, they pin behaviour that already existed.)

One YAML gotcha is documented in the test: the bare key `on:` parses as the **boolean `True`** in YAML 1.1 (the Norway problem), so `yaml.safe_load(...)["on"]` raises `KeyError`. The test looks the key up under both spellings rather than forcing the workflow file to quote it.

## Quality gate

`uv run --extra dev poe check` — all 11 checks green, **1587 tests** (4 new), coverage 94%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)