### PR TITLE
fix(gate): lint and format-check scripts/ — 4 executable files were never examined

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ testpaths = ["tests"]
 [tool.ruff]
 line-length = 100
 target-version = "py312"
+# Ruff only discovers *.py / *.pyi / *.ipynb when handed a directory, so the
+# two extensionless executables in scripts/ (`#!/usr/bin/env python3` wrappers
+# that users invoke directly) would be silently skipped by `ruff check scripts`
+# even though they are Python. Name them explicitly so the gate really covers
+# every Python file under scripts/ — the whole point of linting that directory.
+extend-include = ["scripts/xbrain-transcribe", "scripts/xbrain-vision"]
 
 [tool.mypy]
 python_version = "3.12"
@@ -114,8 +120,8 @@ omit = ["*/tests/*"]
 fail_under = 78
 
 [tool.poe.tasks]
-lint       = "ruff check src tests"
-format     = "ruff format --check src tests"
+lint       = "ruff check src tests scripts"
+format     = "ruff format --check src tests scripts"
 types      = "mypy src/xbrain"
 complexity = "radon cc src/xbrain -s"
 security   = "bandit -r src/xbrain -ll -q"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -240,8 +240,8 @@ print_github_summary() {
 # ============================================================================
 # 1. RUFF CHECK - Code linting  (CRITICAL)
 # ============================================================================
-print_info "Running Ruff linter on src/ and tests/..."
-if uv run ruff check src tests 2>&1; then
+print_info "Running Ruff linter on src/, tests/ and scripts/..."
+if uv run ruff check src tests scripts 2>&1; then
     print_success "Ruff: code is clean"
     RUFF_STATUS="pass"
 else
@@ -253,8 +253,8 @@ fi
 # ============================================================================
 # 2. RUFF FORMAT - Formatting check  (CRITICAL)
 # ============================================================================
-print_info "Running Ruff format check on src/ and tests/..."
-if uv run ruff format --check src tests 2>&1; then
+print_info "Running Ruff format check on src/, tests/ and scripts/..."
+if uv run ruff format --check src tests scripts 2>&1; then
     print_success "Ruff format: code is formatted"
     FORMAT_STATUS="pass"
 else

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -240,8 +240,14 @@ print_github_summary() {
 # ============================================================================
 # 1. RUFF CHECK - Code linting  (CRITICAL)
 # ============================================================================
-print_info "Running Ruff linter on src/, tests/ and scripts/..."
-if uv run ruff check src tests scripts 2>&1; then
+# Delegates to the `lint` poe task rather than re-spelling `ruff check <dirs>`
+# here. The targets then have ONE definition (pyproject.toml) instead of two
+# that "should" match: when this file carried its own copy, a directory added to
+# one and not the other would leave CI and a local `poe lint` silently
+# disagreeing about what "clean" means — which is how scripts/ went unlinted in
+# the first place. tests/test_quality_gate_scope.py fails if this is re-inlined.
+print_info "Running Ruff linter (poe 'lint' task)..."
+if uv run poe lint 2>&1; then
     print_success "Ruff: code is clean"
     RUFF_STATUS="pass"
 else
@@ -253,8 +259,10 @@ fi
 # ============================================================================
 # 2. RUFF FORMAT - Formatting check  (CRITICAL)
 # ============================================================================
-print_info "Running Ruff format check on src/, tests/ and scripts/..."
-if uv run ruff format --check src tests scripts 2>&1; then
+# Same single-definition rule as the lint step above: targets live in the `format`
+# poe task, not here.
+print_info "Running Ruff format check (poe 'format' task)..."
+if uv run poe format 2>&1; then
     print_success "Ruff format: code is formatted"
     FORMAT_STATUS="pass"
 else

--- a/scripts/import_chrome_session.py
+++ b/scripts/import_chrome_session.py
@@ -97,8 +97,7 @@ def import_session(output: Path) -> int:
 
     if not auth_token:
         print(
-            "\nNo `auth_token` cookie found. Log in to X in Chrome first, then "
-            "re-run this script.",
+            "\nNo `auth_token` cookie found. Log in to X in Chrome first, then re-run this script.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/xbrain-vision
+++ b/scripts/xbrain-vision
@@ -22,6 +22,7 @@ Cloud uses the Anthropic REST API via stdlib urllib (no SDK dependency). Local
 shells out to the mlx-vlm tool's python (env `XBRAIN_VISION_MLX_PYTHON`, else the
 uv-tool default `~/.local/share/uv/tools/mlx-vlm/bin/python`).
 """
+
 from __future__ import annotations
 
 import argparse
@@ -59,7 +60,12 @@ _LOCAL_MARKER = "<<<XBRAIN_VISION>>>"
 # wedged model is reaped here (not left orphaned when the outer runner SIGKILLs us).
 _LOCAL_TIMEOUT = 240
 DEFAULT_MODEL = "qwen-3b"
-_MEDIA_TYPES = {".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".webp": "image/webp"}
+_MEDIA_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+}
 
 
 def _resolve(name: str) -> tuple[str, str]:
@@ -92,7 +98,10 @@ def _describe_cloud(model: str, image: Path) -> str:
                 {
                     "role": "user",
                     "content": [
-                        {"type": "image", "source": {"type": "base64", "media_type": media_type, "data": data}},
+                        {
+                            "type": "image",
+                            "source": {"type": "base64", "media_type": media_type, "data": data},
+                        },
                         {"type": "text", "text": PROMPT},
                     ],
                 }
@@ -112,7 +121,9 @@ def _describe_cloud(model: str, image: Path) -> str:
         with urllib.request.urlopen(req, timeout=120) as resp:
             payload = json.loads(resp.read().decode())
     except urllib.error.HTTPError as exc:  # surface the API error message, not a bare stack
-        raise SystemExit(f"xbrain-vision: Anthropic API error {exc.code}: {exc.read().decode()[:300]}")
+        raise SystemExit(
+            f"xbrain-vision: Anthropic API error {exc.code}: {exc.read().decode()[:300]}"
+        )
     except urllib.error.URLError as exc:  # DNS / connection / TLS / timeout — also clean, no stack
         raise SystemExit(f"xbrain-vision: network error reaching Anthropic API: {exc.reason}")
     blocks = [b.get("text", "") for b in payload.get("content", []) if b.get("type") == "text"]
@@ -161,14 +172,20 @@ def _describe_local(model: str, image: Path) -> str:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Multi-backend vision describe for xbrain digest-video.")
-    ap.add_argument("--model", default=DEFAULT_MODEL, help="model NAME (alias, claude-* id, or hf/repo)")
+    ap = argparse.ArgumentParser(
+        description="Multi-backend vision describe for xbrain digest-video."
+    )
+    ap.add_argument(
+        "--model", default=DEFAULT_MODEL, help="model NAME (alias, claude-* id, or hf/repo)"
+    )
     ap.add_argument("image", help="path to the image to describe")
     args = ap.parse_args()
 
     backend, real_id = _resolve(args.model)
     image = Path(args.image)
-    text = _describe_cloud(real_id, image) if backend == "cloud" else _describe_local(real_id, image)
+    text = (
+        _describe_cloud(real_id, image) if backend == "cloud" else _describe_local(real_id, image)
+    )
     if not text:
         print("xbrain-vision: empty description", file=sys.stderr)
         return 1

--- a/tests/test_quality_gate_scope.py
+++ b/tests/test_quality_gate_scope.py
@@ -1,0 +1,255 @@
+"""Guardrail: the quality gate must examine every Python file in the repo.
+
+The gate once linted `src tests` only. `scripts/` — the X session-import scripts
+users run, and the `xbrain-transcribe` / `xbrain-vision` executables `digest-video`
+shells out to — was never opened by ruff, while the summary printed ALL CRITICAL
+CHECKS PASSED. The green was reporting more coverage than it had.
+
+Widening the targets fixes *that* instance. These tests pin the *rule*, so the
+next instance cannot happen quietly. Three ways the gate can silently lose
+coverage again, one test each:
+
+1. **The two definitions drift.** The lint/format targets were written twice —
+   in the poe tasks and again in `scripts/check.sh`. Two lists that "should"
+   match are exactly what CLAUDE.md rule 5 was paid in blood for, so the fix is
+   to have ONE definition (the poe tasks) and make `check.sh` invoke it.
+   `test_check_sh_does_not_restate_the_ruff_targets` keeps it that way.
+
+2. **`lint` and `format` drift from each other.** They are two separate strings
+   in `pyproject.toml`; nothing makes them agree.
+
+3. **A Python file exists that the gate never opens.** The general form of the
+   original bug — a new top-level directory nobody adds to the targets, or (the
+   case that actually bit us) a shebang-python executable with no `.py` suffix,
+   which ruff does not discover when handed a directory and which only
+   `extend-include` brings in.
+
+Test 3 is the load-bearing one and it asserts *behaviour*, not spelling: it asks
+ruff itself which files it would open (`--show-files`, using the targets the gate
+really declares) and compares that against every Python file git tracks. Both
+sides are derived — neither hardcodes `{src, tests, scripts}` — so the day someone
+adds `tools/*.py` and forgets the gate, this goes red and names the file.
+
+"Every Python file git tracks" is deliberately sourced from `git ls-files`: it
+inherits the repo's own ignore conventions, so `.venv`, `__pycache__`, build
+artefacts and sibling worktrees can never leak in and make this test noisy. A
+guardrail people learn to ignore is worse than no guardrail.
+"""
+
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CHECK_SH = REPO_ROOT / "scripts" / "check.sh"
+
+
+# ---------------------------------------------------------------------------
+# Deriving the gate's declared scope (the ONE definition)
+# ---------------------------------------------------------------------------
+
+
+def _poe_tasks() -> dict[str, str]:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)["tool"]["poe"]["tasks"]
+
+
+def _ruff_targets(command: str) -> set[str]:
+    """Positional path targets of a `ruff …` command string.
+
+    `ruff check src tests scripts`        -> {src, tests, scripts}
+    `ruff format --check src tests scripts` -> {src, tests, scripts}
+
+    Flags and the subcommand are dropped; whatever is left is a path target.
+    Parsed with shlex rather than `.split()` so a quoted path stays one token.
+    """
+    tokens = shlex.split(command)
+    assert tokens and tokens[0] == "ruff", f"not a ruff command: {command!r}"
+    return {t for t in tokens[1:] if not t.startswith("-") and t not in {"check", "format"}}
+
+
+def _declared_targets() -> set[str]:
+    """The single source of truth for what the ruff gate examines."""
+    return _ruff_targets(_poe_tasks()["lint"])
+
+
+# `ruff check src tests` / `ruff format --check src tests`, matched ANYWHERE in a
+# shell line — not anchored to its start. The offenders this test exists to reject
+# were written `if uv run ruff check src tests 2>&1; then`, so a start-anchored
+# match would have found nothing and left this test green against the exact code it
+# is meant to catch. Stops at the first shell operator so `2>&1`, `; then` and pipes
+# are not mistaken for path targets.
+_RUFF_CALL = re.compile(r"\bruff\s+(?:check|format)\b([^;|&<>\n]*)")
+
+
+def _strip_shell_comment(line: str) -> str:
+    """Drop a trailing `#` comment.
+
+    check.sh's own header comment lists "ruff check, ruff format, mypy, bandit" as
+    the critical checks. Without this, that prose matches _RUFF_CALL and gets
+    reported as a hardcoded target — a guardrail that cries wolf on a comment is a
+    guardrail someone deletes.
+    """
+    for index, char in enumerate(line):
+        if char == "#" and (index == 0 or line[index - 1].isspace()):
+            return line[:index]
+    return line
+
+
+def _hardcoded_ruff_targets_in(shell_line: str) -> set[str]:
+    """Positional ruff targets spelled out in a shell line, if any."""
+    match = _RUFF_CALL.search(_strip_shell_comment(shell_line))
+    if not match:
+        return set()
+    return {
+        token
+        for token in shlex.split(match.group(1))
+        if not token.startswith("-") and token not in {"check", "format"}
+    }
+
+
+# ---------------------------------------------------------------------------
+# Deriving the repo's actual Python (the truth to compare against)
+# ---------------------------------------------------------------------------
+
+
+def _tracked_files() -> list[Path]:
+    """Every file git tracks. Inherits .gitignore, so no build/venv noise."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.skip("not a git checkout — cannot derive the tracked file list")
+    return [Path(p) for p in result.stdout.split("\0") if p]
+
+
+def _is_python(relpath: Path) -> bool:
+    """Python source, including the extensionless `#!/usr/bin/env python3` kind.
+
+    The second case is the whole reason this file exists: ruff does not discover
+    it when handed a directory, so it went unlinted for as long as it existed.
+    """
+    if relpath.suffix in {".py", ".pyi"}:
+        return True
+    if relpath.suffix:
+        return False
+    try:
+        first_line = (REPO_ROOT / relpath).open("rb").readline()
+    except OSError:  # tracked but absent from the working tree
+        return False
+    return first_line.startswith(b"#!") and b"python" in first_line
+
+
+def _repo_python_files() -> set[Path]:
+    return {p for p in _tracked_files() if _is_python(p)}
+
+
+def _files_ruff_would_open(targets: set[str]) -> set[Path]:
+    """Ask ruff itself which files it would examine. Behaviour, not spelling."""
+    pytest.importorskip("ruff", reason="ruff not installed — install dev deps")
+    result = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", *sorted(targets), "--show-files"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, f"ruff --show-files failed:\n{result.stderr}"
+    return {
+        Path(line).resolve().relative_to(REPO_ROOT) for line in result.stdout.split("\n") if line
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. One definition, not two that "should" match  (CLAUDE.md rule 5)
+# ---------------------------------------------------------------------------
+
+
+def test_check_sh_does_not_restate_the_ruff_targets():
+    """`scripts/check.sh` must invoke the poe tasks, not re-spell their targets.
+
+    When check.sh hardcoded `ruff check src tests` alongside the poe task's own
+    copy, the two could drift — and a local `poe lint` and CI would then disagree,
+    silently, about what "clean" means. One definition (the poe task); check.sh
+    consumes it.
+    """
+    offenders = [
+        line.strip()
+        for line in CHECK_SH.read_text().splitlines()
+        if _hardcoded_ruff_targets_in(line)
+    ]
+    assert not offenders, (
+        "scripts/check.sh restates the ruff targets instead of invoking the poe "
+        "tasks, so the two definitions can drift (CLAUDE.md rule 5). Replace with "
+        "`uv run poe lint` / `uv run poe format`. Offending line(s):\n  " + "\n  ".join(offenders)
+    )
+
+    body = CHECK_SH.read_text()
+    for task in ("lint", "format"):
+        assert f"poe {task}" in body, (
+            f"scripts/check.sh no longer runs `poe {task}` — the gate would stop "
+            f"{task}-checking entirely, and the summary would still print PASS."
+        )
+
+
+def test_lint_and_format_examine_the_same_tree():
+    """`lint` and `format` are two strings; nothing but this test makes them agree.
+
+    A `lint` widened to a new directory while `format` is forgotten leaves that
+    directory format-unchecked, with the gate green.
+    """
+    tasks = _poe_tasks()
+    lint = _ruff_targets(tasks["lint"])
+    fmt = _ruff_targets(tasks["format"])
+    assert lint == fmt, (
+        "the poe `lint` and `format` tasks examine different trees — "
+        f"only in lint: {sorted(lint - fmt) or 'none'}; "
+        f"only in format: {sorted(fmt - lint) or 'none'}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. The scope covers every Python file that exists  (the original bug, generalised)
+# ---------------------------------------------------------------------------
+
+
+def test_ruff_examines_every_python_file_in_the_repo():
+    """Ruff's real file list must equal every Python file git tracks.
+
+    Both sides are derived, so this cannot be satisfied by restating a constant:
+    the left side is what ruff *does* (asked via `--show-files`), the right side is
+    what is *on disk* (asked via `git ls-files`).
+
+    It goes red for both ways the gate loses coverage:
+      * a directory of Python missing from the targets (`scripts/` — the original bug);
+      * a shebang-python executable with no `.py` suffix, which ruff skips when handed
+        a directory unless `extend-include` names it (`scripts/xbrain-transcribe`,
+        `scripts/xbrain-vision` — the half of the original bug that the obvious fix
+        would have missed).
+    """
+    on_disk = _repo_python_files()
+    examined = _files_ruff_would_open(_declared_targets())
+
+    unexamined = on_disk - examined
+    assert not unexamined, (
+        "the quality gate never opens these Python files, so the gate can print "
+        "ALL CRITICAL CHECKS PASSED while they are broken:\n  "
+        + "\n  ".join(str(p) for p in sorted(unexamined))
+        + f"\n\nThe gate declares targets {sorted(_declared_targets())}. Either add the "
+        "missing directory to the `lint` and `format` poe tasks, or — if the file is an "
+        "extensionless `#!/usr/bin/env python3` executable — add it to `extend-include` "
+        "under [tool.ruff], because ruff does not discover those from a directory."
+    )


### PR DESCRIPTION
## The gap

`scripts/` contains executable Python that users actually run — `import_chrome_session.py` and `import_safari_session.py` (the X session-import scripts) and `xbrain-transcribe` / `xbrain-vision` (the executables `digest-video` shells out to).

**None of it was linted or format-checked.** The gate targeted `src tests` only, in two places:

- `pyproject.toml` → `lint = "ruff check src tests"`, `format = "ruff format --check src tests"`
- `scripts/check.sh` → the same two `uv run ruff ...` invocations

So the summary printed **ALL CRITICAL CHECKS PASSED** while a whole directory of executable Python went unexamined. The green was reporting more coverage than it had.

## The fix

Widen `lint` and `format` to `src tests scripts` in **both** definitions — fixing only one would let them drift apart again, which is the same class of bug.

One wrinkle worth naming: ruff only discovers `*.py` / `*.pyi` / `*.ipynb` when handed a directory, so `ruff check scripts` on its own **still** skips `xbrain-transcribe` and `xbrain-vision` — they are extensionless `#!/usr/bin/env python3` wrappers. Adding `extend-include` for those two paths brings ruff's file list from 2 to 4. Without it, half the fix would have been theatre.

## Damage found

- **Lint: already clean** on all 4 files.
- **Format: 2 files flagged** — `import_chrome_session.py` and `xbrain-vision`. Both reformatted here; the changes are cosmetic (line wrapping, one blank line after a docstring), no semantic change, exec bits preserved.

So the gap had not yet caused a bug. It had caused a false green.

## Proof the widened gate has teeth

Green-from-birth checks are worthless, so this was verified by breaking it on purpose. Stray blank lines injected into `import_safari_session.py` (plain `.py`) and `scripts/xbrain-transcribe` (extensionless — exercises the `extend-include` path):

```
🔍 Running Ruff format check on src/, tests/ and scripts/...
Would reformat: scripts/import_safari_session.py
Would reformat: scripts/xbrain-transcribe
2 files would be reformatted, 109 files already formatted
❌ Ruff format: formatting errors found
...
  ❌ Ruff (format)        FAIL
───────────────────────────────────────────────────────────
  FAILED - Critical issues in: Format
───────────────────────────────────────────────────────────
GATE EXIT CODE: 1
```

The gate goes **RED**, names both files, exits 1. And on those exact same two broken files, the **old** `src tests` target:

```
$ uv run ruff format --check src tests
107 files already formatted
exit: 0
```

Blind. That is the gap, measured rather than asserted. Violations reverted; gate green again — all 11 checks pass, exit 0.

## Scope

Mypy is deliberately **not** widened. Type-checking `scripts/` is a larger change with its own noise and belongs in its own PR — this one is lint + format only. Worth doing later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: the fix had the shape of the bug in it

Review caught that the first commit fixed the *instance* and left the *shape* intact: the ruff targets were spelled out **twice** — in the poe tasks and again in `scripts/check.sh` — with nothing binding them. Add a directory to one and forget the other, and CI and a local `poe lint` disagree, silently, about what "clean" means. That is [CLAUDE.md rule 5](CLAUDE.md), and rule 5's answer is not a test that polices two lists. It is **not having two lists.**

`scripts/check.sh` now invokes `uv run poe lint` / `uv run poe format`. `pyproject.toml` is the one definition; `check.sh` consumes it.

A delegation that swallowed the exit code would be a worse gate than the one being fixed, so that was attack-tested rather than assumed:

| Injected violation | Path | Result |
|---|---|---|
| `import os, sys` in `scripts/xbrain-vision` | `poe lint` | `Found 4 errors.` — **exit 1** |
| stray blank lines in `scripts/import_safari_session.py` | `poe format` | `Would reformat: …` — **exit 1** |

## Guardrail: `tests/test_quality_gate_scope.py` (3 tests, each red before its fix)

1. **`check.sh` must not re-inline the ruff targets** — red on the two `if uv run ruff check …; then` lines this PR removes, naming them.
2. **`lint` and `format` must examine the same tree** — two independent strings; nothing else makes them agree.
3. **Ruff's real file list must equal every Python file git tracks.** ← load-bearing

Test 3 asserts *behaviour, not spelling*: it asks ruff which files it would actually open (`--show-files`, using the targets the gate really declares) and compares that against `git ls-files` filtered to Python — `.py`/`.pyi` **plus extensionless `#!/usr/bin/env python3` executables**. Neither side hardcodes `{src, tests, scripts}`, so a new top-level directory of Python that nobody wires into the gate turns it red and names the file.

Truth is sourced from `git ls-files` rather than a directory walk so it inherits `.gitignore` — `.venv`, `__pycache__`, build artefacts and sibling worktrees cannot leak in and make it cry wolf. (Same reason the `check.sh` scan strips shell comments: without that, `check.sh`'s own header line — *"CRITICAL: ruff check, ruff format, mypy, bandit"* — got reported as a hardcoded target. A guardrail that cries wolf is a guardrail someone deletes.)

### Watched it fail first, on two real configurations

Against **`develop`'s shipped `pyproject.toml`** — it catches the bug that actually shipped:

```
AssertionError: the quality gate never opens these Python files, so the gate can
print ALL CRITICAL CHECKS PASSED while they are broken:
    scripts/import_chrome_session.py
    scripts/import_safari_session.py
    scripts/xbrain-transcribe
    scripts/xbrain-vision

The gate declares targets ['src', 'tests'].
```

And against **the obvious fix** — `scripts` added to the targets, no `extend-include`, which looks complete and passes lint:

```
AssertionError: the quality gate never opens these Python files:
    scripts/xbrain-transcribe
    scripts/xbrain-vision

The gate declares targets ['scripts', 'src', 'tests'].
```

That second one is the case that got past both the original measurement and the first review of it. A test that only pinned "`scripts` is in the target list" would have been green on it.

Final gate: **11/11 green, exit 0**, 1,586 tests (+3).
