### PR TITLE
[PROBE - DO NOT MERGE] continue-on-error + red gate

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4,6 +4,7 @@ on:
     branches: [develop, main]
 jobs:
   quality:
+    continue-on-error: true
     runs-on: ubuntu-latest
     env:
       # Pin the Python hash seed so the gate is byte-reproducible run-to-run

--- a/tests/test_probe_red.py
+++ b/tests/test_probe_red.py
@@ -1,0 +1,3 @@
+def test_deliberately_red():
+    """PROBE: forces the gate to fail so we can see what the check run reports."""
+    assert False, "PROBE: the gate MUST fail here"


### PR DESCRIPTION
Measuring: does a `continue-on-error: true` job that FAILS report its check run as success or failure? Determines whether the attack is fail-open (lethal) or fail-closed (harmless). Will be closed immediately.