### PR TITLE
[PROBE - DO NOT MERGE] head-vs-base workflow version

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,6 +11,11 @@ jobs:
       PYTHONHASHSEED: "0"
     steps:
       - uses: actions/checkout@v4
+      - name: PROBE-HEAD-MARKER
+        continue-on-error: true
+        run: |
+          echo "PROBE_HEAD_MARKER_PRESENT"
+          exit 1
       - name: Install uv
         uses: astral-sh/setup-uv@v3
       - name: Set up Python


### PR DESCRIPTION
Throwaway probe. Adds a deliberately-failing step with continue-on-error:true to the quality job. If the run contains PROBE-HEAD-MARKER, the pull_request event uses the HEAD version of the workflow. Will be closed immediately.