### PR TITLE
PROBE (do not merge): measure continue-on-error reporting

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   quality:
     runs-on: ubuntu-latest
+    continue-on-error: true
     env:
       # Pin the Python hash seed so the gate is byte-reproducible run-to-run
       # (determinism; check.sh pins the same default for local runs).

--- a/tests/test_zz_probe_forced_red.py
+++ b/tests/test_zz_probe_forced_red.py
@@ -1,0 +1,6 @@
+"""Throwaway: forces the gate red to measure how continue-on-error reports."""
+
+
+def test_forced_failure() -> None:
+    """Deliberately fails."""
+    assert False, 'forced red for the continue-on-error probe'


### PR DESCRIPTION
Throwaway probe. Measures whether a `continue-on-error: true` job's CHECK RUN reports success or failure when the gate goes red. Closed immediately.