### PR TITLE
[PROBE - DO NOT MERGE] continue-on-error on the GATE STEP

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,4 +20,5 @@ jobs:
           uv venv
           uv pip install -e ".[dev]"
       - name: Quality gate
+        continue-on-error: true
         run: bash scripts/check.sh

--- a/tests/test_probe_red.py
+++ b/tests/test_probe_red.py
@@ -1,0 +1,3 @@
+def test_probe_red():
+    """PROBE: forces check.sh to exit 1."""
+    assert False, "PROBE"


### PR DESCRIPTION
Does continue-on-error on the *Quality gate step* make a FAILING gate report green and CLEAN? Closing immediately.