### PR TITLE
PROBE (do not merge): STEP-level continue-on-error

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -48,6 +48,7 @@ jobs:
           uv venv
           uv pip install -e ".[dev]"
       - name: Quality gate
+        continue-on-error: true
         run: bash scripts/check.sh
 
       # A red PUSH run blocks nothing — the commit has already landed — so it must speak, or

--- a/tests/test_zz_probe_forced_red.py
+++ b/tests/test_zz_probe_forced_red.py
@@ -1,0 +1,6 @@
+"""Throwaway: forces check.sh to exit 1 to measure STEP-level continue-on-error."""
+
+
+def test_forced_failure() -> None:
+    """Deliberately fails so the gate exits non-zero."""
+    assert False, 'forced red: step-level continue-on-error probe'


### PR DESCRIPTION
Throwaway. Measures whether a failing gate STEP with continue-on-error publishes a green check run. Closed immediately.