### PR TITLE
docs(ci): if:false reports `skipped`, not `success` — the last unmeasured cell

### DIFF
--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -114,8 +114,13 @@ is trusted.
     special-casing the gate step: any step can become load-bearing later.
   * `paths-ignore` under `push` -> the merge-result run never happens; #103 reopens, silently.
   * `steps:` gutted to `echo ok` -> a green `quality` check that ran nothing.
-  * `if: false` on the JOB -> GitHub, verbatim: *"if a job within a workflow is skipped due
-    to a conditional, it will report its status as 'Success.'"* A skipped job is a GREEN job.
+  * `if: false` on the JOB -> measured (#130): check run conclusion = **`skipped`**, and the
+    PR goes `MERGEABLE` / **`CLEAN`**. Note that this is NOT what GitHub's own docs imply —
+    they say a skipped job *"will report its status as 'Success'"*, and the API in fact
+    reports `skipped`. The distinction does not save you: **branch protection treats a
+    skipped required check as satisfied.** The merge is waved through either way. Cited from
+    the docs before it was measured, and the docs were wrong about the mechanism while right
+    about the consequence — which is exactly the kind of luck this file refuses to run on.
   * **`checkout` with an explicit `ref:`** -> the gate RUNS. All eleven checks PASS. The check
     run reports a *truthful* ✅ `quality`. And it examined **the wrong tree** — it never looked
     at the code being merged. Not a broken gate: a working gate pointed at the wrong thing,
@@ -146,6 +151,21 @@ Four times in one PR an instrument lied, and each lie was believed until it was 
 
 (3) and (4) are the same directive, measured on the wrong placement. Being careful was not
 enough; only running the experiment on the exact thing under test was.
+
+  5. GitHub's OWN DOCS said a skipped job "will report its status as 'Success'". The API
+     reports `skipped`. The consequence happened to be the same (branch protection waves it
+     through) — so the classification survived on luck, not on evidence.
+
+THE HOUSE RULE THIS BUYS
+------------------------
+Every cell of the table above carries a probe number, or it carries the words "reasoned, not
+measured". Nothing in this file is asserted from a vendor's documentation, from a plausible
+mechanism, or from a colleague's confident summary — including this author's. Two people on
+this PR each measured ONE cell of a 2x2 and claimed the whole table; both were half right,
+and the halves they got wrong were the lethal ones. If you add a row, run the probe against
+a throwaway PR, read the CHECK RUN (not the workflow run, not the log), and close the probe
+the moment you have read it — a probe carrying a gate-killing edit is one careless click from
+a dead gate, so it never sits open.
 """
 
 import fnmatch
@@ -398,12 +418,18 @@ def test_pull_request_trigger_covers_normal_pr_activity() -> None:
 
 
 def test_gate_job_is_not_conditional() -> None:
-    """The gate job must carry no `if:`.
+    """The gate job must carry no `if:`. FAIL-OPEN — measured, not inferred.
 
-    An `if:` on the job is a way to neuter the gate while the trigger block above it looks
-    completely healthy — `if: github.event_name == 'pull_request'` would undo this entire
-    PR. Worse, a job skipped by `if:` does not run the gate yet still resolves its check
-    run, so branch protection can be satisfied by a check that verified nothing.
+    An `if:` on the job neuters the gate while the trigger block above it looks completely
+    healthy: `if: github.event_name == 'pull_request'` would undo this entire workflow in one
+    line. Measured on probe #130 with `if: false` on this job:
+
+        check run `quality` -> conclusion = skipped
+        the PR              -> mergeable = MERGEABLE, mergeStateStatus = CLEAN
+
+    The check run resolves as `skipped` — not `success`, whatever the docs say — and **branch
+    protection treats a skipped required check as satisfied**. The gate never runs, and the
+    merge is waved through. Fail-open, and one word long.
     """
     assert "if" not in _gate_job(), (
         f"The `{_REQUIRED_CHECK}` job declares `if: {_gate_job().get('if')!r}`. A condition "


### PR DESCRIPTION
## First: #128 already landed the correction you're asking for

You're reading `fix/ci-taxonomy-failclosed` **before its final commit** (`84c1123`). Measured against `develop` just now, with a real tree:

```
occurrences of "Also fail-closed" / "invent a lethal hole that does not exist":  0

develop:tests/test_ci_workflow.py
  100:  `continue-on-error` **on the JOB** -> measured (#123): check run FAILURE, PR BLOCKED
  109:  `continue-on-error` **on a STEP** -> measured (#129): CLEAN, MERGEABLE, check run
        SUCCESS, while check.sh exited 1. The worst attack in this repo.
   61:  NEVER TRUST A REPORTED CONCLUSION. ASSERT ON THE SOURCE.
```

The 2×2 is already correct in `develop`, both cells carry probe numbers, and the instrument-trap passage is already turned on the right target. **Nothing is shipping the lie.** #129 was already closed with its branch deleted.

## What you were right about: the one cell I never measured

`if: false` on the job. I asserted it fail-open **from GitHub's docs**, not from a probe. You told me to measure it or label it. I measured it (#130, closed on read):

```
check run "quality"  ->  conclusion = skipped        ← NOT "success"
the PR               ->  mergeable = MERGEABLE, mergeStateStatus = CLEAN
```

**The classification was right. The mechanism I stated was wrong.** GitHub's docs say a skipped job *"will report its status as 'Success'"* — the API reports **`skipped`**. It doesn't save you: **branch protection treats a skipped required check as satisfied.** So the row survived, but on *luck*, not on evidence. That is the fifth instrument failure in this line of work, and the first where the lying instrument was **the vendor's own documentation**.

| # | Instrument | Lie | Damage |
|---|---|---|---|
| 1 | `gh run list` | `success` for a stale run | wrong published account of #103 |
| 2 | issue **list** endpoints | "no issue exists" | duplicate issues #113 + #114 |
| 3 | **workflow run** conclusion | `success` vs check run `FAILURE` | invented a phantom lethal hole |
| 4 | **check run** conclusion | `SUCCESS` vs log `exit 1` | missed a real lethal hole |
| 5 | **GitHub's own docs** | "reports Success" vs actual `skipped` | right answer, wrong reason |

## The house rule this buys

> Every cell of the table carries a **probe number**, or it carries the words **"reasoned, not measured"**. Nothing here is asserted from a vendor's docs, a plausible mechanism, or a colleague's confident summary — **including this author's**. Two people on this PR each measured ONE cell of a 2×2 and claimed the whole table; both were half right, and the halves they got wrong were the lethal ones.

Plus the probe-hygiene rule, paid for in your near miss: **close the probe the moment you have read it.** A probe carrying a gate-killing edit sits green and `CLEAN`, one careless click from a dead gate.

## Scope

`quality.yml` untouched. Every attack still red (`if: false` on job and step-level `continue-on-error` both verified red on this branch). `poe check` 11/11, 1603 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)