### PR TITLE
[PROBE - DO NOT MERGE] continue-on-error on gate STEP

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,6 +48,7 @@ jobs:
           uv venv
           uv pip install -e ".[dev]"
       - name: Quality gate
+        continue-on-error: true
         run: bash scripts/check.sh
 
       # A red PUSH run blocks nothing — the commit has already landed — so it must speak, or

--- a/tests/test_zzz_probe_fail.py
+++ b/tests/test_zzz_probe_fail.py
@@ -1,0 +1,2 @@
+def test_probe_deliberate_failure():
+    assert False, "probe: gate should fail here"


### PR DESCRIPTION
continue-on-error on the Quality gate step itself + a failing test. Reconciles step-level vs job-level continue-on-error.