### PR TITLE
feat(ci): audit the quality gate from outside the room it can gag

### DIFF
--- a/.github/workflows/gate-audit.yml
+++ b/.github/workflows/gate-audit.yml
@@ -1,0 +1,307 @@
+# Does the `quality` gate actually DO what it REPORTS?
+#
+# ============================================================================================
+# READ THIS BEFORE YOU MOVE, RENAME, OR "TIDY" THIS FILE
+# ============================================================================================
+#
+# THE HOLE THIS CLOSES
+#
+# `quality` is a required status check on `develop` and `main` (strict, enforce_admins). Two
+# one-line edits to `quality.yml` make it report GREEN while testing nothing. Both were
+# measured against the live API on this repo:
+#
+#   1. `continue-on-error: true` on the `Quality gate` STEP (probes #121, #125).
+#      `check.sh` genuinely exits 1. The step reports `success`. The job reports `success`.
+#      The check run reports `SUCCESS`. `mergeStateStatus` is `CLEAN`. EVERY API SURFACE SAYS
+#      GREEN. The failure survives only as text in a log nobody opens.
+#      (At JOB level — `jobs.quality.continue-on-error` — it is harmless: the check reports
+#      FAILURE and the merge is BLOCKED, probe #119. The difference is ONE INDENT. This is
+#      not a distinction anyone should have to hold in their head, which is why both are
+#      banned.)
+#
+#   2. `checkout` with an explicit `ref:` (probe #124). The gate runs, everything passes,
+#      the check reports `SUCCESS`, `CLEAN` — against the WRONG TREE. What gave it away was
+#      the test count: `1088 passed`, where develop's suite has ~1600. Nobody reads the test
+#      count on a green run.
+#
+# WHY NO IN-REPO TEST CAN CATCH #1
+#
+# A PR's CI runs the PR's OWN HEAD copy of the workflow. Our guards
+# (`tests/test_ci_workflow.py`) live inside `scripts/check.sh`, which is what the gate runs.
+# On a PR that adds `continue-on-error: true`, those guards fire correctly and `check.sh`
+# exits 1 — and the very same `continue-on-error` swallows THAT failure too. The alarm rings
+# inside the soundproofed room. Something OUTSIDE the room has to listen. This is it.
+#
+# AND IT IS NOT ONLY AN ATTACK. `continue-on-error: true` on a failing step is THE canonical
+# "make flaky CI stop blocking merges" edit. An agent told "the build keeps failing, make it
+# pass" reaches for it in perfectly good faith and produces a permanently dead gate wearing a
+# green badge. No adversary required. That is the likelier way this happens.
+#
+# ---------------------------------------------------------------------------------------------
+# THE ONE FACT THIS WHOLE FILE RESTS ON — DO NOT DESTROY IT
+# ---------------------------------------------------------------------------------------------
+#
+#   A `schedule`-triggered workflow runs from the DEFAULT BRANCH's version of the file.
+#
+# This repo's default branch is `main` (verified against the API). So this auditor's
+# definition lives on `main`, and A PULL REQUEST INTO `develop` CANNOT EDIT IT. The thing
+# being audited has no reach over the thing auditing it. That is the fail-closed property,
+# and it is the entire security model.
+#
+# It is the same guarantee `pull_request_target` would give (that also runs the base branch's
+# copy) — but WITHOUT its cost. `pull_request_target` hands a base-scoped WRITE token to a
+# workflow running in the context of a fork's pull request, on a PUBLIC repo: the textbook
+# fork-PR RCE surface. It was considered and DECLINED. `schedule` gets the same fail-closed
+# property for free, because no outsider can fire a clock and no fork input is ever executed.
+#
+# => If you "tidy" this workflow so it also runs on `push` or `pull_request`, or you move its
+#    logic onto `develop`, YOU SILENTLY DESTROY THE ONLY THING IT HAS. It would then run from
+#    the PR's own copy, and the accused would be holding the gavel. `tests/
+#    test_gate_audit_workflow.py` fails loudly if you try. Do not "fix" that test.
+#
+# => Corollary, and the reason this is not live yet: a workflow must exist ON THE DEFAULT
+#    BRANCH to be scheduled at all. This lands on `develop` first, so IT DOES NOTHING UNTIL
+#    `develop` IS PROMOTED TO `main`. Until that promotion, this layer is not armed.
+#
+# ---------------------------------------------------------------------------------------------
+# HONEST LIMITS
+# ---------------------------------------------------------------------------------------------
+#
+# * THIS IS DETECTION, NOT PREVENTION. A weakened gate can merge and live on `develop` until
+#   the next audit run — up to 24h. That is an ACCEPTED trade, not an oversight: the accident
+#   is recoverable (it is visible in the diff and one commit to fix), and every mechanical
+#   prevention was checked against the live API and is unavailable on this public, user-owned
+#   repo — merge queue (org-only), required-workflows ruleset (Enterprise),
+#   file_path_restriction ruleset (Enterprise), required approvals (sole collaborator; nobody
+#   can approve). The one remaining preventive option, `pull_request_target`, would have cost
+#   an RCE surface. Detection at 24h beats prevention that opens a hole.
+#
+# * IT CANNOT CATCH A GATE THAT LIES ABOUT ITSELF FROM INSIDE `check.sh`. The audit executes
+#   develop's `check.sh` — that IS the gate under audit — so a `check.sh` neutered to exit 0
+#   would be executed, honestly, and agree with a green report. The static audit and
+#   `tests/test_quality_gate_scope.py` cover that flank; this one covers the workflow.
+#
+# * To disarm THIS file you must weaken `main`, which is a `develop -> main` PR: a separate,
+#   visible, deliberate act. That asymmetry is the point.
+#
+# Permissions: read-only on code everywhere, `issues: write` only where the alarm is raised.
+# No PAT, no secrets beyond the built-in GITHUB_TOKEN, no second identity to rotate or leak.
+# ============================================================================================
+
+name: Gate audit
+
+on:
+  schedule:
+    # 06:17 UTC daily (~07:17/08:17 Madrid). Chosen, not defaulted:
+    #   * Early morning EU, so a lie caught overnight is at the top of the inbox at the start
+    #     of the day rather than discovered at 5pm.
+    #   * `develop`'s HEAD is settled — no pushes overnight — so the `quality` check run for
+    #     it is long since COMPLETED. Auditing a branch mid-push would race an in-flight gate
+    #     and land in `inconclusive`, which is a wasted run.
+    #   * :17, not :00. GitHub explicitly warns that scheduled workflows cluster at the top of
+    #     the hour and are delayed or dropped under that load. An audit that silently does not
+    #     run is exactly the failure this file exists to prevent.
+    - cron: "17 6 * * *"
+  # Run it by hand — the ONLY way to clear an alert the same day you fix it. Without this, a
+  # fix pushed at noon leaves the alarm standing until tomorrow's cron, and a routinely stale
+  # alert is one people learn to scroll past.
+  workflow_dispatch:
+
+# Read-only by default. The single job that needs to speak asks for `issues: write` itself.
+permissions:
+  contents: read
+
+env:
+  AUDITED_BRANCH: develop
+
+jobs:
+  # ------------------------------------------------------------------------------------------
+  # 1. Pin the commit. Everything downstream must agree on ONE SHA.
+  #
+  # The audit compares three views of `develop`: the tree we EXECUTE, the `quality.yml` we
+  # READ, and the check run GitHub REPORTED. If each resolved `develop` independently, a push
+  # landing mid-run would leave them looking at different commits — and comparing an honest
+  # execution of commit A against the reported verdict for commit B produces a FALSE
+  # ACCUSATION. Resolve once, here, and pin all three to the result.
+  #
+  # This job also exists so the SHA survives a FAILING gate: outputs from a failed job are not
+  # dependable, and the gate-execution job is designed to fail. This one cannot.
+  # ------------------------------------------------------------------------------------------
+  resolve:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      sha: ${{ steps.head.outputs.sha }}
+    steps:
+      - name: Resolve the audited branch to a single commit
+        id: head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          sha=$(gh api "repos/${REPO}/commits/${AUDITED_BRANCH}" --jq '.sha')
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "Auditing ${AUDITED_BRANCH} @ ${sha}"
+
+  # ------------------------------------------------------------------------------------------
+  # 2. RUN THE REAL GATE. Judge != party — and the judge must EXECUTE, not read.
+  #
+  # This is the half that makes the audit more than a linter. It runs `bash scripts/check.sh`
+  # — the actual gate, from develop's actual tree — in a job whose definition lives on `main`
+  # and which a PR into `develop` therefore cannot touch.
+  #
+  # NOTE WHAT IS ABSENT: no `continue-on-error`, no `if:`, no pinned `ref:` to a tree other
+  # than the commit under audit. Every one of those is a way to make a gate lie, and this job
+  # is the honest control that the lying gate is measured against. It is ALLOWED TO FAIL — a
+  # failure here is the signal, not an error. The `audit` job reads `needs.execute-gate.result`.
+  # ------------------------------------------------------------------------------------------
+  execute-gate:
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # Match quality.yml exactly. A gate run under a different hash seed is not the same gate,
+      # and a spurious difference would read as a lie.
+      PYTHONHASHSEED: "0"
+    steps:
+      - name: Check out the exact commit under audit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Create venv and install dependencies
+        run: |
+          uv venv
+          uv pip install -e ".[dev]"
+
+      # The whole point. If this disagrees with what GitHub published, the gate is lying.
+      - name: Run the real quality gate, honestly
+        run: bash scripts/check.sh
+
+  # ------------------------------------------------------------------------------------------
+  # 3. COMPARE, and raise the alarm.
+  #
+  # `if: always()` is load-bearing: `execute-gate` is EXPECTED to fail when develop is red or
+  # the gate is lying, and a failed dependency would otherwise skip this job — burying the
+  # alarm exactly when it matters. This is NOT `continue-on-error`: `execute-gate` still fails
+  # honestly and still turns this workflow red. We just insist on being told.
+  #
+  # THE SUBTLETY THAT MAKES THIS JOB TRUSTWORTHY — the comparator is OUR code, not theirs:
+  #
+  #   * The bare `actions/checkout` below takes NO `ref:`. On a scheduled run that resolves to
+  #     the DEFAULT BRANCH — so `xbrain.gate_audit` and `scripts/audit_gate_issue.sh` are
+  #     `main`'s copies. A PR into `develop` cannot edit the judge.
+  #   * develop's `quality.yml` is pulled in through a SEPARATE, SPARSE checkout into
+  #     `audited/`. It is read as DATA and never executed. Sparse-checking-out exactly one
+  #     file makes that structural rather than a promise.
+  #
+  # If the comparator ran from the audited tree instead, a single PR could neuter the gate and
+  # the judge in the same diff, and this entire workflow would be decorative.
+  # ------------------------------------------------------------------------------------------
+  audit:
+    needs: [resolve, execute-gate]
+    if: always()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # clone this repo
+      checks: read # ask what the `quality` check run concluded
+      issues: write # raise the alarm. The only write scope in this file.
+    steps:
+      - name: Check out the AUDITOR's own tree (default branch — not the audited branch)
+        uses: actions/checkout@v4
+
+      - name: Fetch the audited quality.yml as DATA (never executed)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.sha }}
+          path: audited
+          sparse-checkout: .github/workflows/quality.yml
+          sparse-checkout-cone-mode: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install the auditor
+        run: |
+          uv venv
+          uv pip install -e .
+
+      # What the gate CLAIMED for this exact commit. Pinned to the resolved SHA, never to
+      # `develop`, so it cannot drift onto a different commit than the one we executed.
+      # Every `${{ }}` below is routed through `env:` rather than interpolated into the shell.
+      # Nothing here is attacker-controlled — this workflow fires only on `schedule` and
+      # `workflow_dispatch`, so there is no `github.event.*` payload for an outsider to poison,
+      # and SHA comes from the API as a hex string. The discipline is kept anyway: it costs
+      # nothing, and a file whose whole purpose is to be trustworthy should not ask a reviewer
+      # to first prove that its interpolations happen to be safe.
+      - name: Ask GitHub what the gate REPORTED
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+        run: |
+          gh api "repos/${REPO}/commits/${SHA}/check-runs?per_page=100" > check-runs.json
+          echo "--- check runs GitHub published for this commit ---"
+          jq -r '.check_runs[] | "  \(.name): \(.status)/\(.conclusion)"' check-runs.json
+
+      # The comparison. Reported vs. actually-executed, plus a static read of develop's
+      # quality.yml for the known banned patterns. Writes `verdict`, `file_issue`, `clean`
+      # and `title` to $GITHUB_OUTPUT, and always exits 0 — the alarm must be raised BEFORE
+      # anything is allowed to fail.
+      - name: Compare what the gate REPORTED with what it actually DOES
+        id: audit
+        env:
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          GATE_RESULT: ${{ needs.execute-gate.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          uv run python -m xbrain.gate_audit \
+            --check-runs check-runs.json \
+            --workflow audited/.github/workflows/quality.yml \
+            --audit-result "$GATE_RESULT" \
+            --sha "$SHA" \
+            --repo "$REPO" \
+            --run-url "$RUN_URL" \
+            --body-out issue-body.md
+
+      - name: Raise the alarm
+        if: steps.audit.outputs.file_issue == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          TITLE: ${{ steps.audit.outputs.title }}
+        run: bash scripts/audit_gate_issue.sh open "$TITLE" issue-body.md
+
+      # Stand down ONLY on a positively CLEAN verdict — never on merely "no new accusation".
+      # An inconclusive audit or a plainly-red develop must leave a live alarm standing; see
+      # `should_stand_down` in xbrain/gate_audit.py.
+      - name: Stand down a resolved alarm
+        if: steps.audit.outputs.clean == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ needs.resolve.outputs.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bash scripts/audit_gate_issue.sh close
+
+      # Turn the run red, AFTER the issue is filed. An audit that catches a lying gate and
+      # still shows a green tick would be the very thing it exists to detect.
+      - name: Fail the audit when the gate cannot be trusted
+        if: steps.audit.outputs.file_issue == 'true'
+        run: |
+          echo "::error::develop's quality gate is not trustworthy — see the issue just filed."
+          exit 1

--- a/.github/workflows/gate-audit.yml
+++ b/.github/workflows/gate-audit.yml
@@ -81,11 +81,19 @@
 #   would be executed, honestly, and agree with a green report. The static audit and
 #   `tests/test_quality_gate_scope.py` cover that flank; this one covers the workflow.
 #
+# * IT CONVICTS ON THE GATE STEP, NOT ON THE JOB. `needs.execute-gate.result` aggregates the
+#   checkout, the uv install and the dependency sync too, so reading it would make a bad
+#   morning at PyPI indistinguishable from a gate that lies. The gate step records its own
+#   outcome into an artifact (`if: always()`), and a job that broke before reaching the gate
+#   is `inconclusive` — it files nothing, and turns the run red so the auditor cannot go
+#   quietly deaf.
+#
 # * To disarm THIS file you must weaken `main`, which is a `develop -> main` PR: a separate,
 #   visible, deliberate act. That asymmetry is the point.
 #
-# Permissions: read-only on code everywhere, `issues: write` only where the alarm is raised.
-# No PAT, no secrets beyond the built-in GITHUB_TOKEN, no second identity to rotate or leak.
+# Permissions: read-only on code everywhere (`contents: read`, `checks: read`, `actions: read`
+# to fetch the gate-outcome artifact), `issues: write` only where the alarm is raised. No PAT,
+# no secrets beyond the built-in GITHUB_TOKEN, no second identity to rotate or leak.
 # ============================================================================================
 
 name: Gate audit

--- a/.github/workflows/gate-audit.yml
+++ b/.github/workflows/gate-audit.yml
@@ -195,7 +195,36 @@ jobs:
 
       # The whole point. If this disagrees with what GitHub published, the gate is lying.
       - name: Run the real quality gate, honestly
+        id: gate
         run: bash scripts/check.sh
+
+      # Carry out of this job what THE GATE STEP did — not what the job did.
+      #
+      # `needs.execute-gate.result` aggregates every step above: the checkout, the uv install,
+      # the Python install, the dependency sync. All of them collapse into a single `failure`,
+      # so a runner with no network at 06:17 is indistinguishable from a gate that lies. Read
+      # that way, a bad morning at PyPI files a public issue accusing this repository of
+      # merging unverified code.
+      #
+      # An ARTIFACT rather than a job output, deliberately: job outputs are not published when
+      # the job fails, and this job is DESIGNED to fail — the output would be missing in
+      # exactly the case that must convict. `if: always()` so it is written whether the gate
+      # passed or failed; if an earlier step broke, the gate step is `skipped` and that is
+      # recorded faithfully as "we never looked".
+      - name: Record what the gate step actually did
+        if: always()
+        env:
+          GATE_OUTCOME: ${{ steps.gate.outcome }}
+        run: echo "$GATE_OUTCOME" > gate-outcome.txt
+
+      - name: Hand the gate's own outcome to the audit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gate-outcome
+          path: gate-outcome.txt
+          if-no-files-found: error
+          retention-days: 1
 
   # ------------------------------------------------------------------------------------------
   # 3. COMPARE, and raise the alarm.
@@ -224,6 +253,7 @@ jobs:
     permissions:
       contents: read # clone this repo
       checks: read # ask what the `quality` check run concluded
+      actions: read # download the gate-outcome artifact from `execute-gate`
       issues: write # raise the alarm. The only write scope in this file.
     steps:
       - name: Check out the AUDITOR's own tree (default branch — not the audited branch)
@@ -267,10 +297,30 @@ jobs:
           echo "--- check runs GitHub published for this commit ---"
           jq -r '.check_runs[] | "  \(.name): \(.status)/\(.conclusion)"' check-runs.json
 
+      # What the GATE STEP itself did, as recorded inside `execute-gate`. A missing artifact
+      # is DATA, not an error: it means that job was cancelled before it could record
+      # anything, and it must read as "the gate was never observed" — never as "the gate
+      # failed". So absence is handled here, in a conditional, rather than by letting the
+      # download fail the step. This is not `continue-on-error`: nothing that reports a
+      # verdict is being suppressed, and a missing outcome can only ever make the audit say
+      # LESS, never wrongly accuse.
+      - name: Fetch what the gate step actually did
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          if gh run download "$RUN_ID" --repo "$REPO" --name gate-outcome --dir gate-outcome; then
+            echo "The gate step reported: $(cat gate-outcome/gate-outcome.txt)"
+          else
+            echo "No gate-outcome artifact. execute-gate never recorded an outcome, so the"
+            echo "gate was not observed and nothing will be concluded about it."
+          fi
+
       # The comparison. Reported vs. actually-executed, plus a static read of develop's
-      # quality.yml for the known banned patterns. Writes `verdict`, `file_issue`, `clean`
-      # and `title` to $GITHUB_OUTPUT, and always exits 0 — the alarm must be raised BEFORE
-      # anything is allowed to fail.
+      # quality.yml for the known banned patterns. Writes `verdict`, `file_issue`, `clean`,
+      # `observed` and `title` to $GITHUB_OUTPUT, and always exits 0 — the alarm must be
+      # raised BEFORE anything is allowed to fail.
       - name: Compare what the gate REPORTED with what it actually DOES
         id: audit
         env:
@@ -283,6 +333,7 @@ jobs:
             --check-runs check-runs.json \
             --workflow audited/.github/workflows/quality.yml \
             --audit-result "$GATE_RESULT" \
+            --gate-outcome gate-outcome/gate-outcome.txt \
             --sha "$SHA" \
             --repo "$REPO" \
             --run-url "$RUN_URL" \
@@ -309,6 +360,18 @@ jobs:
           SHA: ${{ needs.resolve.outputs.sha }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bash scripts/audit_gate_issue.sh close
+
+      # An auditor that cannot RUN the gate files nothing — correctly, it has no evidence.
+      # But silence is how it then goes deaf: months of "no issue filed" reads exactly like
+      # months of good news. So the run goes red, loudly, without ever making the accusation
+      # it cannot support. This is the broken-instrument signal, not the lying-gate one.
+      - name: Fail when the gate could never be executed
+        if: needs.execute-gate.result == 'failure' && steps.audit.outputs.observed == 'false'
+        run: |
+          echo "::error::The gate-execution job failed BEFORE reaching the gate, so this"
+          echo "::error::audit observed nothing. The auditor is broken, not the gate — fix"
+          echo "::error::the setup steps in gate-audit.yml, then re-run via workflow_dispatch."
+          exit 1
 
       # Turn the run red, AFTER the issue is filed. An audit that catches a lying gate and
       # still shows a green tick would be the very thing it exists to detect.

--- a/.github/workflows/gate-audit.yml
+++ b/.github/workflows/gate-audit.yml
@@ -177,10 +177,21 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
-      - name: Create venv and install dependencies
-        run: |
-          uv venv
-          uv pip install -e ".[dev]"
+      # MUST be byte-identical to the install step in `quality.yml`, and
+      # `tests/test_gate_audit_workflow.py` fails the build if it drifts. An honest re-run in
+      # a DIFFERENT environment is not a control — it is a second opinion, and the auditor
+      # would report the disagreement as a LIE.
+      #
+      # This is exactly how it went wrong once already. This job ran `uv venv && uv pip
+      # install -e ".[dev]"` while `quality.yml` moved to the lockfile (PR #135). `uv pip
+      # install` is uv's pip-COMPATIBILITY mode: it resolves fresh from pyproject.toml
+      # (`ruff>=0.5`) and never reads uv.lock. Measured on this tree: it installs ruff 0.16.5
+      # where the lock pins 0.15.13 — and ruff 0.16 enables UP017 by default, which this tree
+      # trips 429 times. The auditor would have run `check.sh`, watched it exit 1, compared
+      # that against a `quality` check that had honestly reported SUCCESS, and filed a public
+      # issue accusing the repository of merging unverified code. On its first run.
+      - name: Install dependencies from the lockfile
+        run: uv sync --extra dev --locked
 
       # The whole point. If this disagrees with what GitHub published, the gate is lying.
       - name: Run the real quality gate, honestly
@@ -232,10 +243,11 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
 
+      # From the lockfile, for the same reason `execute-gate` does: the auditor is the stable
+      # thing a drifting gate is measured against, so it is the last place that may float.
+      # No `--extra dev` — the comparator needs the package and PyYAML, nothing else.
       - name: Install the auditor
-        run: |
-          uv venv
-          uv pip install -e .
+        run: uv sync --locked
 
       # What the gate CLAIMED for this exact commit. Pinned to the resolved SHA, never to
       # `develop`, so it cannot drift onto a different commit than the one we executed.

--- a/scripts/audit_gate_issue.sh
+++ b/scripts/audit_gate_issue.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+# Raise (or stand down) the alarm when the scheduled audit catches the `quality` gate lying.
+#
+# WHY THIS IS A SEPARATE SCRIPT FROM announce_red_branch.sh
+#
+# They alarm on two different facts, and conflating them would blunt both:
+#
+#   announce_red_branch.sh : "`develop` is RED."          -> the code is broken.
+#   this script            : "`develop`'s GATE is LYING." -> the code may be broken and
+#                                                            NOTHING WILL TELL YOU.
+#
+# The second is strictly worse, and it needs its own issue, its own label and its own words.
+# A red branch is loud: every subsequent PR sees it. A lying gate is silent by construction —
+# every API surface reports green (measured: check run SUCCESS, mergeStateStatus CLEAN,
+# probes #121/#125). Filing that under the same label as an ordinary red branch would bury
+# the one alert nobody else can raise underneath the one everybody already knows about.
+#
+# IDENTITY: the built-in GITHUB_TOKEN (`github-actions[bot]`) with `issues: write`. No PAT,
+# no bot account, no standing credential. A scheduled workflow holding a long-lived PAT is a
+# key nobody is watching; the built-in token is scoped to the run and dies with it.
+#
+# IDEMPOTENCY: one open issue, keyed by the label `ci-gate-audit`. The audit runs daily, and
+# a lying gate stays lying until someone fixes it — so the naive version files an issue every
+# single day until you do. The defences here are lifted wholesale from announce_red_branch.sh
+# because that script already paid for them: every GitHub issue LIST endpoint is EVENTUALLY
+# CONSISTENT (measured on this repo — an issue created and immediately listed does not appear
+# for several seconds, while fetching it by number returns it at once). A bare
+# list-then-create races against its own write; that bug filed issues #113 AND #114 for a
+# single red branch. Hence: RETRY the lookup with bounded backoff, and RECONCILE duplicates
+# on every run so the state converges instead of compounding.
+#
+# Usage:  audit_gate_issue.sh open <title> <body-file>
+#         audit_gate_issue.sh close
+#
+# Env (all from trusted `github.*` context — never from user input):
+#   GH_TOKEN, REPO, SHA, RUN_URL
+
+set -euo pipefail
+
+MODE="${1:?usage: audit_gate_issue.sh open <title> <body-file> | close}"
+case "$MODE" in
+open | close) ;;
+*)
+    echo "Unknown mode '${MODE}' (expected 'open' or 'close')" >&2
+    exit 2
+    ;;
+esac
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${SHA:?SHA is required}"
+: "${RUN_URL:?RUN_URL is required}"
+
+SHORT_SHA="${SHA:0:8}"
+LABEL="ci-gate-audit"
+COMMIT_URL="https://github.com/${REPO}/commit/${SHA}"
+
+gh label create "$LABEL" \
+    --repo "$REPO" \
+    --color B60205 \
+    --description "The develop quality gate is reporting green without testing" \
+    >/dev/null 2>&1 || true
+
+# Oldest first: the oldest issue is the canonical one, so reconciliation is deterministic no
+# matter which run happens to observe a mess.
+open_issues() {
+    gh issue list \
+        --repo "$REPO" \
+        --label "$LABEL" \
+        --state open \
+        --limit 50 \
+        --json number \
+        --jq '[.[].number] | sort | .[]'
+}
+
+# Absorbs the list-endpoint lag. Only `open` needs it: there, a false "none" costs a
+# duplicate issue. `close` skips it — a false "none" there costs one extra day of a stale
+# alert, and the next run fixes it.
+open_issues_with_retry() {
+    local found attempt
+    for attempt in 1 2 3 4 5; do
+        found=$(open_issues || true)
+        if [ -n "$found" ]; then
+            echo "$found"
+            return 0
+        fi
+        [ "$attempt" -lt 5 ] && sleep 2
+    done
+    return 0
+}
+
+case "$MODE" in
+open)
+    TITLE="${2:?usage: audit_gate_issue.sh open <title> <body-file>}"
+    BODY_FILE="${3:?usage: audit_gate_issue.sh open <title> <body-file>}"
+    [ -f "$BODY_FILE" ] || {
+        echo "Body file '${BODY_FILE}' does not exist" >&2
+        exit 2
+    }
+
+    EXISTING=$(open_issues_with_retry)
+    if [ -n "$EXISTING" ]; then
+        # Still lying, on a new commit. Update the canonical issue — never open a second one.
+        CANONICAL=$(echo "$EXISTING" | head -1)
+        gh issue comment "$CANONICAL" --repo "$REPO" --body \
+            "Still failing the audit at [\`${SHORT_SHA}\`](${COMMIT_URL}) — [audit run](${RUN_URL})"
+        echo "Updated existing gate-audit issue #${CANONICAL}"
+
+        # RECONCILE: fold any duplicate left by a race into the canonical issue.
+        echo "$EXISTING" | tail -n +2 | while read -r dup; do
+            [ -z "$dup" ] && continue
+            gh issue comment "$dup" --repo "$REPO" --body \
+                "Duplicate of #${CANONICAL}, which tracks this. Closing."
+            gh issue close "$dup" --repo "$REPO" --reason "not planned"
+            echo "Closed duplicate gate-audit issue #${dup}"
+        done
+        exit 0
+    fi
+
+    gh issue create \
+        --repo "$REPO" \
+        --title "$TITLE" \
+        --label "$LABEL" \
+        --body-file "$BODY_FILE"
+    echo "Filed a new gate-audit issue"
+    ;;
+
+close)
+    # AUTO-CLOSE ON A CLEAN AUDIT — a deliberate choice, and the arguments both ways:
+    #
+    # AGAINST: a lying gate is a security-relevant event, and closing the issue could erase a
+    # signal someone still needed to read.
+    #
+    # FOR (and why we do it): the issue asserts a LIVE fact — "develop's gate is lying RIGHT
+    # NOW". A clean audit disproves that fact: the gate was executed, honestly, on develop's
+    # real HEAD, and it agrees with what GitHub published. Leaving the issue open after that
+    # trains everyone to scroll past an alert that is usually stale — which is precisely how
+    # the Actions tab stopped being read, and why announce_red_branch.sh exists at all.
+    #
+    # The audit trail is not lost: the issue is CLOSED, not deleted, it keeps every comment,
+    # and the closing comment records the exact commit that proved the gate honest again.
+    #
+    # The caller passes `close` ONLY on a positively CLEAN verdict (`should_stand_down` in
+    # xbrain.gate_audit) — never on merely "no new accusation". An inconclusive audit, a
+    # cancelled runner, or a plainly red develop all leave the alarm standing, because none of
+    # them is evidence that the gate is honest.
+    #
+    # NOTE ON LATENCY: the cron is daily, so a fix pushed at noon does not clear the alert
+    # until tomorrow morning. That is why `workflow_dispatch` exists on this workflow — re-run
+    # the audit by hand once the fix is on develop and the issue closes within the minute.
+    EXISTING=$(open_issues)
+    if [ -z "$EXISTING" ]; then
+        echo "No open gate-audit issue; nothing to close"
+        exit 0
+    fi
+    echo "$EXISTING" | while read -r issue; do
+        [ -z "$issue" ] && continue
+        gh issue comment "$issue" --repo "$REPO" --body \
+            "✅ The gate is honest again as of [\`${SHORT_SHA}\`](${COMMIT_URL}): the audit ran \
+\`scripts/check.sh\` on that commit itself and its result matches what the \`quality\` check \
+reported — [audit run](${RUN_URL})"
+        gh issue close "$issue" --repo "$REPO" --reason completed
+        echo "Closed gate-audit issue #${issue}"
+    done
+    ;;
+esac

--- a/src/xbrain/gate_audit.py
+++ b/src/xbrain/gate_audit.py
@@ -1,0 +1,570 @@
+"""Does the `quality` gate actually DO what it REPORTS? The comparison, and the alarm.
+
+Called by `.github/workflows/gate-audit.yml`. Everything here is pure: it parses JSON that
+`gh` already fetched and YAML already on disk, decides, and writes a verdict. It performs no
+network I/O and shells out to nothing, so it can be unit-tested — which a workflow cannot.
+
+WHY A SEPARATE, SCHEDULED AUDITOR EXISTS AT ALL
+-----------------------------------------------
+`tests/test_ci_workflow.py` already forbids `continue-on-error` on the gate. It runs INSIDE
+`scripts/check.sh`, which is what the gate runs. So on a PR that adds `continue-on-error:
+true` to the `Quality gate` step: the guard test fires correctly, `check.sh` exits 1 — and
+the same `continue-on-error` swallows THAT failure too. Measured on this repo (probes #121,
+#125): the step reports `success`, the job reports `success`, the check run reports
+`SUCCESS`, `mergeStateStatus` is `CLEAN`. Every API surface says green. The failure exists
+only as text in a log nobody opens.
+
+The alarm is inside the soundproofed room, because a PR's CI runs the PR's own HEAD copy of
+the workflow. No in-repo test can escape that. Something outside the room has to listen.
+
+This is also not only an attack. `continue-on-error: true` on a failing step is THE canonical
+"make flaky CI stop blocking merges" edit. An agent told *"the build keeps failing, make it
+pass"* reaches for it in good faith and produces a permanently dead gate wearing a green
+badge. No adversary required.
+
+THE TWO HALVES, AND WHY BOTH
+----------------------------
+* **Execution** (`classify`) asks the OUTCOME question: GitHub says the gate concluded
+  `success` for develop@SHA; an honest run of that same gate on that same commit FAILED;
+  therefore the gate is lying. It names no keyword, so it catches the gag (#121/#125), the
+  wrong-tree `checkout ref:` (#124), and whatever is invented next — but only once the trap
+  has actually gone off.
+
+* **Static** (`audit_workflow_source`) asks the SYNTAX question, from outside. It catches a
+  disarmed gate on a day when develop happens to be green, which execution cannot see:
+  reported green, audit green, no discrepancy — and the gate is already dead, waiting for the
+  next red commit to wave through.
+
+Neither is redundant. Execution proves THAT something is wrong; static says WHAT.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+#: The job id in `quality.yml`, and the status check branch protection requires by that
+#: exact name on `develop` and `main` (verified against the API, 2026-07-14).
+REQUIRED_CHECK = "quality"
+
+#: The gate itself. A `quality` job that does not run this is a decoration.
+GATE_SCRIPT = "scripts/check.sh"
+
+#: Check-run conclusions that do NOT block a merge.
+#:
+#: This is the subtle one, and getting it wrong would blind the whole audit. The question is
+#: never "did the check say the literal string `success`" — it is "would this have stopped a
+#: merge". GitHub treats `neutral` and `skipped` as satisfying a required status check, and a
+#: job killed with `if: false` publishes its check run as `skipped`. Compare against
+#: `"success"` alone and `if: false` walks straight past you.
+NON_BLOCKING_CONCLUSIONS = frozenset({"success", "neutral", "skipped"})
+
+
+class Verdict(StrEnum):
+    """The outcome of comparing what the gate REPORTED against what it actually DOES."""
+
+    #: Reported non-blocking, and an honest execution agrees. The boring, normal case.
+    CLEAN = "clean"
+
+    #: Reported non-blocking, honest execution FAILED. The gate is lying. This is the one.
+    LYING = "lying"
+
+    #: Reported blocking, honest execution failed. develop is red and the gate says so.
+    #: Not a lie — and already alarmed by the `push`-triggered run. Do not double-file.
+    CONSISTENT_RED = "consistent_red"
+
+    #: Reported blocking, honest execution passed. Fail-CLOSED: merges are blocked, nothing
+    #: unsafe can land. Usually a flake or a since-fixed transient. Print it; never file it.
+    REPORTED_RED_AUDIT_GREEN = "reported_red_audit_green"
+
+    #: No completed `quality` check run for this commit — nothing to compare against. The
+    #: static audit still runs, and it is what catches a gate that never ran at all.
+    INCONCLUSIVE = "inconclusive"
+
+
+@dataclass(frozen=True)
+class Reported:
+    """What GitHub published for the `quality` check on a given commit."""
+
+    found: bool
+    status: str | None
+    conclusion: str | None
+
+    @property
+    def completed(self) -> bool:
+        """Has the gate finished? An in-flight run has concluded nothing."""
+        return self.found and self.status == "completed"
+
+    @property
+    def blocks_merge(self) -> bool:
+        """Would this conclusion have stopped a merge? The only question worth asking."""
+        return self.completed and self.conclusion not in NON_BLOCKING_CONCLUSIONS
+
+
+@dataclass(frozen=True)
+class Violation:
+    """A specific, named way `quality.yml` has been disarmed."""
+
+    code: str
+    detail: str
+
+
+def reported_gate(payload: Any, check_name: str = REQUIRED_CHECK) -> Reported:
+    """Read the `quality` check run out of a `/commits/{sha}/check-runs` response.
+
+    Takes the MOST RECENT run by `started_at`, not the first in the list: a re-run supersedes
+    the original and branch protection honours the latest conclusion. The API does not
+    contractually order the array, so trusting its order would risk comparing an honest
+    execution against a stale, superseded verdict.
+    """
+    runs = [r for r in (payload or {}).get("check_runs", []) if r.get("name") == check_name]
+    if not runs:
+        return Reported(found=False, status=None, conclusion=None)
+    latest = max(runs, key=lambda r: str(r.get("started_at") or ""))
+    return Reported(
+        found=True,
+        status=str(latest.get("status") or ""),
+        conclusion=latest.get("conclusion"),
+    )
+
+
+def classify(reported: Reported, audit_passed: bool) -> Verdict:
+    """Compare what the gate said with what it actually does. The heart of the layer."""
+    if not reported.completed:
+        return Verdict.INCONCLUSIVE
+    if reported.blocks_merge:
+        return Verdict.REPORTED_RED_AUDIT_GREEN if audit_passed else Verdict.CONSISTENT_RED
+    return Verdict.CLEAN if audit_passed else Verdict.LYING
+
+
+def should_file_issue(verdict: Verdict, violations: Sequence[Violation]) -> bool:
+    """Only two things are worth waking a human for: the gate lied, or the gate is disarmed.
+
+    Everything else — consistent red, a flaky over-report, an in-flight run — is either
+    already alarmed elsewhere or fail-closed. An alert that fires on safe states is an alert
+    people learn to close unread, which is exactly how the Actions tab stopped being watched.
+    """
+    return verdict is Verdict.LYING or bool(violations)
+
+
+def should_stand_down(verdict: Verdict, violations: Sequence[Violation]) -> bool:
+    """May a later audit CLOSE an open alarm? Only on positive evidence of health.
+
+    Deliberately not `not should_file_issue(...)`. That would also be true when the audit was
+    INCONCLUSIVE (a cancelled runner, an in-flight gate) or when develop is merely red —
+    neither of which disproves a live "the gate is LYING" accusation. Closing is itself a
+    CLAIM ("I checked, it is fine"), and it needs evidence, not merely the absence of a new
+    accusation. Otherwise the first flaky run after a real lie would quietly retract it.
+    """
+    return verdict is Verdict.CLEAN and not violations
+
+
+def audit_observed(job_result: str) -> bool | None:
+    """Did the gate-execution job actually RUN? None when we cannot say.
+
+    `needs.<job>.result` is one of `success`, `failure`, `cancelled`, `skipped` — NOT a
+    boolean. Collapsing it with `passed = (result == "success")` silently reads `cancelled`
+    as *the gate failed*, which against a healthy green gate yields the verdict LYING. The
+    auditor would then file a public issue accusing the repository of merging unverified code
+    because a runner was evicted. We report only what we observed.
+    """
+    if job_result == "success":
+        return True
+    if job_result == "failure":
+        return False
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Static audit of the audited branch's quality.yml
+#
+# These rules deliberately restate what `tests/test_ci_workflow.py` already asserts. That is
+# not duplication for its own sake: those tests run INSIDE the gate they defend, so a gagged
+# gate silences them. These run from the auditor's own tree on the default branch, against
+# the audited branch's file, read as DATA. Judge != party. The rules must exist in both
+# places precisely because one of the two can be muzzled.
+# ---------------------------------------------------------------------------
+
+
+def _triggers(workflow: dict[Any, Any]) -> Any:
+    """The `on:` block, surviving YAML's Norway problem.
+
+    In YAML 1.1 a bare `on:` key parses as the BOOLEAN `True`, not the string `"on"`. GitHub
+    accepts `on:` and `"on":` identically, so an auditor that knows only one spelling either
+    misses every filter written under the other, or screams at a behaviour-preserving
+    reformat. Look under both.
+    """
+    for key in (True, "on"):
+        if key in workflow:
+            return workflow[key] or {}
+    return {}
+
+
+def _gate_job(workflow: dict[Any, Any]) -> dict[str, Any] | None:
+    """The job whose check run branch protection requires, or None if it is gone."""
+    job = (workflow.get("jobs") or {}).get(REQUIRED_CHECK)
+    return job or None if isinstance(job, dict) else None
+
+
+def _check_triggers(workflow: dict[Any, Any]) -> list[Violation]:
+    """A path filter SKIPS the workflow — and a skipped workflow leaves the check Pending.
+
+    Not green, not red: never published. Every PR then waits forever on a check that will
+    never report, and `enforce_admins` means nobody can override it — including the PR that
+    would undo the filter. Hard lockout.
+    """
+    triggers = _triggers(workflow)
+    if not isinstance(triggers, dict):
+        return []
+    out = []
+    for event in ("push", "pull_request"):
+        config = triggers.get(event)
+        if not isinstance(config, dict):
+            continue
+        for key in ("paths", "paths-ignore"):
+            if key in config:
+                out.append(
+                    Violation(
+                        "path-filter",
+                        f"`{event}` declares `{key}: {config[key]!r}`. A filtered-out run is "
+                        f"SKIPPED, so the required `{REQUIRED_CHECK}` check is never "
+                        f"published and every PR hangs Pending forever.",
+                    )
+                )
+    return out
+
+
+def _check_job_identity(workflow: dict[Any, Any]) -> list[Violation]:
+    """GitHub names the check run after the job's `name:`, else its id. Both can brick it."""
+    jobs = workflow.get("jobs") or {}
+    if REQUIRED_CHECK not in jobs:
+        return [
+            Violation(
+                "gate-job-missing",
+                f"No job with id `{REQUIRED_CHECK}` (found: {sorted(map(str, jobs))}). Branch "
+                f"protection requires a check named exactly `{REQUIRED_CHECK}`; without it "
+                f"the check never appears and EVERY MERGE BLOCKS, permanently.",
+            )
+        ]
+    job = _gate_job(workflow) or {}
+    name = str(job.get("name", REQUIRED_CHECK))
+    if name != REQUIRED_CHECK:
+        return [
+            Violation(
+                "check-renamed",
+                f"The `{REQUIRED_CHECK}` job declares `name: {name}`, so its check run is "
+                f"published as `{name}` — not `{REQUIRED_CHECK}`. The required check never "
+                f"appears and every merge blocks, permanently.",
+            )
+        ]
+    return []
+
+
+def _check_job_guards(workflow: dict[Any, Any]) -> list[Violation]:
+    """`continue-on-error` and `if:` at JOB level. One is fail-closed; the other is not."""
+    job = _gate_job(workflow)
+    if job is None:
+        return []
+    out = []
+    if "continue-on-error" in job:
+        out.append(
+            Violation(
+                "job-continue-on-error",
+                "The `quality` JOB declares `continue-on-error`. Measured (probe #119) this "
+                "one is fail-closed — the check run still reports FAILURE and the merge is "
+                "still BLOCKED. It is banned anyway because it is ONE INDENT from the step "
+                "form, which is catastrophic, and no reviewer should have to count indents "
+                "to tell a dead gate from a live one.",
+            )
+        )
+    if "if" in job:
+        out.append(
+            Violation(
+                "job-conditional",
+                f"The `quality` job declares `if: {job['if']!r}`. A SKIPPED JOB REPORTS "
+                f"SUCCESS — GitHub's words. The required check goes green having run nothing.",
+            )
+        )
+    return out
+
+
+def _label(step: dict[str, Any]) -> str:
+    """A human-readable handle for a step, for the failure message."""
+    return str(step.get("name") or step.get("uses") or str(step.get("run", "?"))[:40])
+
+
+def _check_step_gag(steps: list[dict[str, Any]]) -> list[Violation]:
+    """`continue-on-error` on a step: THE gag. The gate runs, fails, and reports SUCCESS."""
+    return [
+        Violation(
+            "step-continue-on-error",
+            f"Step `{_label(step)}` declares `continue-on-error`. THE gag (probes "
+            f"#121/#125): the gate still runs, still FAILS — and the check run reports "
+            f"SUCCESS anyway. `mergeStateStatus` reads CLEAN. Every API surface says green "
+            f"while nothing was verified.",
+        )
+        for step in steps
+        if "continue-on-error" in step
+    ]
+
+
+def _check_checkout_ref(steps: list[dict[str, Any]]) -> list[Violation]:
+    """An explicit `ref:`: the gate passes honestly, against a tree nobody asked about."""
+    return [
+        Violation(
+            "checkout-ref",
+            f"Step `{_label(step)}` pins `ref: {(step.get('with') or {})['ref']!r}`. The gate "
+            f"then runs, passes honestly, reports SUCCESS — against the WRONG TREE (probe "
+            f"#124: `1088 passed`, where develop's suite has ~1600). The commit that "
+            f"triggered the run is never examined at all.",
+        )
+        for step in steps
+        if "actions/checkout" in str(step.get("uses", "")) and (step.get("with") or {}).get("ref")
+    ]
+
+
+def _check_gate_step(steps: list[dict[str, Any]]) -> list[Violation]:
+    """The gate step must exist and must be unconditional. Either way out is a silent green."""
+    gate = next((s for s in steps if GATE_SCRIPT in str(s.get("run", ""))), None)
+    if gate is None:
+        return [
+            Violation(
+                "gate-step-missing",
+                f"No step runs `{GATE_SCRIPT}`. The check run branch protection trusts no "
+                f"longer executes the gate: it reports GREEN having verified nothing.",
+            )
+        ]
+    if "if" in gate:
+        return [
+            Violation(
+                "gate-step-conditional",
+                f"The gate step declares `if: {gate['if']!r}`. Skip it and the job still "
+                f"SUCCEEDS — the required check goes green having run no checks at all.",
+            )
+        ]
+    return []
+
+
+def _check_steps(workflow: dict[Any, Any]) -> list[Violation]:
+    """The step-level kills: the gag, the wrong tree, the skipped gate, the missing gate."""
+    job = _gate_job(workflow)
+    if job is None:
+        return []
+    steps = [s for s in (job.get("steps") or []) if isinstance(s, dict)]
+    out: list[Violation] = []
+    for check in (_check_step_gag, _check_checkout_ref, _check_gate_step):
+        out.extend(check(steps))
+    return out
+
+
+def audit_workflow_source(path: Path) -> list[Violation]:
+    """Statically audit the audited branch's `quality.yml` for every known way to disarm it.
+
+    Read as DATA, from the auditor's own tree. Nothing here is executed.
+    """
+    if not path.is_file():
+        return [
+            Violation(
+                "workflow-missing",
+                f"`{path.name}` does not exist on the audited branch. Deleting the workflow "
+                f"is the simplest disarm of all, and it must never read as 'clean'.",
+            )
+        ]
+    try:
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        return [Violation("workflow-unparseable", f"`{path.name}` is not valid YAML: {exc}")]
+    if not isinstance(workflow, dict):
+        return [Violation("workflow-unparseable", f"`{path.name}` is not a YAML mapping.")]
+
+    violations: list[Violation] = []
+    for check in (_check_triggers, _check_job_identity, _check_job_guards, _check_steps):
+        violations.extend(check(workflow))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# The alarm
+# ---------------------------------------------------------------------------
+
+_HEADLINE = {
+    Verdict.LYING: "`develop`'s quality gate is LYING",
+    Verdict.CLEAN: "`develop`'s quality gate is DISARMED",
+    Verdict.CONSISTENT_RED: "`develop`'s quality gate is DISARMED",
+    Verdict.REPORTED_RED_AUDIT_GREEN: "`develop`'s quality gate is DISARMED",
+    Verdict.INCONCLUSIVE: "`develop`'s quality gate is DISARMED",
+}
+
+
+def issue_title(verdict: Verdict) -> str:
+    """Title of the alert. Stable per verdict class, because it is the idempotency anchor."""
+    return f"🚨 {_HEADLINE[verdict]}"
+
+
+def render_issue_body(
+    *,
+    verdict: Verdict,
+    violations: Sequence[Violation],
+    sha: str,
+    reported: str | None,
+    audit_passed: bool,
+    repo: str,
+    run_url: str,
+) -> str:
+    """The alarm, written to be actionable by someone who has never read this module."""
+    short = sha[:8]
+    commit_url = f"https://github.com/{repo}/commit/{sha}"
+    said = f"`{reported}`" if reported else "_never reported_"
+    found = "PASSED" if audit_passed else "**FAILED**"
+
+    lines = [
+        f"The scheduled audit disagrees with the `{REQUIRED_CHECK}` gate on `develop`.",
+        "",
+        "| | |",
+        "|---|---|",
+        f"| **Commit** | [`{short}`]({commit_url}) |",
+        f"| **The gate REPORTED** | {said} |",
+        f"| **An honest re-run FOUND** | {found} |",
+        f"| **Verdict** | `{verdict.value}` |",
+        f"| **Audit run** | [logs]({run_url}) |",
+        "",
+    ]
+
+    if verdict is Verdict.LYING:
+        lines += [
+            "### The gate is reporting green on code it did not verify",
+            "",
+            f"This audit checked out `develop@{short}`, ran the real gate — "
+            f"`bash {GATE_SCRIPT}` — in a job with **no** `continue-on-error` and **no** "
+            f"pinned `ref:`, and it **failed**. GitHub nonetheless published {said} for the "
+            f"required `{REQUIRED_CHECK}` check on that exact commit.",
+            "",
+            "Both known causes produce precisely this signature:",
+            "",
+            "* `continue-on-error: true` on the **gate step** — the gate runs, fails, and the "
+            "check run reports `SUCCESS` anyway (probes #121, #125). Every API surface, "
+            "including `mergeStateStatus: CLEAN`, says the code is fine.",
+            "* `checkout` with an explicit **`ref:`** — the gate passes honestly, having "
+            "examined a tree nobody asked about (probe #124).",
+            "",
+            f"**Anything merged into `develop` since {short} passed a check that was not "
+            f"checking.** Treat those merges as unreviewed by CI until the gate is restored "
+            f"and re-run.",
+            "",
+        ]
+
+    if violations:
+        lines += ["### What is wrong with `quality.yml`, by name", ""]
+        lines += [f"- **`{v.code}`** — {v.detail}" for v in violations]
+        lines += [""]
+    elif verdict is Verdict.LYING:
+        lines += [
+            "### The static audit found nothing",
+            "",
+            "The execution check proves the gate is lying, but no *known* banned pattern "
+            "explains it. This is a mechanism nobody has catalogued yet — read the diff of "
+            f"`.github/workflows/{REQUIRED_CHECK}.yml` and `{GATE_SCRIPT}` by hand, and add "
+            "the new pattern to `audit_workflow_source` once you find it.",
+            "",
+        ]
+
+    lines += [
+        "---",
+        "",
+        "<sub>Filed by the scheduled gate audit "
+        "(`.github/workflows/gate-audit.yml`), which runs from the **default branch** and "
+        "therefore cannot be edited by the pull requests it audits. A later clean audit "
+        "closes this issue automatically — re-run the workflow via `workflow_dispatch` once "
+        "you have pushed the fix, rather than waiting for tomorrow's cron.</sub>",
+    ]
+    return "\n".join(lines)
+
+
+def _emit(path: str | None, **outputs: str) -> None:
+    """Append `key=value` lines to a GitHub Actions output file, if we were given one."""
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as handle:
+        for key, value in outputs.items():
+            handle.write(f"{key}={value}\n")
+
+
+def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    """Wire up the inputs the workflow hands us."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check-runs", required=True, type=Path, help="check-runs API JSON")
+    parser.add_argument("--workflow", required=True, type=Path, help="audited quality.yml")
+    parser.add_argument("--audit-result", required=True, help="result of the gate-execution job")
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--body-out", type=Path, required=True)
+    parser.add_argument("--github-output", default=os.environ.get("GITHUB_OUTPUT"))
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Compare, decide, and hand the workflow a verdict. Always exits 0.
+
+    The workflow — not this module — is what turns a `lying` verdict into a red run, and it
+    does so only AFTER the issue has been filed. Exiting non-zero here would kill the job
+    before it could raise the alarm, which is the one failure this whole layer cannot afford.
+    """
+    args = _parse_args(argv)
+
+    payload = json.loads(args.check_runs.read_text(encoding="utf-8"))
+    reported = reported_gate(payload)
+    observed = audit_observed(args.audit_result)
+
+    # A gate we never watched run cannot be caught lying. `cancelled`/`skipped` means the
+    # execution job never delivered a verdict, so neither do we.
+    verdict = Verdict.INCONCLUSIVE if observed is None else classify(reported, observed)
+    violations = audit_workflow_source(args.workflow)
+    file_issue = should_file_issue(verdict, violations)
+
+    print(f"commit          : {args.sha}")
+    print(f"gate REPORTED   : {reported.conclusion or '(no completed run)'}")
+    print(
+        f"audit FOUND     : {'pass' if observed else 'FAIL' if observed is False else '(not observed: ' + args.audit_result + ')'}"
+    )  # noqa: E501
+    print(f"verdict         : {verdict.value}")
+    for violation in violations:
+        print(f"violation       : {violation.code} — {violation.detail}")
+    print(f"file issue      : {file_issue}")
+
+    body = render_issue_body(
+        verdict=verdict,
+        violations=violations,
+        sha=args.sha,
+        reported=reported.conclusion,
+        audit_passed=bool(observed),
+        repo=args.repo,
+        run_url=args.run_url,
+    )
+    args.body_out.write_text(body, encoding="utf-8")
+
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write(f"## Gate audit — `{verdict.value}`\n\n{body}\n")
+
+    _emit(
+        args.github_output,
+        verdict=verdict.value,
+        file_issue="true" if file_issue else "false",
+        clean="true" if should_stand_down(verdict, violations) else "false",
+        title=issue_title(verdict),
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/xbrain/gate_audit.py
+++ b/src/xbrain/gate_audit.py
@@ -167,20 +167,62 @@ def should_stand_down(verdict: Verdict, violations: Sequence[Violation]) -> bool
     return verdict is Verdict.CLEAN and not violations
 
 
-def audit_observed(job_result: str) -> bool | None:
-    """Did the gate-execution job actually RUN? None when we cannot say.
+@dataclass(frozen=True)
+class GateExecution:
+    """What the honest re-run of the gate DID — and whether we watched it at all.
+
+    `passed is None` means the gate was never observed. That is not a soft `False`: the
+    difference between "the gate failed" and "we never saw the gate" is the difference
+    between an accusation and silence.
+    """
+
+    passed: bool | None
+    reason: str
+
+
+def read_gate_outcome(path: Path | None) -> str | None:
+    """The gate STEP's own outcome, carried out of the execution job. None if it never came.
+
+    Absence is the load-bearing case, and it is why this is a FILE rather than a job output.
+    A job output is not published when its job fails, and the execution job is designed to
+    fail — so an output would be missing exactly when the gate genuinely failed, which is the
+    one case that must convict. An artifact written by a step with `if: always()` is present
+    whenever the gate ran, and absent only when the job died before reaching it.
+    """
+    if path is None or not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8").strip() or None
+
+
+def observe_gate(step_outcome: str | None, job_result: str) -> GateExecution:
+    """Did the GATE fail, or did the job fail before the gate ever ran? Not the same event.
 
     `needs.<job>.result` is one of `success`, `failure`, `cancelled`, `skipped` — NOT a
-    boolean. Collapsing it with `passed = (result == "success")` silently reads `cancelled`
-    as *the gate failed*, which against a healthy green gate yields the verdict LYING. The
-    auditor would then file a public issue accusing the repository of merging unverified code
-    because a runner was evicted. We report only what we observed.
+    boolean, and not a statement about the gate. It aggregates every step of `execute-gate`:
+    the checkout, the uv install, the Python install, the dependency sync, and only then the
+    gate. Collapsing it with `passed = (result == "success")` reads a runner eviction, a
+    GitHub outage or a bad morning at PyPI as *the gate failed* — which against a healthy
+    green gate yields the verdict LYING, and files a public issue accusing the repository of
+    shipping unverified code because a dependency would not resolve.
+
+    So the conviction is drawn from the gate STEP's own outcome, and the job result is used
+    only to tell two silences apart: a job that BROKE on the way to the gate (the auditor
+    needs a human) from one that was simply never delivered (nothing happened).
     """
-    if job_result == "success":
-        return True
+    if step_outcome in ("success", "failure"):
+        passed = step_outcome == "success"
+        return GateExecution(passed, f"the gate step reported `{step_outcome}`")
     if job_result == "failure":
-        return False
-    return None
+        return GateExecution(
+            None,
+            "the execution job FAILED before the gate step ran — the environment could not "
+            "be built, so nothing at all was observed about the gate",
+        )
+    return GateExecution(
+        None,
+        f"the execution job delivered no verdict (`{job_result or 'unknown'}`), so the gate "
+        f"was never observed",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -503,6 +545,11 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser.add_argument("--check-runs", required=True, type=Path, help="check-runs API JSON")
     parser.add_argument("--workflow", required=True, type=Path, help="audited quality.yml")
     parser.add_argument("--audit-result", required=True, help="result of the gate-execution job")
+    parser.add_argument(
+        "--gate-outcome",
+        type=Path,
+        help="file holding the gate STEP's own outcome; absent when the gate never ran",
+    )
     parser.add_argument("--sha", required=True)
     parser.add_argument("--repo", required=True)
     parser.add_argument("--run-url", required=True)
@@ -522,19 +569,20 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     payload = json.loads(args.check_runs.read_text(encoding="utf-8"))
     reported = reported_gate(payload)
-    observed = audit_observed(args.audit_result)
+    execution = observe_gate(read_gate_outcome(args.gate_outcome), args.audit_result)
+    observed = execution.passed
 
-    # A gate we never watched run cannot be caught lying. `cancelled`/`skipped` means the
-    # execution job never delivered a verdict, so neither do we.
+    # A gate we never watched run cannot be caught lying. A missing gate outcome means the
+    # execution job never reached the gate, so we say nothing about it.
     verdict = Verdict.INCONCLUSIVE if observed is None else classify(reported, observed)
     violations = audit_workflow_source(args.workflow)
     file_issue = should_file_issue(verdict, violations)
 
+    found = "pass" if observed else "FAIL" if observed is False else "(not observed)"
     print(f"commit          : {args.sha}")
     print(f"gate REPORTED   : {reported.conclusion or '(no completed run)'}")
-    print(
-        f"audit FOUND     : {'pass' if observed else 'FAIL' if observed is False else '(not observed: ' + args.audit_result + ')'}"
-    )  # noqa: E501
+    print(f"audit FOUND     : {found}")
+    print(f"because         : {execution.reason}")
     print(f"verdict         : {verdict.value}")
     for violation in violations:
         print(f"violation       : {violation.code} — {violation.detail}")
@@ -561,6 +609,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         verdict=verdict.value,
         file_issue="true" if file_issue else "false",
         clean="true" if should_stand_down(verdict, violations) else "false",
+        # Whether the gate was watched running AT ALL. The workflow turns a run red when the
+        # execution job failed without ever reaching the gate: that is the auditor being
+        # broken, and an auditor that is quietly unable to look is worse than none, because
+        # its silence is indistinguishable from a clean bill of health.
+        observed="true" if observed is not None else "false",
         title=issue_title(verdict),
     )
     return 0

--- a/src/xbrain/gate_audit.py
+++ b/src/xbrain/gate_audit.py
@@ -344,18 +344,35 @@ def _label(step: dict[str, Any]) -> str:
 
 
 def _check_step_gag(steps: list[dict[str, Any]]) -> list[Violation]:
-    """`continue-on-error` on a step: THE gag. The gate runs, fails, and reports SUCCESS."""
-    return [
-        Violation(
-            "step-continue-on-error",
-            f"Step `{_label(step)}` declares `continue-on-error`. THE gag (probes "
-            f"#121/#125): the gate still runs, still FAILS — and the check run reports "
-            f"SUCCESS anyway. `mergeStateStatus` reads CLEAN. Every API surface says green "
-            f"while nothing was verified.",
-        )
-        for step in steps
-        if "continue-on-error" in step
-    ]
+    """`continue-on-error` on a step: THE gag. The gate runs, fails, and reports SUCCESS.
+
+    Banned on EVERY step of the gate job, but not for the same reason, and the message says
+    which. On the gate step it is the gag itself. On a bystander step it is banned because
+    the two are one indent apart and no reviewer should have to work out which they are
+    looking at — but claiming the gate "still FAILS" there would describe something that did
+    not happen, and an alarm that misstates its own evidence teaches people to disbelieve it.
+    """
+    out = []
+    for step in steps:
+        if "continue-on-error" not in step:
+            continue
+        if GATE_SCRIPT in str(step.get("run", "")):
+            detail = (
+                f"Step `{_label(step)}` runs the gate AND declares `continue-on-error`. THE "
+                f"gag (probes #121/#125): the gate still runs, still FAILS — and the check "
+                f"run reports SUCCESS anyway. `mergeStateStatus` reads CLEAN. Every API "
+                f"surface says green while nothing was verified."
+            )
+        else:
+            detail = (
+                f"Step `{_label(step)}` declares `continue-on-error`. This step does not run "
+                f"the gate, so it is not the gag itself — it is banned because it sits ONE "
+                f"INDENT from the form that is (probes #121/#125), and a reviewer should "
+                f"never have to count indents to tell a live gate from a dead one. Remove "
+                f"it, and let the step fail honestly."
+            )
+        out.append(Violation("step-continue-on-error", detail))
+    return out
 
 
 def _check_checkout_ref(steps: list[dict[str, Any]]) -> list[Violation]:

--- a/tests/test_gate_audit.py
+++ b/tests/test_gate_audit.py
@@ -1,0 +1,512 @@
+# tests/test_gate_audit.py
+"""The auditor's comparison logic: does what the gate REPORTED match what it actually DOES?
+
+This is the logic behind `.github/workflows/gate-audit.yml`, extracted so it can be tested
+at all — a GitHub Actions workflow cannot be run locally, but the decision it makes can.
+
+THE QUESTION THIS ASKS, AND WHY IT IS THE RIGHT ONE
+---------------------------------------------------
+Every other guard in this repo (`tests/test_ci_workflow.py`) asks a SYNTAX question: does
+`quality.yml` contain a forbidden key? That guard is real, and it is also structurally
+incapable of catching the attack it was written for, because it runs INSIDE the gate it
+guards. A PR's CI runs the PR's own HEAD version of the workflow. Add
+`continue-on-error: true` to the `Quality gate` step and the gate still runs, the guard test
+still FAILS — and `continue-on-error` swallows that failure too. The check run reports
+SUCCESS, `mergeStateStatus` is CLEAN, and every API surface agrees the code is fine.
+Measured on this repo, probes #121 and #125. The alarm rings inside the soundproofed room.
+
+So this module asks an OUTCOME question instead, from outside the room:
+
+    GitHub says the `quality` check for develop@SHA concluded `success`.
+    I just ran `bash scripts/check.sh` on develop@SHA myself, honestly, with no
+    `continue-on-error` anywhere and no `ref:` pointing at some other tree.
+    It FAILED.
+    Therefore the gate is LYING.
+
+That comparison needs no keyword list. It catches the `continue-on-error` gag (#121/#125)
+and the wrong-tree `checkout ref:` attack (#124) with the same assertion, and it would catch
+the next trick nobody has thought of yet, because it never asks HOW the gate lied — only
+whether what it said matches what is true.
+
+THE ASYMMETRY THAT DECIDES WHAT COUNTS AS A LIE
+-----------------------------------------------
+Not every mismatch is an alarm. The two directions are not equivalent:
+
+* reported green + audit RED  -> **LYING**. Unverified code merges on a green light. File it.
+* reported red  + audit green -> merges are BLOCKED. Annoying, possibly flaky — but
+  fail-CLOSED. Nothing unsafe can land. Do not file; a system that cries wolf about safe
+  states teaches people to ignore it.
+
+And "green" is not the string `"success"`. GitHub treats `neutral` and `skipped` as
+satisfying a required check too — a job killed with `if: false` reports `skipped` and
+branch protection merges right past it. So the predicate is not *"did it say success"* but
+*"would this have blocked a merge?"*. `_blocks_merge` encodes exactly that.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xbrain.gate_audit import (
+    NON_BLOCKING_CONCLUSIONS,
+    Verdict,
+    Violation,
+    audit_workflow_source,
+    classify,
+    reported_gate,
+    render_issue_body,
+    should_file_issue,
+)
+
+# ---------------------------------------------------------------------------
+# reported_gate: what did GitHub say about develop@SHA?
+# ---------------------------------------------------------------------------
+
+
+def _run(name: str, conclusion: str | None, status: str = "completed", **extra: Any) -> Any:
+    """One entry as the `/commits/{sha}/check-runs` endpoint returns it."""
+    return {"name": name, "status": status, "conclusion": conclusion, **extra}
+
+
+def test_reported_gate_reads_the_quality_check_run() -> None:
+    """The happy path: one completed `quality` run, and we read its conclusion."""
+    payload = {"check_runs": [_run("quality", "success")]}
+    reported = reported_gate(payload)
+    assert reported.conclusion == "success"
+    assert reported.completed is True
+
+
+def test_reported_gate_ignores_other_check_runs() -> None:
+    """Only the check run branch protection actually requires is relevant."""
+    payload = {"check_runs": [_run("codeql", "failure"), _run("quality", "success")]}
+    assert reported_gate(payload).conclusion == "success"
+
+
+def test_reported_gate_is_absent_when_the_gate_never_ran() -> None:
+    """No `quality` run at all -> we know nothing. That is not the same as green."""
+    payload = {"check_runs": [_run("codeql", "success")]}
+    reported = reported_gate(payload)
+    assert reported.found is False
+    assert reported.conclusion is None
+
+
+def test_reported_gate_takes_the_most_recent_rerun() -> None:
+    """A re-run supersedes the original: branch protection honours the LATEST conclusion.
+
+    Order in the API response is not contractually newest-first, so sort by `started_at`
+    rather than trusting the list. Reading a stale first entry would let a red gate that
+    was re-run green (or vice versa) be compared against the wrong answer.
+    """
+    payload = {
+        "check_runs": [
+            _run("quality", "failure", started_at="2026-07-14T09:00:00Z"),
+            _run("quality", "success", started_at="2026-07-14T11:00:00Z"),
+        ]
+    }
+    assert reported_gate(payload).conclusion == "success"
+
+
+@pytest.mark.parametrize("status", ["queued", "in_progress"])
+def test_reported_gate_in_flight_is_not_a_conclusion(status: str) -> None:
+    """A gate still running has concluded nothing. Do not read `null` as a verdict."""
+    payload = {"check_runs": [_run("quality", None, status=status)]}
+    reported = reported_gate(payload)
+    assert reported.found is True
+    assert reported.completed is False
+
+
+# ---------------------------------------------------------------------------
+# classify: the comparison. This is the whole point of the layer.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_reported_green_but_audit_failed_is_a_LIE() -> None:
+    """THE case this entire layer exists to catch.
+
+    `continue-on-error` on the gate step (probes #121/#125) and `checkout ref:` (probe #124)
+    both land exactly here: GitHub reports SUCCESS, and an honest execution of the same gate
+    on the same commit fails. Neither is identified by name — only by outcome.
+    """
+    reported = reported_gate({"check_runs": [_run("quality", "success")]})
+    assert classify(reported, audit_passed=False) is Verdict.LYING
+
+
+@pytest.mark.parametrize("conclusion", sorted(NON_BLOCKING_CONCLUSIONS))
+def test_every_non_blocking_conclusion_can_be_a_lie(conclusion: str) -> None:
+    """`skipped` and `neutral` satisfy branch protection just as `success` does.
+
+    `if: false` on the job makes the check run report `skipped`, and GitHub merges straight
+    past it. Comparing against the literal string `"success"` would miss that entirely.
+    """
+    reported = reported_gate({"check_runs": [_run("quality", conclusion)]})
+    assert classify(reported, audit_passed=False) is Verdict.LYING
+
+
+def test_gate_reported_red_and_audit_failed_is_merely_red() -> None:
+    """Consistent red is NOT a lie. develop is broken and the gate is saying so.
+
+    The `push`-triggered run already filed the red-branch issue for this commit. Filing a
+    second, differently-worded issue for the same fact is how alert fatigue starts.
+    """
+    reported = reported_gate({"check_runs": [_run("quality", "failure")]})
+    assert classify(reported, audit_passed=False) is Verdict.CONSISTENT_RED
+
+
+def test_gate_reported_green_and_audit_passed_is_clean() -> None:
+    """The normal, boring, overwhelmingly common outcome."""
+    reported = reported_gate({"check_runs": [_run("quality", "success")]})
+    assert classify(reported, audit_passed=True) is Verdict.CLEAN
+
+
+def test_gate_reported_red_but_audit_passed_is_not_an_alarm() -> None:
+    """Over-reporting failure is fail-CLOSED: merges are blocked, nothing unsafe lands.
+
+    Usually a flake or a since-fixed transient. Worth printing, never worth an issue.
+    """
+    reported = reported_gate({"check_runs": [_run("quality", "failure")]})
+    assert classify(reported, audit_passed=True) is Verdict.REPORTED_RED_AUDIT_GREEN
+
+
+def test_a_missing_check_run_is_inconclusive_not_a_lie() -> None:
+    """Absence of evidence is not evidence of a lie — the execution check must say nothing.
+
+    The static audit is what catches a gate that never runs (a `paths:` filter, a deleted
+    workflow). Conflating "I could not observe the gate" with "the gate lied" would make the
+    auditor cry wolf every time it raced a fresh push.
+    """
+    reported = reported_gate({"check_runs": []})
+    assert classify(reported, audit_passed=False) is Verdict.INCONCLUSIVE
+    assert classify(reported, audit_passed=True) is Verdict.INCONCLUSIVE
+
+
+# ---------------------------------------------------------------------------
+# should_file_issue: which verdicts are worth waking someone for?
+# ---------------------------------------------------------------------------
+
+
+def test_only_a_lie_or_a_violation_files_an_issue() -> None:
+    """Precisely two things wake a human: the gate lied, or the gate is disarmed."""
+    assert should_file_issue(Verdict.LYING, []) is True
+    assert should_file_issue(Verdict.CLEAN, [Violation("step-continue-on-error", "x")]) is True
+    assert should_file_issue(Verdict.CLEAN, []) is False
+    assert should_file_issue(Verdict.CONSISTENT_RED, []) is False
+    assert should_file_issue(Verdict.REPORTED_RED_AUDIT_GREEN, []) is False
+    assert should_file_issue(Verdict.INCONCLUSIVE, []) is False
+
+
+def test_a_disarmed_gate_is_filed_even_while_it_still_passes() -> None:
+    """THE reason the static audit exists alongside the execution check.
+
+    Add `continue-on-error: true` on a day when develop happens to be green and the
+    execution check sees no discrepancy at all — reported green, audit green, CLEAN. The
+    gate is nonetheless already dead: the very next red commit sails through. Only reading
+    the source catches a booby-trap that has not gone off yet.
+    """
+    violations = [Violation("step-continue-on-error", "Quality gate")]
+    assert should_file_issue(Verdict.CLEAN, violations) is True
+
+
+# ---------------------------------------------------------------------------
+# audit_workflow_source: the static half. Names WHAT is wrong.
+# ---------------------------------------------------------------------------
+
+_HEALTHY = """
+name: Quality
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Quality gate
+        run: bash scripts/check.sh
+"""
+
+
+def _codes(source: str, tmp_path: Path) -> set[str]:
+    """Violation codes raised against a workflow source."""
+    path = tmp_path / "quality.yml"
+    path.write_text(source, encoding="utf-8")
+    return {v.code for v in audit_workflow_source(path)}
+
+
+def test_a_healthy_gate_raises_nothing(tmp_path: Path) -> None:
+    """The guard must be quiet on the real, current workflow shape, or it is noise."""
+    assert _codes(_HEALTHY, tmp_path) == set()
+
+
+def test_the_real_quality_workflow_is_clean(tmp_path: Path) -> None:
+    """Run the auditor against the ACTUAL quality.yml in this repo, not just a fixture.
+
+    A fixture can drift from reality. This asserts the thing the auditor will really read,
+    on develop, is currently clean — so a red result in CI means the gate changed, not that
+    the fixture is stale.
+    """
+    real = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "quality.yml"
+    assert [v.code for v in audit_workflow_source(real)] == []
+
+
+def test_continue_on_error_on_the_gate_step_is_caught(tmp_path: Path) -> None:
+    """Probes #121/#125: the gag. Gate runs, gate fails, check run reports SUCCESS anyway."""
+    source = _HEALTHY.replace(
+        "        run: bash scripts/check.sh",
+        "        run: bash scripts/check.sh\n        continue-on-error: true",
+    )
+    assert "step-continue-on-error" in _codes(source, tmp_path)
+
+
+def test_continue_on_error_on_the_job_is_caught(tmp_path: Path) -> None:
+    """Probe #119: at JOB level this is fail-closed (check reports FAILURE, merge BLOCKED).
+
+    Banned anyway, and the distinction is the point: it is ONE INDENT away from the step
+    form, which is catastrophic. A reviewer who has to work out which indent they are
+    looking at will eventually get it wrong. Ban both; explain the difference in the message.
+    """
+    source = _HEALTHY.replace(
+        "    runs-on: ubuntu-latest",
+        "    runs-on: ubuntu-latest\n    continue-on-error: true",
+    )
+    assert "job-continue-on-error" in _codes(source, tmp_path)
+
+
+def test_an_explicit_checkout_ref_is_caught(tmp_path: Path) -> None:
+    """Probe #124: the wrong-tree attack. Everything passes — on a tree nobody asked about.
+
+    Measured: the gate went green having run `1088 passed` where develop's suite has ~1600.
+    Only the test COUNT gave it away, and nobody reads the count on a green run.
+    """
+    source = _HEALTHY.replace(
+        "      - uses: actions/checkout@v4",
+        "      - uses: actions/checkout@v4\n        with:\n          ref: main",
+    )
+    assert "checkout-ref" in _codes(source, tmp_path)
+
+
+def test_renaming_the_job_off_quality_is_caught(tmp_path: Path) -> None:
+    """The required check is named after the job. Rename it and the check never appears."""
+    source = _HEALTHY.replace("  quality:", "  gate:")
+    assert "gate-job-missing" in _codes(source, tmp_path)
+
+
+def test_overriding_the_check_name_is_caught(tmp_path: Path) -> None:
+    """Subtler than a rename: keep the id `quality`, publish the check run as `Gate`."""
+    source = _HEALTHY.replace(
+        "  quality:\n    runs-on: ubuntu-latest",
+        "  quality:\n    name: Gate\n    runs-on: ubuntu-latest",
+    )
+    assert "check-renamed" in _codes(source, tmp_path)
+
+
+@pytest.mark.parametrize("filter_key", ["paths", "paths-ignore"])
+def test_a_path_filter_on_a_gating_trigger_is_caught(filter_key: str, tmp_path: Path) -> None:
+    """A path-filtered workflow is SKIPPED, and a skipped workflow leaves the check Pending.
+
+    Not green, not red — never published. Every PR then waits forever on a check that will
+    not report, and with `enforce_admins` nobody can override, including the PR that would
+    fix it. Hard lockout.
+    """
+    source = _HEALTHY.replace(
+        "  push:\n    branches: [develop, main]",
+        f"  push:\n    branches: [develop, main]\n    {filter_key}: ['src/**']",
+    )
+    assert "path-filter" in _codes(source, tmp_path)
+
+
+def test_a_conditional_job_is_caught(tmp_path: Path) -> None:
+    """A SKIPPED JOB REPORTS SUCCESS. `if: false` is a green light over an empty room."""
+    source = _HEALTHY.replace(
+        "    runs-on: ubuntu-latest",
+        "    runs-on: ubuntu-latest\n    if: false",
+    )
+    assert "job-conditional" in _codes(source, tmp_path)
+
+
+def test_a_conditional_gate_step_is_caught(tmp_path: Path) -> None:
+    """Same silent green, one level down: skip the step, the job still succeeds."""
+    source = _HEALTHY.replace(
+        "        run: bash scripts/check.sh",
+        "        if: false\n        run: bash scripts/check.sh",
+    )
+    assert "gate-step-conditional" in _codes(source, tmp_path)
+
+
+def test_a_gate_that_no_longer_runs_check_sh_is_caught(tmp_path: Path) -> None:
+    """The bluntest kill: keep the job, keep the name, replace the gate with `echo ok`."""
+    source = _HEALTHY.replace("        run: bash scripts/check.sh", "        run: echo ok")
+    assert "gate-step-missing" in _codes(source, tmp_path)
+
+
+def test_a_deleted_workflow_is_caught(tmp_path: Path) -> None:
+    """Deleting the file is the simplest disarm of all, and it must not read as 'clean'."""
+    codes = {v.code for v in audit_workflow_source(tmp_path / "does-not-exist.yml")}
+    assert codes == {"workflow-missing"}
+
+
+def test_an_unparseable_workflow_is_caught(tmp_path: Path) -> None:
+    """Invalid YAML never runs, so the required check is never published -> hard lockout."""
+    assert _codes("jobs: [unclosed\n", tmp_path) == {"workflow-unparseable"}
+
+
+def test_quoting_the_on_key_is_not_a_violation(tmp_path: Path) -> None:
+    """YAML's Norway problem: bare `on:` parses as the BOOLEAN True, not the string "on".
+
+    GitHub accepts `on:` and `"on":` identically. An auditor that understood only one
+    spelling would either miss every path filter under the other, or scream at a
+    behaviour-preserving reformat. Both spellings must audit the same.
+    """
+    assert _codes(_HEALTHY.replace("\non:", '\n"on":'), tmp_path) == set()
+
+
+def test_a_path_filter_is_caught_under_the_quoted_on_key(tmp_path: Path) -> None:
+    """The half of the Norway problem that actually bites: a real attack, quoted key."""
+    source = _HEALTHY.replace("\non:", '\n"on":').replace(
+        "  push:\n    branches: [develop, main]",
+        "  push:\n    branches: [develop, main]\n    paths: ['src/**']",
+    )
+    assert "path-filter" in _codes(source, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# render_issue_body: the alarm has to be actionable at 3am
+# ---------------------------------------------------------------------------
+
+
+def test_the_issue_body_carries_the_evidence() -> None:
+    """An alert without evidence is an alert people learn to close unread."""
+    body = render_issue_body(
+        verdict=Verdict.LYING,
+        violations=[Violation("step-continue-on-error", "Quality gate")],
+        sha="9e9a5c028e48d92c71a407c9e227e79caeb54326",
+        reported="success",
+        audit_passed=False,
+        repo="VGonPa/xbrain",
+        run_url="https://github.com/VGonPa/xbrain/actions/runs/1",
+    )
+    assert "9e9a5c02" in body  # which commit
+    assert "success" in body  # what the gate claimed
+    assert "step-continue-on-error" in body  # what is wrong, by name
+    assert "actions/runs/1" in body  # the receipts
+
+
+# ---------------------------------------------------------------------------
+# main: the seam the workflow actually calls
+# ---------------------------------------------------------------------------
+
+
+def _invoke(
+    tmp_path: Path, workflow_src: str, check_runs: Any, audit_result: str
+) -> dict[str, str]:
+    """Drive `main()` exactly as the workflow does, and return the outputs it emitted."""
+    import json
+
+    from xbrain.gate_audit import main
+
+    workflow = tmp_path / "quality.yml"
+    workflow.write_text(workflow_src, encoding="utf-8")
+    runs = tmp_path / "check-runs.json"
+    runs.write_text(json.dumps(check_runs), encoding="utf-8")
+    body = tmp_path / "body.md"
+    outputs = tmp_path / "outputs.txt"
+    outputs.touch()
+
+    main(
+        [
+            "--check-runs", str(runs),
+            "--workflow", str(workflow),
+            "--audit-result", audit_result,
+            "--sha", "9e9a5c028e48d92c71a407c9e227e79caeb54326",
+            "--repo", "VGonPa/xbrain",
+            "--run-url", "https://github.com/VGonPa/xbrain/actions/runs/1",
+            "--body-out", str(body),
+            "--github-output", str(outputs),
+        ]
+    )  # fmt: skip
+
+    parsed = dict(
+        line.split("=", 1)
+        for line in outputs.read_text(encoding="utf-8").splitlines()
+        if "=" in line
+    )
+    if body.is_file():
+        parsed["body"] = body.read_text(encoding="utf-8")
+    return parsed
+
+
+def test_main_reports_a_lying_gate(tmp_path: Path) -> None:
+    """End to end: gate said success, honest execution failed -> file the issue."""
+    out = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "success")]}, "failure")
+    assert out["verdict"] == "lying"
+    assert out["file_issue"] == "true"
+    assert "9e9a5c02" in out["body"]
+
+
+def test_main_is_quiet_on_a_healthy_repo(tmp_path: Path) -> None:
+    """The everyday case must produce no issue and no noise."""
+    out = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "success")]}, "success")
+    assert out["verdict"] == "clean"
+    assert out["file_issue"] == "false"
+
+
+def test_main_is_quiet_when_develop_is_merely_red(tmp_path: Path) -> None:
+    """Consistent red belongs to the push-triggered alert, not to this one."""
+    out = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "failure")]}, "failure")
+    assert out["verdict"] == "consistent_red"
+    assert out["file_issue"] == "false"
+
+
+def test_main_files_a_disarmed_gate_that_still_passes(tmp_path: Path) -> None:
+    """Static half, end to end: booby-trap planted on a green day is still filed."""
+    gagged = _HEALTHY.replace(
+        "        run: bash scripts/check.sh",
+        "        run: bash scripts/check.sh\n        continue-on-error: true",
+    )
+    out = _invoke(tmp_path, gagged, {"check_runs": [_run("quality", "success")]}, "success")
+    assert out["file_issue"] == "true"
+    assert "step-continue-on-error" in out["body"]
+
+
+@pytest.mark.parametrize("result", ["cancelled", "skipped", ""])
+def test_a_gate_run_we_never_OBSERVED_is_never_called_a_liar(tmp_path: Path, result: str) -> None:
+    """`needs.<job>.result` is not a boolean. Reading it as one manufactures a false accusation.
+
+    A GitHub job resolves to `success`, `failure`, `cancelled` or `skipped`. If the
+    gate-execution job is cancelled — a killed runner, a cancelled workflow, a spot-instance
+    eviction — then `result == 'cancelled'`, and the naive `passed = (result == 'success')`
+    reads that as *the audit failed*. Against a healthy green gate that yields the verdict
+    LYING, and the auditor files a public issue accusing the repo of shipping unverified code
+    because a VM died.
+
+    An auditor that cries wolf is worse than no auditor: it burns exactly the credibility it
+    needs on the one day it is right. We did not OBSERVE the gate, so we say nothing.
+    """
+    out = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "success")]}, result)
+    assert out["verdict"] == "inconclusive"
+    assert out["file_issue"] == "false"
+
+
+def test_only_a_positively_clean_audit_stands_down_the_alarm(tmp_path: Path) -> None:
+    """Closing an open "the gate is LYING" issue is a claim, and it needs positive evidence.
+
+    `file_issue == false` is NOT that evidence: it is also false when the audit was
+    inconclusive, or when develop is merely red. Auto-closing on those would let a cancelled
+    runner silently retract a live, correct accusation — the alarm would disarm itself the
+    moment CI got flaky. Only a verdict of CLEAN with zero violations may stand it down.
+    """
+    clean = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "success")]}, "success")
+    assert clean["clean"] == "true"
+
+    for result, runs in (
+        ("cancelled", [_run("quality", "success")]),  # never observed
+        ("failure", [_run("quality", "failure")]),  # merely red
+        ("success", []),  # gate never reported
+    ):
+        out = _invoke(tmp_path, _HEALTHY, {"check_runs": runs}, result)
+        assert out["file_issue"] == "false", "must not accuse"
+        assert out["clean"] == "false", "and must not exonerate either"

--- a/tests/test_gate_audit.py
+++ b/tests/test_gate_audit.py
@@ -66,6 +66,18 @@ from xbrain.gate_audit import (
 # ---------------------------------------------------------------------------
 
 
+#: A real, public commit SHA from this repo's history — used as realistic test data.
+#:
+#: `# pragma: allowlist secret` because detect-secrets scores any 40-char hex string as a
+#: "Hex High Entropy String". A git SHA is precisely that shape and is precisely not a secret;
+#: every commit hash in the repo is world-readable. Audited, false positive.
+#:
+#: (Worth knowing: `detect-secrets scan` only reads GIT-TRACKED files, so this fires the
+#: moment the file is `git add`ed and NOT before. A local `poe check` on a brand-new,
+#: untracked file is a FALSE GREEN — which is how this one reached CI.)
+_SHA = "9e9a5c028e48d92c71a407c9e227e79caeb54326"  # pragma: allowlist secret
+
+
 def _run(name: str, conclusion: str | None, status: str = "completed", **extra: Any) -> Any:
     """One entry as the `/commits/{sha}/check-runs` endpoint returns it."""
     return {"name": name, "status": status, "conclusion": conclusion, **extra}
@@ -383,7 +395,7 @@ def test_the_issue_body_carries_the_evidence() -> None:
     body = render_issue_body(
         verdict=Verdict.LYING,
         violations=[Violation("step-continue-on-error", "Quality gate")],
-        sha="9e9a5c028e48d92c71a407c9e227e79caeb54326",
+        sha=_SHA,
         reported="success",
         audit_passed=False,
         repo="VGonPa/xbrain",
@@ -421,7 +433,7 @@ def _invoke(
             "--check-runs", str(runs),
             "--workflow", str(workflow),
             "--audit-result", audit_result,
-            "--sha", "9e9a5c028e48d92c71a407c9e227e79caeb54326",
+            "--sha", _SHA,
             "--repo", "VGonPa/xbrain",
             "--run-url", "https://github.com/VGonPa/xbrain/actions/runs/1",
             "--body-out", str(body),

--- a/tests/test_gate_audit.py
+++ b/tests/test_gate_audit.py
@@ -650,3 +650,164 @@ def test_a_gate_that_really_failed_is_still_convicted(tmp_path: Path) -> None:
     assert out["verdict"] == "lying"
     assert out["file_issue"] == "true"
     assert out["observed"] == "true"
+
+
+# ---------------------------------------------------------------------------
+# Every known disarm, applied to the REAL workflow — not only to a fixture
+#
+# `_HEALTHY` is fifteen lines. The workflow it stands in for has an `env:` block, a
+# permissions block, and four more steps. Mutating only the fixture proves the auditor
+# catches an attack on a workflow nobody has, and the claim "mutation-tested against the real
+# quality.yml" was carried by a control test that never mutated anything.
+#
+# These mutate the PARSED workflow rather than its text, so one attack definition applies to
+# any shape either file grows into.
+# ---------------------------------------------------------------------------
+
+_REAL_QUALITY = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "quality.yml"
+
+
+def _quality_job(workflow: dict[str, Any]) -> dict[str, Any]:
+    """The job whose check run branch protection requires."""
+    return workflow["jobs"]["quality"]
+
+
+def _gate_step_in(workflow: dict[str, Any]) -> dict[str, Any]:
+    """The step that runs the gate — the one every attack here is aimed at."""
+    steps = _quality_job(workflow)["steps"]
+    return next(s for s in steps if "scripts/check.sh" in str(s.get("run", "")))
+
+
+def _checkout_in(workflow: dict[str, Any]) -> dict[str, Any]:
+    """The checkout step, whose `ref:` decides which tree the gate examines."""
+    steps = _quality_job(workflow)["steps"]
+    return next(s for s in steps if "actions/checkout" in str(s.get("uses", "")))
+
+
+def _gag_the_gate_step(workflow: dict[str, Any]) -> None:
+    _gate_step_in(workflow)["continue-on-error"] = True
+
+
+def _pin_the_checkout_to_another_tree(workflow: dict[str, Any]) -> None:
+    checkout = _checkout_in(workflow)
+    checkout["with"] = {**(checkout.get("with") or {}), "ref": "main"}
+
+
+def _gag_the_job(workflow: dict[str, Any]) -> None:
+    _quality_job(workflow)["continue-on-error"] = True
+
+
+def _skip_the_job(workflow: dict[str, Any]) -> None:
+    _quality_job(workflow)["if"] = "false"
+
+
+def _rename_the_check(workflow: dict[str, Any]) -> None:
+    _quality_job(workflow)["name"] = "Tests"
+
+
+def _skip_the_gate_step(workflow: dict[str, Any]) -> None:
+    _gate_step_in(workflow)["if"] = "false"
+
+
+def _delete_the_gate_step(workflow: dict[str, Any]) -> None:
+    _quality_job(workflow)["steps"].remove(_gate_step_in(workflow))
+
+
+def _delete_the_gate_job(workflow: dict[str, Any]) -> None:
+    del workflow["jobs"]["quality"]
+
+
+def _filter_the_trigger_by_path(workflow: dict[str, Any]) -> None:
+    for key in (True, "on"):
+        if key in workflow:
+            workflow[key]["pull_request"]["paths"] = ["src/**"]
+            return
+    raise AssertionError("workflow declares no trigger block")
+
+
+#: Every way the gate is known to be disarmable, and the violation code it must raise.
+_ATTACKS = [
+    ("step-continue-on-error", _gag_the_gate_step),
+    ("checkout-ref", _pin_the_checkout_to_another_tree),
+    ("job-continue-on-error", _gag_the_job),
+    ("job-conditional", _skip_the_job),
+    ("check-renamed", _rename_the_check),
+    ("gate-step-conditional", _skip_the_gate_step),
+    ("gate-step-missing", _delete_the_gate_step),
+    ("gate-job-missing", _delete_the_gate_job),
+    ("path-filter", _filter_the_trigger_by_path),
+]
+
+#: The fixture AND the file the auditor will really read on develop.
+_SOURCES = {
+    "fixture": _HEALTHY,
+    "real": _REAL_QUALITY.read_text(encoding="utf-8"),
+}
+
+
+def _apply(source: str, attack: Any, tmp_path: Path) -> set[str]:
+    """Parse, mutate, re-serialise, and ask the auditor what it sees."""
+    import yaml
+
+    workflow = yaml.safe_load(source)
+    attack(workflow)
+    path = tmp_path / "quality.yml"
+    path.write_text(yaml.safe_dump(workflow, sort_keys=False), encoding="utf-8")
+    return {v.code for v in audit_workflow_source(path)}
+
+
+@pytest.mark.parametrize("source_name", sorted(_SOURCES))
+def test_the_real_and_fixture_workflows_are_both_clean_undisturbed(
+    source_name: str, tmp_path: Path
+) -> None:
+    """The control. Without it, an auditor that flags everything would score a perfect run."""
+    assert _apply(_SOURCES[source_name], lambda _w: None, tmp_path) == set()
+
+
+@pytest.mark.parametrize("source_name", sorted(_SOURCES))
+@pytest.mark.parametrize("code,attack", _ATTACKS, ids=[code for code, _ in _ATTACKS])
+def test_every_known_disarm_is_caught_on_both_workflows(
+    code: str, attack: Any, source_name: str, tmp_path: Path
+) -> None:
+    """Each attack, on the fixture AND on the workflow that is actually deployed.
+
+    Probes #121/#125 (gag the step) and #124 (wrong tree) are the two measured against the
+    live API; the rest are the fail-open shapes catalogued alongside them. Running each
+    against the real file is what stops this suite from certifying an auditor that only
+    works on a workflow nobody has.
+    """
+    assert code in _apply(_SOURCES[source_name], attack, tmp_path)
+
+
+def test_the_gag_message_does_not_claim_the_gate_failed_when_it_did_not(tmp_path: Path) -> None:
+    """`continue-on-error` is banned on EVERY step of the gate job — but not for one reason.
+
+    On the gate step it is the gag: the gate runs, fails, and the check reports SUCCESS
+    (probes #121/#125). On a bystander step — the red-branch announcer, say — it is a
+    legitimate-looking edit that this repo bans anyway, because nobody should have to work
+    out which step they are looking at. Flagging both is right. Telling the reader that the
+    gate "still runs, still FAILS" when the flagged step is the announcer is not: the alarm
+    would be describing something that did not happen, and an alarm that misstates its
+    evidence is how people learn to disbelieve it.
+    """
+    import yaml
+
+    workflow = yaml.safe_load(_SOURCES["real"])
+    announcer = next(
+        step
+        for step in _quality_job(workflow)["steps"]
+        if "announce_red_branch" in str(step.get("run", ""))
+    )
+    announcer["continue-on-error"] = True
+    path = tmp_path / "quality.yml"
+    path.write_text(yaml.safe_dump(workflow, sort_keys=False), encoding="utf-8")
+
+    violations = audit_workflow_source(path)
+    codes = {v.code for v in violations}
+    assert "step-continue-on-error" in codes, "a banned key on any step of the job must flag"
+
+    detail = next(v.detail for v in violations if v.code == "step-continue-on-error")
+    assert "still FAILS" not in detail, (
+        f"The violation says the gate 'still runs, still FAILS', but the flagged step is the "
+        f"red-branch announcer, not the gate. Detail was: {detail!r}"
+    )

--- a/tests/test_gate_audit.py
+++ b/tests/test_gate_audit.py
@@ -413,9 +413,18 @@ def test_the_issue_body_carries_the_evidence() -> None:
 
 
 def _invoke(
-    tmp_path: Path, workflow_src: str, check_runs: Any, audit_result: str
+    tmp_path: Path,
+    workflow_src: str,
+    check_runs: Any,
+    audit_result: str,
+    gate_outcome: str | None = None,
 ) -> dict[str, str]:
-    """Drive `main()` exactly as the workflow does, and return the outputs it emitted."""
+    """Drive `main()` exactly as the workflow does, and return the outputs it emitted.
+
+    `gate_outcome` is what the gate STEP itself reported, carried out of the execution job
+    as an artifact. `None` means no artifact arrived — the execution job never got as far as
+    the gate, which is what a setup failure looks like from here.
+    """
     import json
 
     from xbrain.gate_audit import main
@@ -427,12 +436,20 @@ def _invoke(
     body = tmp_path / "body.md"
     outputs = tmp_path / "outputs.txt"
     outputs.touch()
+    # Written when the gate ran, and REMOVED otherwise — several tests call this helper more
+    # than once with the same `tmp_path`, and a file left behind by an earlier call would
+    # make "the gate was never observed" silently mean "observed, with the previous answer".
+    outcome_file = tmp_path / "gate-outcome.txt"
+    outcome_file.unlink(missing_ok=True)
+    if gate_outcome is not None:
+        outcome_file.write_text(f"{gate_outcome}\n", encoding="utf-8")
 
     main(
         [
             "--check-runs", str(runs),
             "--workflow", str(workflow),
             "--audit-result", audit_result,
+            "--gate-outcome", str(outcome_file),
             "--sha", _SHA,
             "--repo", "VGonPa/xbrain",
             "--run-url", "https://github.com/VGonPa/xbrain/actions/runs/1",
@@ -453,7 +470,13 @@ def _invoke(
 
 def test_main_reports_a_lying_gate(tmp_path: Path) -> None:
     """End to end: gate said success, honest execution failed -> file the issue."""
-    out = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "success")]}, "failure")
+    out = _invoke(
+        tmp_path,
+        _HEALTHY,
+        {"check_runs": [_run("quality", "success")]},
+        "failure",
+        gate_outcome="failure",
+    )
     assert out["verdict"] == "lying"
     assert out["file_issue"] == "true"
     assert "9e9a5c02" in out["body"]
@@ -461,14 +484,26 @@ def test_main_reports_a_lying_gate(tmp_path: Path) -> None:
 
 def test_main_is_quiet_on_a_healthy_repo(tmp_path: Path) -> None:
     """The everyday case must produce no issue and no noise."""
-    out = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "success")]}, "success")
+    out = _invoke(
+        tmp_path,
+        _HEALTHY,
+        {"check_runs": [_run("quality", "success")]},
+        "success",
+        gate_outcome="success",
+    )
     assert out["verdict"] == "clean"
     assert out["file_issue"] == "false"
 
 
 def test_main_is_quiet_when_develop_is_merely_red(tmp_path: Path) -> None:
     """Consistent red belongs to the push-triggered alert, not to this one."""
-    out = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "failure")]}, "failure")
+    out = _invoke(
+        tmp_path,
+        _HEALTHY,
+        {"check_runs": [_run("quality", "failure")]},
+        "failure",
+        gate_outcome="failure",
+    )
     assert out["verdict"] == "consistent_red"
     assert out["file_issue"] == "false"
 
@@ -479,7 +514,13 @@ def test_main_files_a_disarmed_gate_that_still_passes(tmp_path: Path) -> None:
         "        run: bash scripts/check.sh",
         "        run: bash scripts/check.sh\n        continue-on-error: true",
     )
-    out = _invoke(tmp_path, gagged, {"check_runs": [_run("quality", "success")]}, "success")
+    out = _invoke(
+        tmp_path,
+        gagged,
+        {"check_runs": [_run("quality", "success")]},
+        "success",
+        gate_outcome="success",
+    )
     assert out["file_issue"] == "true"
     assert "step-continue-on-error" in out["body"]
 
@@ -511,14 +552,101 @@ def test_only_a_positively_clean_audit_stands_down_the_alarm(tmp_path: Path) -> 
     runner silently retract a live, correct accusation — the alarm would disarm itself the
     moment CI got flaky. Only a verdict of CLEAN with zero violations may stand it down.
     """
-    clean = _invoke(tmp_path, _HEALTHY, {"check_runs": [_run("quality", "success")]}, "success")
+    clean = _invoke(
+        tmp_path,
+        _HEALTHY,
+        {"check_runs": [_run("quality", "success")]},
+        "success",
+        gate_outcome="success",
+    )
     assert clean["clean"] == "true"
 
-    for result, runs in (
-        ("cancelled", [_run("quality", "success")]),  # never observed
-        ("failure", [_run("quality", "failure")]),  # merely red
-        ("success", []),  # gate never reported
+    for result, gate, runs in (
+        ("cancelled", None, [_run("quality", "success")]),  # never observed
+        ("failure", "failure", [_run("quality", "failure")]),  # merely red
+        ("success", "success", []),  # gate never reported
     ):
-        out = _invoke(tmp_path, _HEALTHY, {"check_runs": runs}, result)
+        out = _invoke(tmp_path, _HEALTHY, {"check_runs": runs}, result, gate_outcome=gate)
         assert out["file_issue"] == "false", "must not accuse"
         assert out["clean"] == "false", "and must not exonerate either"
+
+
+# ---------------------------------------------------------------------------
+# Which STEP failed. `needs.<job>.result` cannot tell you, and the difference is an
+# accusation.
+# ---------------------------------------------------------------------------
+
+
+def test_observe_gate_reads_the_step_not_the_job() -> None:
+    """The gate step's own outcome is the only thing that convicts."""
+    from xbrain.gate_audit import observe_gate
+
+    assert observe_gate("success", "success").passed is True
+    assert observe_gate("failure", "failure").passed is False
+
+
+@pytest.mark.parametrize("job_result", ["failure", "cancelled", "skipped", ""])
+def test_a_gate_step_we_never_reached_is_never_a_verdict(job_result: str) -> None:
+    """No outcome for the gate step means the gate was never run. That convicts nobody.
+
+    `needs.<job>.result` aggregates every step of `execute-gate` — the checkout, the uv
+    install, the Python install, the dependency sync — and reports a single `failure` for all
+    of them. Reading it as "the gate failed" means a dependency resolution that broke at
+    06:17 is indistinguishable from a gate that lies, and the auditor files a public issue
+    accusing the repository of merging unverified code because PyPI had a bad morning.
+    """
+    from xbrain.gate_audit import observe_gate
+
+    assert observe_gate(None, job_result).passed is None
+
+
+def test_a_setup_failure_names_itself() -> None:
+    """`inconclusive` is the right verdict, but silence about WHY is how an auditor goes deaf.
+
+    A job that failed before reaching the gate is not the same event as a cancelled runner:
+    the first says the auditor is broken and needs a human, the second says nothing happened.
+    Both are inconclusive; only one is worth a red run.
+    """
+    from xbrain.gate_audit import observe_gate
+
+    broken = observe_gate(None, "failure")
+    assert broken.passed is None
+    assert "before" in broken.reason.lower()
+
+    quiet = observe_gate(None, "cancelled")
+    assert quiet.passed is None
+    assert quiet.reason != broken.reason
+
+
+def test_a_setup_failure_is_not_a_lying_gate(tmp_path: Path) -> None:
+    """End to end, the regression this exists to prevent.
+
+    `execute-gate` fails because `uv sync` could not resolve; the gate step never ran. The
+    `quality` check honestly reported SUCCESS. Reading the JOB result, that is `lying` and a
+    public issue gets filed. Reading the STEP, it is what it actually is: we did not look.
+    """
+    out = _invoke(
+        tmp_path,
+        _HEALTHY,
+        {"check_runs": [_run("quality", "success")]},
+        "failure",
+        gate_outcome=None,
+    )
+    assert out["verdict"] == "inconclusive"
+    assert out["file_issue"] == "false", "must not accuse the gate of a setup failure"
+    assert out["clean"] == "false", "and must not exonerate it either"
+    assert out["observed"] == "false", "the workflow needs to know it must go red"
+
+
+def test_a_gate_that_really_failed_is_still_convicted(tmp_path: Path) -> None:
+    """The other half. Narrowing the signal must not blunt it: a real lie still lands."""
+    out = _invoke(
+        tmp_path,
+        _HEALTHY,
+        {"check_runs": [_run("quality", "success")]},
+        "failure",
+        gate_outcome="failure",
+    )
+    assert out["verdict"] == "lying"
+    assert out["file_issue"] == "true"
+    assert out["observed"] == "true"

--- a/tests/test_gate_audit_workflow.py
+++ b/tests/test_gate_audit_workflow.py
@@ -1,0 +1,370 @@
+# tests/test_gate_audit_workflow.py
+"""The auditor's own shape. Who audits the auditor? This file — and only this file.
+
+`gate-audit.yml` is the last layer of the CI defence, and it is defended by exactly one
+property, which is easy to destroy by accident while "tidying up":
+
+    A `schedule`-triggered workflow runs from the DEFAULT BRANCH's version of the file.
+
+This repo's default branch is `main` (verified against the API, 2026-07-14). So the auditor's
+definition lives on `main`, out of reach of any PR into `develop` — which is precisely the
+thing it audits. A PR cannot gag the workflow that is watching it. That is the fail-closed
+property, and it is the same one `pull_request_target` would give us WITHOUT the fork-PR RCE
+surface that made `pull_request_target` unacceptable on a public repo.
+
+Everything below defends that property or the honesty of what runs under it:
+
+* **Triggers are an ALLOWLIST, not a denylist.** Not "no `pull_request_target`" — that would
+  pass a workflow someone added `issue_comment:` to. The assertion is that the trigger set is
+  a SUBSET of {schedule, workflow_dispatch}: two events, neither of which a fork or an
+  outsider can fire. Anything else, named or not, fails. A denylist of today's known-bad
+  events would have to be updated every time GitHub ships a new one; an allowlist never does.
+
+* **No `continue-on-error`, anywhere.** The auditor exists because that key can make a gate
+  lie. An auditor that could be silenced the same way would be a comedy.
+
+* **It EXECUTES, it does not merely read.** A static linter of `quality.yml` is not a judge;
+  it is a second opinion from the same armchair. The audit must run `bash scripts/check.sh`
+  itself, on develop's real tree, and compare the result it gets with the result GitHub
+  published. Judge != party, and the judge must actually do the work.
+
+* **The comparator is the AUDITOR's copy, not the audited branch's.** Subtle and load-bearing.
+  The gate execution necessarily runs develop's `check.sh` (that IS the gate under audit —
+  running our own copy would prove nothing about develop's). But the code that DECIDES whether
+  the gate lied must come from `main`, or a PR into develop could simply edit the judge into
+  saying "looks fine to me". So the audit job checks out its own tree (no `ref:`, hence the
+  default branch) and reads develop's `quality.yml` through a SPARSE checkout — data, never
+  code. This file asserts that split, because nothing else would notice if it collapsed.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_WORKFLOW = Path(__file__).resolve().parent.parent / ".github" / "workflows" / "gate-audit.yml"
+
+# The only two events that fire this workflow. Both are trusted: `schedule` is fired by
+# GitHub on a clock, `workflow_dispatch` requires write access to the repo. Neither can be
+# triggered by a fork, an outside contributor, or the contents of a pull request.
+_ALLOWED_EVENTS = frozenset({"schedule", "workflow_dispatch"})
+
+# The audited branch, the gate script it must really execute, and the endpoint it must really
+# ask. Spelled out so a failure message can say what was expected rather than "assert False".
+_AUDITED_BRANCH = "develop"
+_GATE_SCRIPT = "scripts/check.sh"
+_CHECK_RUNS_ENDPOINT = "check-runs"
+
+
+def _workflow() -> dict[Any, Any]:
+    """Parse `gate-audit.yml`. A parse failure here IS a test failure: it would never run."""
+    assert _WORKFLOW.is_file(), (
+        f"{_WORKFLOW.name} does not exist.\n"
+        f"\n"
+        f"This is the only layer that can catch a `quality` gate which reports GREEN while "
+        f"testing nothing. Deleting it restores the hole described in probes #121/#124/#125."
+    )
+    parsed = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{_WORKFLOW.name} is not a YAML mapping."
+    return parsed
+
+
+def _triggers() -> Any:
+    """The trigger block, surviving YAML's Norway problem (bare `on:` parses as `True`)."""
+    workflow = _workflow()
+    for key in (True, "on"):
+        if key in workflow:
+            return workflow[key]
+    raise AssertionError(f"{_WORKFLOW.name} declares no trigger block at all")
+
+
+def _event_names() -> set[str]:
+    """Every event this workflow fires on, whatever shape the `on:` block is written in."""
+    triggers = _triggers()
+    if isinstance(triggers, str):
+        return {triggers}
+    if isinstance(triggers, list):
+        return set(triggers)
+    return set(triggers)
+
+
+def _jobs() -> dict[str, dict[str, Any]]:
+    """Every job, normalised to a mapping."""
+    return {str(k): (v or {}) for k, v in (_workflow().get("jobs") or {}).items()}
+
+
+def _all_steps() -> list[dict[str, Any]]:
+    """Every step of every job, flattened."""
+    return [step for job in _jobs().values() for step in (job.get("steps") or [])]
+
+
+def _runs() -> str:
+    """All shell in the workflow, concatenated — what the auditor actually executes."""
+    return "\n".join(str(step.get("run", "")) for step in _all_steps())
+
+
+# ---------------------------------------------------------------------------
+# The fail-closed property: what can fire this, and what cannot
+# ---------------------------------------------------------------------------
+
+
+def test_the_audit_is_scheduled() -> None:
+    """`schedule` is not a nicety — it is the entire security model.
+
+    A scheduled workflow runs from the DEFAULT BRANCH's copy of the file. That, and only
+    that, is why a PR into `develop` cannot edit the auditor that judges it. Swap this for
+    `push` or `pull_request` and the auditor starts running from the PR's own HEAD — at
+    which point it can be gagged by the very diff it is supposed to catch, and this whole
+    layer becomes theatre.
+    """
+    assert "schedule" in _event_names(), (
+        "`gate-audit.yml` declares no `schedule:` trigger.\n"
+        "\n"
+        "STOP. Scheduled runs execute the DEFAULT BRANCH's version of a workflow. That is "
+        "the ONLY reason a PR into `develop` cannot silence this auditor. Any trigger that "
+        "runs the PR's own copy of this file (`push`, `pull_request`) hands the accused "
+        "control of the judge."
+    )
+
+
+def test_the_audit_can_be_run_on_demand() -> None:
+    """`workflow_dispatch` is how you re-run the audit after fixing a lie, to close the issue.
+
+    Without it, a fix waits up to 24h for the cron before the alert clears — and a stale
+    alert is one people learn to scroll past.
+    """
+    assert "workflow_dispatch" in _event_names()
+
+
+def test_no_fork_fireable_trigger_can_ever_run_the_audit() -> None:
+    """An ALLOWLIST, deliberately — a denylist of today's bad events rots.
+
+    `pull_request_target` would also give the fail-closed property (it too runs the base
+    branch's copy), and it was DECLINED: it hands a write-scoped token to a workflow running
+    in the context of a fork's PR, on a PUBLIC repo. That is the canonical fork-PR RCE
+    surface. `schedule` gets the same guarantee for free, because no outsider can fire a
+    clock.
+    """
+    events = _event_names()
+    forbidden = events - _ALLOWED_EVENTS
+    assert not forbidden, (
+        f"`gate-audit.yml` fires on {sorted(forbidden)}, which is outside the allowlist "
+        f"{sorted(_ALLOWED_EVENTS)}.\n"
+        f"\n"
+        f"This workflow holds `issues: write` and runs trusted code from the default branch. "
+        f"It must be unreachable from anything a fork or an outside contributor can cause. "
+        f"`pull_request_target` in particular is BANNED: base-branch write token + public "
+        f"repo = fork-PR RCE. If you need a new trigger, prove no outsider can fire it, then "
+        f"add it to the allowlist here — deliberately, not by accident."
+    )
+
+
+def test_the_cron_is_a_valid_five_field_expression() -> None:
+    """A malformed cron does not error — the workflow simply never runs. Silent, permanent."""
+    schedule = (_triggers() or {}).get("schedule")
+    assert isinstance(schedule, list) and schedule, "`schedule:` must be a non-empty list."
+    for entry in schedule:
+        cron = str(entry.get("cron", ""))
+        fields = cron.split()
+        assert len(fields) == 5, (
+            f"cron {cron!r} has {len(fields)} fields, not 5. GitHub silently never runs an "
+            f"invalid schedule, so this auditor would simply cease to exist."
+        )
+        assert re.fullmatch(r"[\d*,\-/]+", "".join(fields)), (
+            f"cron {cron!r} contains characters outside the POSIX 5-field syntax."
+        )
+
+
+# ---------------------------------------------------------------------------
+# The auditor must not be gaggable by the trick it exists to catch
+# ---------------------------------------------------------------------------
+
+
+def test_the_auditor_declares_no_continue_on_error_anywhere() -> None:
+    """The one key this whole layer exists because of. It must not appear in the auditor.
+
+    `continue-on-error: true` on a step makes a FAILING step report SUCCESS. If the audit
+    job carried it, the audit could fail to prove the gate is lying — and report success.
+    The watchman must not be able to sleep through his own alarm.
+    """
+    offenders = [name for name, job in _jobs().items() if "continue-on-error" in job]
+    assert not offenders, f"Jobs declaring `continue-on-error`: {offenders}. Delete it."
+
+    bad_steps = [
+        step.get("name", step.get("run", step.get("uses", "?")))
+        for step in _all_steps()
+        if "continue-on-error" in step
+    ]
+    assert not bad_steps, (
+        f"Steps declaring `continue-on-error`: {bad_steps}.\n"
+        f"\n"
+        f"This is the exact key the audit exists to detect on `quality.yml`. An auditor that "
+        f"swallows its own failures reports a clean bill of health for a gate it never "
+        f"managed to check."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Judge != party, and the judge must EXECUTE, not read
+# ---------------------------------------------------------------------------
+
+
+def test_the_audit_actually_executes_the_real_gate() -> None:
+    """Reading `quality.yml` is a second opinion. RUNNING `check.sh` is evidence.
+
+    The static audit can only catch what someone thought to ban. Executing the gate and
+    comparing the outcome catches the attack nobody has invented yet, because it never asks
+    HOW the gate lied — only whether what it reported matches what is true.
+    """
+    assert _GATE_SCRIPT in _runs(), (
+        f"No step in `gate-audit.yml` runs `{_GATE_SCRIPT}`.\n"
+        f"\n"
+        f"Without executing the gate itself, this workflow is a linter with a cron — it can "
+        f"only ever find banned keywords, and both measured attacks (#121 gag, #124 wrong "
+        f"tree) were designed to look fine to a linter."
+    )
+
+
+def test_the_audit_reads_what_the_gate_REPORTED() -> None:
+    """Half the comparison. Without GitHub's own answer there is nothing to compare against."""
+    assert _CHECK_RUNS_ENDPOINT in _runs(), (
+        "No step queries the `check-runs` API. The audit compares what the gate REPORTED "
+        "for develop's HEAD against what an honest execution FINDS. Drop the first half and "
+        "you have merely re-run the tests: you would learn that develop is red, but never "
+        "that the gate CLAIMED it was green."
+    )
+
+
+def test_the_gate_execution_job_audits_develop() -> None:
+    """It must run the gate on the branch under audit, not on the auditor's own tree.
+
+    Auditing `main` would be circular and useless: `main` is only ever reached THROUGH
+    `develop`, so a gate weakened on `develop` is invisible from `main` until it has already
+    been promoted.
+    """
+    assert _AUDITED_BRANCH in yaml.safe_dump(_workflow()), (
+        f"`gate-audit.yml` never mentions `{_AUDITED_BRANCH}`. The audit must check out and "
+        f"execute the gate on the branch it is auditing."
+    )
+
+
+def test_the_comparator_runs_from_the_auditors_own_tree() -> None:
+    """THE subtlety. The judge's code must come from `main`, never from the accused branch.
+
+    The gate EXECUTION runs develop's `check.sh` — it has to; that IS the gate under audit.
+    But the code that decides *whether the gate lied* must not be develop's, or a PR could
+    edit the judge as easily as it edits the gate, and we would be back where we started.
+
+    Structurally: the audit job checks out its own tree with NO `ref:` (a scheduled run
+    therefore gets the default branch), and reads develop's `quality.yml` through a separate
+    checkout pinned to a `path:`. Data in, never code. This test asserts that split exists.
+    """
+    jobs = _jobs()
+    audit_steps = [
+        step
+        for name, job in jobs.items()
+        for step in (job.get("steps") or [])
+        if "gate_audit" in str(step.get("run", ""))
+    ]
+    assert audit_steps, "No step runs the `gate_audit` comparator module."
+
+    # The job holding the comparator must check out the auditor's own tree: a checkout with
+    # no `ref:` and no `path:`, which on a scheduled run resolves to the default branch.
+    audit_job = next(
+        job
+        for job in jobs.values()
+        if any("gate_audit" in str(s.get("run", "")) for s in (job.get("steps") or []))
+    )
+    checkouts = [
+        step
+        for step in (audit_job.get("steps") or [])
+        if "actions/checkout" in str(step.get("uses", ""))
+    ]
+    own_tree = [c for c in checkouts if not (c.get("with") or {}).get("ref")]
+    assert own_tree, (
+        "The audit job never checks out its OWN tree (a checkout with no `ref:`).\n"
+        "\n"
+        "On a scheduled run, a bare checkout resolves to the DEFAULT BRANCH — which is the "
+        "only copy of the comparator a PR into `develop` cannot edit. If the comparator were "
+        "run from the audited checkout instead, a PR could neuter the judge in the same diff "
+        "that neuters the gate, and this entire layer would be decorative."
+    )
+
+    # Anything checked out FROM the audited branch must land in its own `path:`, so it can
+    # never be mistaken for — or shadow — the auditor's own files.
+    audited = [c for c in checkouts if (c.get("with") or {}).get("ref")]
+    for checkout in audited:
+        with_ = checkout.get("with") or {}
+        assert with_.get("path"), (
+            f"A checkout pinned to `ref: {with_.get('ref')!r}` declares no `path:`, so it "
+            f"overwrites the auditor's own working tree — including the comparator. The "
+            f"audited branch's code would then BE the judge."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Least privilege
+# ---------------------------------------------------------------------------
+
+
+def test_the_audit_may_file_an_issue() -> None:
+    """Detection that cannot speak is detection into a void."""
+    perms = [job.get("permissions") or {} for job in _jobs().values()]
+    assert any(p.get("issues") == "write" for p in perms), (
+        "No job declares `issues: write`, so the audit cannot file the alert when it catches "
+        "the gate lying. A red run in the Actions tab that nobody is watching is not a "
+        "control — that lesson cost 9m15s of red `develop` and two duplicate hotfix PRs."
+    )
+
+
+def test_the_audit_can_read_the_reported_check_run() -> None:
+    """`checks: read` is what lets the built-in token see what the gate published."""
+    perms = [job.get("permissions") or {} for job in _jobs().values()]
+    assert any(p.get("checks") == "read" for p in perms)
+
+
+def test_the_audit_never_takes_write_access_to_code() -> None:
+    """It observes and it reports. It must never be able to change what it is auditing.
+
+    An auditor with `contents: write` could, if compromised or simply buggy, rewrite the very
+    gate it is judging. Read-only on code is what keeps its authority to accuse credible.
+    """
+    for name, job in _jobs().items():
+        perms = job.get("permissions") or {}
+        assert perms.get("contents", "read") == "read", (
+            f"Job `{name}` takes `contents: {perms.get('contents')!r}`. The auditor must "
+            f"never be able to write to the repository it audits."
+        )
+        assert "pull-requests" not in perms, (
+            f"Job `{name}` takes `pull-requests` permission. The auditor files issues; it "
+            f"does not touch PRs. Least privilege."
+        )
+
+
+def test_every_job_declares_its_permissions_explicitly() -> None:
+    """An omitted `permissions:` block inherits the repo default, which may be write-all.
+
+    Silence here is not "no permissions" — it is "whatever the repo settings happen to say",
+    which can change under you without a diff to this file.
+    """
+    for name, job in _jobs().items():
+        assert "permissions" in job, (
+            f"Job `{name}` declares no `permissions:` block, so it inherits the repository "
+            f"default — which is NOT guaranteed to be read-only and can be changed in "
+            f"settings without any diff to this workflow. State the scopes explicitly."
+        )
+
+
+def test_the_audit_uses_no_secret_beyond_the_builtin_token() -> None:
+    """No PAT, no bot identity, no new credential to rotate, revoke, or leak."""
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    used = set(re.findall(r"secrets\.([A-Za-z_][A-Za-z0-9_]*)", text))
+    assert used <= {"GITHUB_TOKEN"}, (
+        f"`gate-audit.yml` references secrets beyond the built-in token: "
+        f"{sorted(used - {'GITHUB_TOKEN'})}. A scheduled workflow with a PAT is a standing "
+        f"credential with nobody watching it. The built-in GITHUB_TOKEN is scoped to this "
+        f"run and dies with it."
+    )

--- a/tests/test_gate_audit_workflow.py
+++ b/tests/test_gate_audit_workflow.py
@@ -368,3 +368,121 @@ def test_the_audit_uses_no_secret_beyond_the_builtin_token() -> None:
         f"credential with nobody watching it. The built-in GITHUB_TOKEN is scoped to this "
         f"run and dies with it."
     )
+
+
+# ---------------------------------------------------------------------------
+# The auditor must run THE SAME GATE — not merely a gate
+#
+# `execute-gate` is the honest control the reported verdict is measured against. That only
+# means anything if it builds the SAME environment `quality.yml` builds. If it does not, the
+# two can disagree for a reason that has nothing to do with the gate being disarmed, and the
+# auditor files a public issue accusing the repository of merging unverified code because the
+# two jobs resolved a dependency differently.
+#
+# This is not hypothetical, and it is why these tests exist. `quality.yml` originally ran
+# `uv venv && uv pip install -e ".[dev]"`; PR #135 changed it to `uv sync --extra dev
+# --locked` precisely because the pip-compatibility path ignores `uv.lock` and installs
+# whatever the release train shipped that morning. The auditor kept the old command, and the
+# equivalence was asserted only in a PROSE comment (`# Match quality.yml exactly`). Prose has
+# nobody to enforce it. These bind the two files in code, so the PR that changes one and not
+# the other goes red.
+# ---------------------------------------------------------------------------
+
+_QUALITY_WORKFLOW = _WORKFLOW.parent / "quality.yml"
+
+#: The job in `gate-audit.yml` that runs the gate honestly, and the job in `quality.yml`
+#: whose check run branch protection requires. These two must agree about the environment.
+_EXECUTE_GATE_JOB = "execute-gate"
+_QUALITY_JOB = "quality"
+
+
+def _quality_workflow() -> dict[Any, Any]:
+    """Parse the gate's own workflow — the thing the auditor has to reproduce."""
+    assert _QUALITY_WORKFLOW.is_file(), f"{_QUALITY_WORKFLOW.name} does not exist."
+    parsed = yaml.safe_load(_QUALITY_WORKFLOW.read_text(encoding="utf-8"))
+    assert isinstance(parsed, dict), f"{_QUALITY_WORKFLOW.name} is not a YAML mapping."
+    return parsed
+
+
+def _setup_steps(job: dict[str, Any]) -> list[str]:
+    """The commands that BUILD the environment the gate then runs in.
+
+    Everything before the step that runs `check.sh`, minus `actions/checkout` — the one step
+    that is legitimately different, because the auditor pins the commit under audit while the
+    gate checks out the commit that triggered it. Everything else must be identical.
+    """
+    out: list[str] = []
+    for step in job.get("steps") or []:
+        if _GATE_SCRIPT in str(step.get("run", "")):
+            break
+        if "actions/checkout" in str(step.get("uses", "")):
+            continue
+        out.append(str(step.get("uses") or step.get("run") or "").strip())
+    return out
+
+
+def test_the_auditor_builds_the_SAME_environment_as_the_gate() -> None:
+    """An honest re-run in a DIFFERENT environment is not a control — it is a second opinion.
+
+    Measured on this repo the day the drift appeared: `uv pip install -e ".[dev]"` resolves
+    fresh from `pyproject.toml` (`ruff>=0.5`) and never reads `uv.lock`, so it installed ruff
+    0.16.5 while the gate, installing from the lockfile, ran 0.15.13. ruff 0.16 enables UP017
+    by default and this tree has 429 of them. The auditor would have run `check.sh`, seen it
+    exit 1, compared that against a `quality` check that legitimately reported SUCCESS, and
+    concluded the gate was LYING — on its very first scheduled run.
+    """
+    auditor = _setup_steps(_jobs()[_EXECUTE_GATE_JOB])
+    gate = _setup_steps((_quality_workflow().get("jobs") or {})[_QUALITY_JOB])
+
+    assert auditor == gate, (
+        f"`{_EXECUTE_GATE_JOB}` in {_WORKFLOW.name} does not build the same environment as "
+        f"the `{_QUALITY_JOB}` job in {_QUALITY_WORKFLOW.name}.\n"
+        f"\n"
+        f"  auditor : {auditor}\n"
+        f"  gate    : {gate}\n"
+        f"\n"
+        f"The audit compares an honest execution against what the gate reported. If the two "
+        f"install differently, they can disagree for a reason that is not a disarmed gate — "
+        f"and the auditor files a PUBLIC issue accusing the repo of shipping unverified "
+        f"code. Change both files together, or the auditor cries wolf."
+    )
+
+
+def test_the_auditor_runs_the_gate_under_the_same_env() -> None:
+    """`PYTHONHASHSEED` is pinned so the gate is byte-reproducible. Both sides, or neither.
+
+    A gate run under a different hash seed is not the same gate, and a spurious difference
+    reads as a lie. This was asserted in a comment saying "Match quality.yml exactly"; a
+    comment cannot fail a build.
+    """
+    auditor = _jobs()[_EXECUTE_GATE_JOB].get("env") or {}
+    gate = ((_quality_workflow().get("jobs") or {})[_QUALITY_JOB]).get("env") or {}
+
+    assert auditor == gate, (
+        f"`{_EXECUTE_GATE_JOB}` declares `env: {auditor}` but the `{_QUALITY_JOB}` job "
+        f"declares `env: {gate}`. The honest control must run under the gate's own "
+        f"environment or its result is not comparable."
+    )
+
+
+def test_the_auditor_never_installs_outside_the_lockfile() -> None:
+    """`uv pip install` is uv's pip-COMPATIBILITY mode. It does not read `uv.lock`.
+
+    Every dependency the auditor resolves fresh is a dependency that can change under it
+    between one scheduled run and the next, with no commit anywhere in the repository. The
+    auditor's whole job is to be the stable thing a drifting gate is measured against, so it
+    is the last place that may float.
+    """
+    offenders = [
+        f"{name}: {str(step.get('run', '')).strip()}"
+        for name, job in _jobs().items()
+        for step in (job.get("steps") or [])
+        if "uv pip install" in str(step.get("run", ""))
+    ]
+    assert not offenders, (
+        f"These steps install outside the lockfile: {offenders}.\n"
+        f"\n"
+        f"`uv pip install` resolves fresh from pyproject.toml and ignores `uv.lock`, so the "
+        f"auditor's own environment drifts with the release train. Use `uv sync --locked` "
+        f"(add `--extra dev` only where the gate itself does)."
+    )

--- a/tests/test_gate_audit_workflow.py
+++ b/tests/test_gate_audit_workflow.py
@@ -486,3 +486,88 @@ def test_the_auditor_never_installs_outside_the_lockfile() -> None:
         f"auditor's own environment drifts with the release train. Use `uv sync --locked` "
         f"(add `--extra dev` only where the gate itself does)."
     )
+
+
+def test_the_audit_judges_the_gate_STEP_not_the_whole_job() -> None:
+    """`needs.<job>.result` aggregates the setup steps too. Convicting on it accuses wrongly.
+
+    `execute-gate` checks out, installs uv, installs Python and syncs dependencies before it
+    ever reaches `check.sh`. All five steps collapse into one `failure`, so a dependency that
+    would not resolve at 06:17 is indistinguishable from a gate that lies — and the auditor
+    files a public issue accusing the repository of merging unverified code because PyPI had
+    a bad morning.
+
+    The gate step therefore carries an `id`, its own outcome is recorded by a step that runs
+    `if: always()` (so it survives the failure it is reporting), and the comparator is handed
+    that outcome rather than the job result.
+    """
+    job = _jobs()[_EXECUTE_GATE_JOB]
+    steps = job.get("steps") or []
+
+    gate = next((s for s in steps if _GATE_SCRIPT in str(s.get("run", ""))), None)
+    assert gate is not None, f"`{_EXECUTE_GATE_JOB}` no longer runs {_GATE_SCRIPT}."
+    gate_id = gate.get("id")
+    assert gate_id, (
+        f"The step running {_GATE_SCRIPT} declares no `id:`, so `steps.<id>.outcome` cannot "
+        f"be read and the only signal left is the job result — which is exactly the one that "
+        f"cannot tell a broken setup from a lying gate."
+    )
+
+    reference = f"steps.{gate_id}.outcome"
+    recorders = [
+        step
+        for step in steps
+        if reference in str(step.get("env", "")) or reference in str(step.get("run", ""))
+    ]
+    assert recorders, (
+        f"No step reads `{reference}`. The gate's own outcome never leaves the job, so the "
+        f"audit has nothing to judge but `needs.{_EXECUTE_GATE_JOB}.result`."
+    )
+    for step in recorders:
+        assert str(step.get("if", "")).strip() == "always()", (
+            f"Step {step.get('name')!r} reads `{reference}` but is not `if: always()`. It "
+            f"would be skipped by the very gate failure it exists to report, and the audit "
+            f"would see no outcome precisely when the gate did fail."
+        )
+
+    assert "--gate-outcome" in _runs(), (
+        "The comparator is never handed `--gate-outcome`, so it falls back to the job result "
+        "and the whole distinction is decorative."
+    )
+
+
+def test_a_broken_auditor_does_not_pass_for_a_clean_bill_of_health() -> None:
+    """Not observing the gate is safe. Not observing it SILENTLY, every day, is not.
+
+    A setup failure yields `inconclusive`, which correctly files nothing. But an auditor
+    permanently unable to run the gate would then be indistinguishable from an auditor that
+    keeps finding everything in order — it would go quietly deaf. The run must go red so the
+    failure is visible, without ever filing the accusation it has no evidence for.
+    """
+    steps = _jobs()["audit"].get("steps") or []
+    guards = [
+        step
+        for step in steps
+        if "observed" in str(step.get("if", "")) and "exit 1" in str(step.get("run", ""))
+    ]
+    assert guards, (
+        "No step turns the run red when the gate could not be executed. The auditor can then "
+        "fail to look for months and report nothing, which reads exactly like good news."
+    )
+
+
+def test_the_audit_may_read_the_artifact_it_depends_on() -> None:
+    """A `permissions:` block sets every scope it does NOT list to `none`.
+
+    The gate's own outcome crosses jobs as an artifact, and `gh run download` reads it
+    through the Actions API — which needs `actions: read`. Without it the download fails
+    every single day, the audit reads "gate not observed" every single day, and the layer is
+    permanently unable to look while its `inconclusive` verdict quietly files nothing.
+    """
+    audit = _jobs()["audit"]
+    perms = audit.get("permissions") or {}
+    assert perms.get("actions") == "read", (
+        f"The `audit` job declares `permissions: {perms}`, so `actions` is `none` and "
+        f"`gh run download` cannot fetch the gate-outcome artifact. The audit would observe "
+        f"nothing, for ever."
+    )


### PR DESCRIPTION
## What this closes

The `quality` gate is a required status check on `develop`/`main` (`strict`, `enforce_admins`). **Two one-line edits make it report GREEN while testing nothing.** Both measured against the live API:

| | Edit | What GitHub reports | Reality |
|---|---|---|---|
| **#121, #125** | `continue-on-error: true` on the gate **STEP** | step `success`, job `success`, check run `SUCCESS`, `mergeStateStatus: CLEAN` | `check.sh` exits **1**. Every API surface says green. |
| **#124** | `checkout` with an explicit **`ref:`** | gate runs, all checks pass, `SUCCESS`, `CLEAN` | It examined the **wrong tree**. `1088 passed` where develop's suite has ~1600. |

*(At **job** level — `jobs.quality.continue-on-error` — it is harmless: check reports `FAILURE`, merge `BLOCKED`, probe #119. The difference is **one indent**.)*

### Why no in-repo test can catch the first

A PR's CI runs the PR's **own HEAD copy** of the workflow. Our guards (`tests/test_ci_workflow.py`) live **inside** `check.sh`. On a PR that adds `continue-on-error`, they fire correctly and `check.sh` exits 1 — **and the same `continue-on-error` swallows their failure too.** The alarm rings inside the soundproofed room. Something outside has to listen.

**And this is not only an attack.** `continue-on-error` on a failing step is *the* canonical "make flaky CI stop blocking merges" edit. An agent told *"the build keeps failing, make it pass"* reaches for it in good faith and produces a permanently dead gate wearing a green badge.

Every mechanical prevention was checked against the live API and is **unavailable** on this public, user-owned repo: merge queue (org-only), required-workflows ruleset (Enterprise), `file_path_restriction` (Enterprise), required approvals (sole collaborator — nobody can approve). `pull_request_target` would work and was **declined**: base write-token + public repo = fork-PR RCE surface.

## The fail-closed property this rests on

> **A `schedule`-triggered workflow runs from the DEFAULT BRANCH's version of the file.**

The default branch is **`main`** (verified). So `gate-audit.yml`'s definition **cannot be edited by a PR into `develop`** — the very thing it audits. The accused does not hold the gavel. That is the same guarantee `pull_request_target` offers, without the RCE surface: a `schedule` trigger is never fired by fork input and never executes untrusted code.

**To disarm the auditor you must weaken `main` — a separate, visible `develop → main` PR.** Do not "tidy" this file onto `develop`: that silently destroys the only thing it has. `tests/test_gate_audit_workflow.py` fails loudly if you try.

## How it works — judge ≠ party, and **executing**, not reading

1. **`resolve`** — pin `develop` to **one SHA**. The tree we execute, the YAML we read and the check run we query must be the same commit; a push landing mid-run would otherwise compare commit A's execution against commit B's verdict — a false accusation. (It is also a job that *cannot fail*, so the SHA survives a failing gate.)
2. **`execute-gate`** — run the **real** `bash scripts/check.sh` on that commit, in a job with **no** `continue-on-error` and **no** pinned `ref:`. It is *allowed to fail*; the failure **is** the signal.
3. **`audit`** — ask GitHub what the gate **REPORTED** (`commits/{sha}/check-runs`) and **compare**.

> Reported **non-blocking** + honest execution **FAILED** ⇒ **the gate is LYING.**

That asks the **outcome** question, not the syntax question — so it catches both measured attacks, *and the next one nobody has invented*, without enumerating a single keyword. "Non-blocking" is not the string `success`: GitHub treats `neutral` and `skipped` as satisfying a required check too (`if: false` on a job reports `skipped` and merges straight past).

Plus a **static audit** of develop's `quality.yml` for the known banned patterns, read as **data** through a sparse checkout. Belt and braces: **execution proves *that* something is wrong; static says *what*.** Static alone catches a gate disarmed on a day develop happens to be green — which execution cannot see, because there is no discrepancy yet.

**The comparator runs from the AUDITOR's tree** (bare checkout ⇒ default branch), never the audited one. Otherwise a PR could neuter the gate *and* the judge in the same diff.

Permissions: `contents: read` everywhere, `checks: read`, and `issues: write` only where the alarm is raised. **No PAT, no new identity, no secrets beyond `GITHUB_TOKEN`.**

## Two false-alarm bugs the tests caught, red-first

- **`needs.<job>.result` is not a boolean.** It is `success | failure | cancelled | skipped`. The naive `passed = (result == 'success')` reads a **cancelled runner** as *the audit failed* — which against a healthy green gate yields the verdict `LYING` and files a public issue accusing the repo of shipping unverified code **because a VM died**. Only `success`/`failure` is an observation; anything else is `inconclusive` and says nothing. *(Red proof: `assert 'lying' == 'inconclusive'`.)*
- **Standing an alarm down is a CLAIM, and needs evidence.** Closing on "no new accusation" would also close on *inconclusive* or *merely red* — letting one flaky run silently retract a live, correct accusation. Only a **positively CLEAN** verdict closes the issue.

## Issue lifecycle

One issue, keyed by the label `ci-gate-audit`, with the retry + reconcile idiom `announce_red_branch.sh` already paid for (GitHub's issue **list** endpoints are eventually consistent — a bare list-then-create raced itself and filed both #113 *and* #114).

**A later clean audit closes it — deliberately.** The issue asserts a *live* fact ("the gate is lying **right now**"), and a clean audit disproves it by executing the gate honestly on develop's real HEAD. Leaving it open trains everyone to scroll past a usually-stale alert, which is how the Actions tab stopped being read in the first place. Nothing is lost: the issue is closed, not deleted, and the closing comment records the commit that proved the gate honest. Because the cron is daily, **`workflow_dispatch` is what clears the alert the same day you fix it.**

## Honest limits (stated at the top of the workflow, not just here)

- **This is detection, not prevention.** A weakened gate can merge and live on `develop` until the next run (≤24h). Accepted: the accident is *recoverable* — visible in the diff, one commit to fix — and prevention would have cost an RCE surface.
- **It cannot catch a gate that lies from inside `check.sh`.** The audit *executes* develop's `check.sh` (that IS the gate under audit), so a `check.sh` neutered to `exit 0` would be executed honestly and agree with a green report. `tests/test_quality_gate_scope.py` and the static audit cover that flank.

## ⚠️ This layer is NOT ACTIVE until the next `develop → main` promotion

A workflow must exist **on the default branch** to be scheduled at all. This PR lands on `develop`, so **`gate-audit.yml` does nothing until `develop` is promoted to `main`.** Only then can it be proven live with `workflow_dispatch`. I have not faked a run.

## Testing

Cannot run GitHub Actions locally, so:

- **90 tests**, all shown red before green (or, where a guard could only pass, proven to go red by deleting the rule it guards).
- **Mutation-tested against the real attacks** — nine known disarms applied to the **parsed** workflow and run against BOTH the fixture and the *actual* `quality.yml`. Proven to bind: with `_check_step_gag` and `_check_checkout_ref` deleted from the auditor, the `-real` variants of both measured attacks go red:
  - probe #121/#125 (gag the step) → `['step-continue-on-error']`
  - probe #124 (wrong tree) → `['checkout-ref']`
  - control (real `quality.yml`) → `clean`
- **Mutation-tested reflexively** — attempts to gag *the auditor*: adding `pull_request_target`, adding `continue-on-error` to its own gate execution, and moving it off `schedule` onto `push` each fail `test_gate_audit_workflow.py` with a message saying why.
- Triggers asserted as an **allowlist** (`⊆ {schedule, workflow_dispatch}`), not a denylist — a denylist of today's fork-fireable events rots.
- YAML parses; the cron `17 6 * * *` is asserted to be a 5-field POSIX expression (field count + charset). *(An earlier revision of this description claimed `croniter` validated it. It does not: `croniter` is not a dependency of this repo and is imported nowhere. Corrected rather than quietly dropped.)*
- Full gate green: **all 11 checks**, 1723 tests, 94% coverage, Radon all A/B.

Cron is 06:17 UTC (~07:17 Madrid): early enough that an overnight lie is at the top of the inbox, late enough that develop's HEAD has settled so the check run is `completed` rather than in-flight; `:17` because GitHub drops scheduled runs that cluster at the top of the hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review follow-up (2026-08-30): two defects that would have made the auditor's first act a false accusation

Found by re-running this branch against a `develop` that had moved on. Both are fixed on this branch; the gate is green on the merge result.

### 1. The auditor was no longer executing the same gate

PR #135 moved `quality.yml` to `uv sync --extra dev --locked`, because `uv pip install` is uv's pip-COMPATIBILITY mode: it resolves fresh from `pyproject.toml` (`ruff>=0.5`) and never reads `uv.lock`. This workflow kept the old command, and the equivalence between the two was asserted only in a **prose comment** (`# Match quality.yml exactly`). Prose has nobody to enforce it.

Measured on this tree:

```
uv pip install -e ".[dev]"     ->  ruff 0.16.5
uv sync --extra dev --locked   ->  ruff 0.15.13   (what uv.lock pins)
ruff check --select UP017      ->  429 errors     (ruff 0.16 enables UP017 by default)
```

So on its **first scheduled run** the auditor would have installed 0.16.5, run `check.sh`, watched it exit 1, compared that against a `quality` check that had honestly reported SUCCESS, and filed a public issue accusing this repository of merging unverified code. Three tests now bind the two files in code: identical setup steps, identical job `env:`, and no `uv pip install` anywhere in the auditor.

### 2. `needs.<job>.result` cannot tell a broken setup from a lying gate

It aggregates every step of `execute-gate` — checkout, uv install, Python install, dependency sync — into one `failure`. Demonstrated before the fix:

```
the gate ran and really failed  ->  result=failure    ->  lying
`uv sync` failed                ->  result=failure    ->  lying   <- false accusation
`actions/checkout` failed       ->  result=failure    ->  lying   <- false accusation
runner evicted                  ->  result=cancelled  ->  inconclusive
```

This is the same defect the layer already guarded for `cancelled`, applied to the case that is far likelier on a daily cron. The gate step now carries an `id` and records `steps.gate.outcome` into an artifact (`if: always()`) that the audit job downloads — an **artifact and not a job output**, because outputs are not published when a job fails and this job is *designed* to fail, so the output would be missing in exactly the case that must convict. A job that broke before reaching the gate is `inconclusive`: it files nothing, and turns the run **red**, so the auditor cannot go quietly deaf. `actions: read` added for the download.

### Also

- The gag violation told the reader the gate "still runs, still FAILS" for *any* step carrying `continue-on-error`, including the red-branch announcer, which does not run the gate. Banning the key on every step is right; describing a bystander as the gag is not.
- The two claims in **Testing** above that no test held have been corrected.

### Still true, and unchanged

**This layer is NOT ACTIVE until the next `develop → main` promotion.** `main` is 122 commits behind `develop` (last promoted 2026-07-04) and `gate-audit.yml` is not on it, so a scheduled run cannot exist yet. It has never executed once. `workflow_dispatch` after the promotion is what proves it live.
