### PR TITLE
fix: content the pipeline was silently losing (articles, ASR, Firecrawl) + verify coverage on the dashboard

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -168,6 +168,24 @@
         "line_number": 476
       }
     ],
+    "tests/fixtures/art-Rich_Entities.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/fixtures/art-Rich_Entities.json",
+        "hashed_secret": "4124e25382612088af82448c8d5e95ea40171398",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
+    "tests/fixtures/art-Video_Embed.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/fixtures/art-Video_Embed.json",
+        "hashed_secret": "1f43c9cc931633dfc964f95c2225187a8ab35c21",
+        "is_verified": false,
+        "line_number": 130
+      }
+    ],
     "tests/fixtures/art-Wiki_Memory.json": [
       {
         "type": "Base64 High Entropy String",
@@ -187,5 +205,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-12T17:19:33Z"
+  "generated_at": "2026-08-30T17:45:02Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -140,14 +140,14 @@
         "filename": "scripts/check.sh",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 414
+        "line_number": 422
       },
       {
         "type": "Secret Keyword",
         "filename": "scripts/check.sh",
         "hashed_secret": "a602e216eb44a3ac5e096036eeaaef6bb9159677",
         "is_verified": false,
-        "line_number": 418
+        "line_number": 426
       }
     ],
     "tests/fixtures/art-Headcount_AI.json": [
@@ -176,7 +176,16 @@
         "is_verified": false,
         "line_number": 424
       }
+    ],
+    "tests/test_fetch.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_fetch.py",
+        "hashed_secret": "ed5e66488a192d6c73fc2db0bbbe2d0b0bf8529f",
+        "is_verified": false,
+        "line_number": 284
+      }
     ]
   },
-  "generated_at": "2026-07-04T06:13:06Z"
+  "generated_at": "2026-08-12T17:19:33Z"
 }

--- a/config.toml.example
+++ b/config.toml.example
@@ -70,8 +70,22 @@ version = "v1"
 # audio track (silent clips, GIFs) attach as has_speech=false instead of failing
 # (parakeet writes no file for them). Point at the wrapper, or straight at
 # `parakeet-mlx` if you don't need silent-video handling.
+#
+# ON A MULTILINGUAL CORPUS, USE `scripts/xbrain-transcribe-auto` INSTEAD.
+# parakeet-mlx is English-only and does not fail on other languages — it
+# FABRICATES fluent English from Spanish audio, which is the worst failure mode
+# available: a confident transcript nobody can tell is invented, feeding the
+# digest and every downstream summary. The router detects the language on the
+# first 30s and dispatches: English → parakeet (fast), anything else or any
+# uncertainty → whisper. It prefers `xbrain-transcribe-mlx` (mlx-whisper on the
+# Apple GPU, ~25x faster than CPU whisper on the same clip and byte-identical
+# output) and falls back to `xbrain-transcribe-whisper` (brew whisper, CPU,
+# portable). Tuning knobs (all optional env vars): XBRAIN_ASR_DETECT_MODEL
+# (default `base`), XBRAIN_ASR_DETECT_SECONDS (30), XBRAIN_ASR_FORCE to pin one
+# backend, and XBRAIN_TRANSCRIBE_{PARAKEET,MLX,WHISPER} to override each binary.
 command = "parakeet-mlx"
 # command = "/absolute/path/to/scripts/xbrain-transcribe"
+# command = "/absolute/path/to/scripts/xbrain-transcribe-auto"   # multilingual
 # Optional model id passed through to the transcriber. Omit for the tool default.
 # model = "parakeet-tdt-0.6b-v2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,11 +49,19 @@ testpaths = ["tests"]
 line-length = 100
 target-version = "py312"
 # Ruff only discovers *.py / *.pyi / *.ipynb when handed a directory, so the
-# two extensionless executables in scripts/ (`#!/usr/bin/env python3` wrappers
-# that users invoke directly) would be silently skipped by `ruff check scripts`
-# even though they are Python. Name them explicitly so the gate really covers
-# every Python file under scripts/ — the whole point of linting that directory.
-extend-include = ["scripts/xbrain-transcribe", "scripts/xbrain-vision"]
+# extensionless executables in scripts/ (`#!/usr/bin/env python3` wrappers that
+# users invoke directly) would be silently skipped by `ruff check scripts` even
+# though they are Python. Name them explicitly so the gate really covers every
+# Python file under scripts/ — the whole point of linting that directory.
+# `test_ruff_examines_every_python_file_in_the_repo` fails when a new one is
+# added and not listed here, which is how these three got caught.
+extend-include = [
+    "scripts/xbrain-transcribe",
+    "scripts/xbrain-transcribe-auto",
+    "scripts/xbrain-transcribe-mlx",
+    "scripts/xbrain-transcribe-whisper",
+    "scripts/xbrain-vision",
+]
 
 [tool.mypy]
 python_version = "3.12"

--- a/scripts/xbrain-transcribe-auto
+++ b/scripts/xbrain-transcribe-auto
@@ -104,9 +104,20 @@ def _confirmed_no_audio(media: str) -> bool:
     if not ffprobe or not media:
         return False
     probe = subprocess.run(
-        [ffprobe, "-v", "error", "-select_streams", "a",
-         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
-        capture_output=True, text=True,
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            media,
+        ],
+        capture_output=True,
+        text=True,
     )
     if probe.returncode != 0:
         return False
@@ -140,17 +151,42 @@ def detect_language(media: str) -> str | None:
     try:
         clip = Path(workdir) / "probe.wav"
         sliced = subprocess.run(
-            [ffmpeg, "-v", "error", "-y", "-t", str(seconds), "-i", media,
-             "-ac", "1", "-ar", "16000", str(clip)],
-            capture_output=True, text=True,
+            [
+                ffmpeg,
+                "-v",
+                "error",
+                "-y",
+                "-t",
+                str(seconds),
+                "-i",
+                media,
+                "-ac",
+                "1",
+                "-ar",
+                "16000",
+                str(clip),
+            ],
+            capture_output=True,
+            text=True,
         )
         if sliced.returncode != 0 or not clip.exists():
             return None
         # No `--language`: the omission IS the detection request.
         detected = subprocess.run(
-            [whisper, str(clip), "--model", model, "--output_format", "json",
-             "--output_dir", workdir, "--verbose", "False"],
-            capture_output=True, text=True,
+            [
+                whisper,
+                str(clip),
+                "--model",
+                model,
+                "--output_format",
+                "json",
+                "--output_dir",
+                workdir,
+                "--verbose",
+                "False",
+            ],
+            capture_output=True,
+            text=True,
         )
         if detected.returncode != 0:
             return None
@@ -166,7 +202,7 @@ def detect_language(media: str) -> str | None:
 
 
 def pick_backend(language: str | None) -> str:
-    """"parakeet" for a language parakeet is correct on, else "whisper".
+    """ "parakeet" for a language parakeet is correct on, else "whisper".
 
     `None` (undetected) deliberately lands on whisper: the failure modes are not
     symmetric, and only one of them produces a plausible transcript of something
@@ -218,8 +254,10 @@ def main() -> int:
         code = subprocess.run([sys.executable, command, *args], env=env).returncode
         if code == 0:
             return code
-        print(f"xbrain-transcribe-auto: {default_name} exited {code}; trying the next backend",
-              file=sys.stderr)
+        print(
+            f"xbrain-transcribe-auto: {default_name} exited {code}; trying the next backend",
+            file=sys.stderr,
+        )
     return code
 
 

--- a/scripts/xbrain-transcribe-auto
+++ b/scripts/xbrain-transcribe-auto
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""xbrain `[transcribe].command` router — detects the language, then picks the ASR.
+
+xbrain invokes `<cmd> [--model M] --output-format json --output-dir <DIR> <media>`
+and reads the transcript from the first NON-EMPTY `*.json` in `<DIR>`. This script
+honours that contract and delegates to one of two backends that already do:
+
+  - `xbrain-transcribe`         → parakeet-mlx. Fast on Apple Silicon. ENGLISH ONLY.
+  - `xbrain-transcribe-mlx`     → mlx-whisper. Multilingual, runs on the Apple GPU.
+  - `xbrain-transcribe-whisper` → OpenAI Whisper CLI. Multilingual, CPU, ~25x slower.
+
+Non-English tries the GPU backend and falls back to the CPU one if it cannot run
+(no uv, no wheel, not an Apple machine). The two were verified to produce a
+character-identical transcript on a real clip, so the fallback trades only time.
+
+WHY THIS EXISTS. parakeet-tdt (v2 and v3) does not fail on Spanish audio — it
+INVENTS. Verified 17-jul-2026 against an es-ES TV clip: it exits 0 and emits
+fluent, broken English that never reproduces what was said. A noisy failure is
+visible in a log; this one passes the whole pipeline and lands in a note as a
+quotation. By the time you read the transcript you can no longer tell "the video
+said that" from "parakeet made it up", so the choice of backend HAS to be made
+before transcription, not after.
+
+HOW. `ffmpeg` slices the first `XBRAIN_ASR_DETECT_SECONDS` (default 30) of audio;
+`whisper` transcribes that slice with no `--language`, so it reports what it
+detected; the full media then goes to parakeet for English and to whisper for
+anything else. Detection costs one small-model pass over 30 seconds — the whole
+point of routing is to keep the fast backend for the case it is correct on.
+
+COST, measured on this machine (M-series, 12-ago-2026) over one real es-ES and
+one real en-US clip from the store: `base` ~19 s per clip, `tiny` ~10 s, and both
+identified both clips correctly. The default stays `base`: two samples are not
+enough evidence to trade accuracy for 9 seconds on the axis where being wrong
+means a fabricated transcript. `XBRAIN_ASR_DETECT_MODEL=tiny` is there for a
+large backlog where the halving matters.
+
+FAILING SAFE. Any uncertainty — ffmpeg missing, whisper failing, an unreadable
+result — routes to WHISPER, never to parakeet. The costs are asymmetric in
+exactly one direction: whisper on English is slower than it needed to be, while
+parakeet on non-English is a fabricated transcript. A silent video short-circuits
+before any of this (`ffprobe` confirms no audio) and yields the empty-speech JSON
+the two wrappers already agree on.
+
+ENV
+  XBRAIN_ASR_DETECT_MODEL    whisper model used for detection  (default: base)
+  XBRAIN_ASR_DETECT_SECONDS  seconds of audio sampled          (default: 30)
+  XBRAIN_ASR_FORCE           "parakeet" | "whisper" — skip detection entirely
+  XBRAIN_TRANSCRIBE_PARAKEET path to the parakeet wrapper      (default: alongside this file)
+  XBRAIN_TRANSCRIBE_WHISPER  path to the whisper wrapper       (default: alongside this file)
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# parakeet is correct for these and materially faster; everything else — including
+# an undetected language — goes to whisper. Kept as a set so the "English family"
+# can grow (whisper reports plain "en", but a future detector may be finer-grained)
+# without turning the routing rule into a chain of string comparisons.
+PARAKEET_LANGUAGES = {"en", "english"}
+
+DEFAULT_DETECT_MODEL = "base"
+DEFAULT_DETECT_SECONDS = 30
+_HERE = Path(__file__).resolve().parent
+
+
+def _wrapper(env_var: str, default_name: str) -> str:
+    """Resolve a backend wrapper: the env override, else a sibling of this script.
+
+    Defaulting to a sibling keeps the three scripts deployable as one directory
+    (repo `scripts/` or `~/.local/bin`) with no absolute paths baked in.
+    """
+    override = os.environ.get(env_var)
+    if override:
+        return override
+    sibling = _HERE / default_name
+    return str(sibling) if sibling.exists() else default_name
+
+
+def _parse_args(args: list[str]) -> tuple[str, str]:
+    """Extract `(output_dir, media)` from xbrain's invocation.
+
+    Mirrors the parakeet wrapper's own parsing so the three scripts agree on what
+    the contract is; every other flag is passed through untouched to the backend.
+    """
+    out_dir = "."
+    for i, arg in enumerate(args):
+        if arg == "--output-dir" and i + 1 < len(args):
+            out_dir = args[i + 1]
+    return out_dir, (args[-1] if args else "")
+
+
+def _confirmed_no_audio(media: str) -> bool:
+    """True ONLY if ffprobe positively confirms `media` has no audio stream.
+
+    Unknown (ffprobe absent / errors / empty path) → False, so a real failure is
+    never MASKED as "silent". Same rule, same reason, as in both wrappers.
+    """
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe or not media:
+        return False
+    probe = subprocess.run(
+        [ffprobe, "-v", "error", "-select_streams", "a",
+         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
+        capture_output=True, text=True,
+    )
+    if probe.returncode != 0:
+        return False
+    return "audio" not in probe.stdout
+
+
+def _write_silent(out_dir: str, media: str) -> None:
+    """Emit the empty-speech JSON both wrappers use for a genuinely silent clip."""
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / f"{Path(media).stem}.json").write_text(
+        json.dumps({"text": "", "language": None, "segments": [], "has_speech": False})
+    )
+
+
+def detect_language(media: str) -> str | None:
+    """The language whisper detects in the first N seconds of `media`, or None.
+
+    None means "could not tell" — from a missing ffmpeg/whisper, a non-zero exit,
+    or output we could not read. Every one of those routes to whisper (see
+    `pick_backend`), so an undetectable clip is never handed to the backend that
+    fabricates.
+    """
+    ffmpeg = shutil.which("ffmpeg")
+    whisper = shutil.which("whisper")
+    if not ffmpeg or not whisper or not media:
+        return None
+    seconds = os.environ.get("XBRAIN_ASR_DETECT_SECONDS", DEFAULT_DETECT_SECONDS)
+    model = os.environ.get("XBRAIN_ASR_DETECT_MODEL", DEFAULT_DETECT_MODEL)
+    workdir = tempfile.mkdtemp(prefix="xbrain-lang-")
+    try:
+        clip = Path(workdir) / "probe.wav"
+        sliced = subprocess.run(
+            [ffmpeg, "-v", "error", "-y", "-t", str(seconds), "-i", media,
+             "-ac", "1", "-ar", "16000", str(clip)],
+            capture_output=True, text=True,
+        )
+        if sliced.returncode != 0 or not clip.exists():
+            return None
+        # No `--language`: the omission IS the detection request.
+        detected = subprocess.run(
+            [whisper, str(clip), "--model", model, "--output_format", "json",
+             "--output_dir", workdir, "--verbose", "False"],
+            capture_output=True, text=True,
+        )
+        if detected.returncode != 0:
+            return None
+        result = Path(workdir) / "probe.json"
+        if not result.exists():
+            return None
+        language = json.loads(result.read_text()).get("language")
+        return language.strip().lower() if isinstance(language, str) and language.strip() else None
+    except (OSError, ValueError):
+        return None
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+def pick_backend(language: str | None) -> str:
+    """"parakeet" for a language parakeet is correct on, else "whisper".
+
+    `None` (undetected) deliberately lands on whisper: the failure modes are not
+    symmetric, and only one of them produces a plausible transcript of something
+    that was never said.
+    """
+    return "parakeet" if language in PARAKEET_LANGUAGES else "whisper"
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    out_dir, media = _parse_args(args)
+    if not media:
+        print("xbrain-transcribe-auto: no media file given", file=sys.stderr)
+        return 2
+
+    if _confirmed_no_audio(media):
+        _write_silent(out_dir, media)
+        return 0
+
+    forced = (os.environ.get("XBRAIN_ASR_FORCE") or "").strip().lower()
+    if forced in ("parakeet", "whisper"):
+        backend, language = forced, None
+    else:
+        language = detect_language(media)
+        backend = pick_backend(language)
+
+    print(
+        f"xbrain-transcribe-auto: language={language or 'undetected'} -> {backend}",
+        file=sys.stderr,
+    )
+    env = dict(os.environ)
+    if backend == "parakeet":
+        command = _wrapper("XBRAIN_TRANSCRIBE_PARAKEET", "xbrain-transcribe")
+        return subprocess.run([sys.executable, command, *args], env=env).returncode
+
+    # Pass the detected language through; "auto" tells the backend to detect for
+    # itself rather than force a wrapper's default onto a clip we could not
+    # identify — the same class of error as sending it to parakeet.
+    env["WHISPER_LANGUAGE"] = language or "auto"
+    # GPU first, CPU second: the two produce the same transcript (verified
+    # character-identical on a real clip) and differ only by 25x in wall time, so
+    # the fallback costs correctness nothing. `xbrain-transcribe-mlx` exits
+    # non-zero WITHOUT writing when it cannot run, which is what makes this safe.
+    for env_var, default_name in (
+        ("XBRAIN_TRANSCRIBE_MLX", "xbrain-transcribe-mlx"),
+        ("XBRAIN_TRANSCRIBE_WHISPER", "xbrain-transcribe-whisper"),
+    ):
+        command = _wrapper(env_var, default_name)
+        code = subprocess.run([sys.executable, command, *args], env=env).returncode
+        if code == 0:
+            return code
+        print(f"xbrain-transcribe-auto: {default_name} exited {code}; trying the next backend",
+              file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/xbrain-transcribe-mlx
+++ b/scripts/xbrain-transcribe-mlx
@@ -121,9 +121,20 @@ def confirmed_no_audio(media: str) -> bool:
     if not ffprobe or not media:
         return False
     probe = subprocess.run(
-        [ffprobe, "-v", "error", "-select_streams", "a",
-         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
-        capture_output=True, text=True,
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            media,
+        ],
+        capture_output=True,
+        text=True,
     )
     if probe.returncode != 0:
         return False
@@ -144,23 +155,36 @@ def run_mlx(media: str, repo: str, language: str) -> dict | None:
         driver = Path(workdir) / "driver.py"
         driver.write_text(_DRIVER)
         completed = subprocess.run(
-            [uv, "run", "--no-project", "--with", "mlx-whisper",
-             # The private FITIZENS index in ~/.config/pip/pip.conf needs auth and
-             # would hang the resolve waiting on stdin; pin the public one.
-             "--index-url", "https://pypi.org/simple",
-             "python", str(driver), media, repo, language],
-            capture_output=True, text=True,
+            [
+                uv,
+                "run",
+                "--no-project",
+                "--with",
+                "mlx-whisper",
+                # The private FITIZENS index in ~/.config/pip/pip.conf needs auth and
+                # would hang the resolve waiting on stdin; pin the public one.
+                "--index-url",
+                "https://pypi.org/simple",
+                "python",
+                str(driver),
+                media,
+                repo,
+                language,
+            ],
+            capture_output=True,
+            text=True,
         )
         if completed.returncode != 0 or not completed.stdout.strip():
-            print(f"xbrain-transcribe-mlx: mlx-whisper unavailable or failed "
-                  f"(rc={completed.returncode}): {completed.stderr.strip()[-400:]}",
-                  file=sys.stderr)
+            print(
+                f"xbrain-transcribe-mlx: mlx-whisper unavailable or failed "
+                f"(rc={completed.returncode}): {completed.stderr.strip()[-400:]}",
+                file=sys.stderr,
+            )
             return None
         try:
             return json.loads(completed.stdout)
         except ValueError:
-            print("xbrain-transcribe-mlx: mlx-whisper produced unreadable output",
-                  file=sys.stderr)
+            print("xbrain-transcribe-mlx: mlx-whisper produced unreadable output", file=sys.stderr)
             return None
 
 
@@ -172,8 +196,10 @@ def normalise(raw: dict) -> dict:
         for s in raw.get("segments") or []
     ]
     if is_hallucinated_silence(text):
-        print(f"xbrain-transcribe-mlx: discarding known no-speech artefact ({text!r})",
-              file=sys.stderr)
+        print(
+            f"xbrain-transcribe-mlx: discarding known no-speech artefact ({text!r})",
+            file=sys.stderr,
+        )
         text, segments = "", []
     return {
         "text": text,

--- a/scripts/xbrain-transcribe-mlx
+++ b/scripts/xbrain-transcribe-mlx
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""xbrain `[transcribe].command` backend — mlx-whisper (multilingual, Apple GPU).
+
+Same contract as the other wrappers: xbrain invokes
+`<cmd> [--model M] --output-format json --output-dir <DIR> <media>` and reads the
+first NON-EMPTY `*.json` in `<DIR>`. This one emits `{text, language, segments,
+has_speech}` directly.
+
+WHY, measured on this machine (M-series, 12-ago-2026) over a 68-second Spanish
+clip from the store: the brew `whisper` CLI took **7 min 25 s** — it warns
+`FP16 is not supported on CPU` and runs there — while mlx-whisper produced a
+character-identical transcript in **17.7 s**. Six times slower than realtime is
+not a backend you can point a nightly at; a backlog of a couple hundred videos
+turns a fixed pipeline back into a broken one. Hence a GPU path.
+
+mlx-whisper is pulled on demand through `uv run --with`, so nothing has to be
+installed into the environment ahead of time and no global state is touched. The
+first call downloads the wheel and the model; warm start is ~0.2 s. If `uv` or
+`mlx_whisper` is unavailable (a non-Apple machine, no network on first use) this
+script exits non-zero WITHOUT writing anything, and the router falls back to
+`xbrain-transcribe-whisper` — a missing accelerator degrades to slow, never to
+wrong.
+
+ENV
+  WHISPER_LANGUAGE  language to force, or "auto"/empty to let the model detect
+  WHISPER_MODEL     model name or an mlx-community repo id (default: small)
+  XBRAIN_UV         path to the `uv` binary (default: looked up on PATH)
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Short names → the mlx-community repo that serves them. An id containing "/" is
+# passed through untouched, so any HF repo works without this map having to know it.
+MLX_REPOS = {
+    "tiny": "mlx-community/whisper-tiny-mlx",
+    "base": "mlx-community/whisper-base-mlx",
+    "small": "mlx-community/whisper-small-mlx",
+    "medium": "mlx-community/whisper-medium-mlx",
+    "large": "mlx-community/whisper-large-v3-mlx",
+    "large-v3": "mlx-community/whisper-large-v3-mlx",
+    "turbo": "mlx-community/whisper-large-v3-turbo",
+    "large-v3-turbo": "mlx-community/whisper-large-v3-turbo",
+}
+
+# Whisper's canned hallucinations on audio with NO speech. Kept in step with the
+# same list in `xbrain-transcribe-whisper`: both wrap the same model family, so
+# both inherit the same artefact, and a guard on only one backend would mean the
+# vault's protection depended on which machine ran the nightly.
+NO_SPEECH_ARTEFACTS = {
+    "subtítulos realizados por la comunidad de amara.org",
+    "subtítulos por la comunidad de amara.org",
+    "subtitulos realizados por la comunidad de amara.org",
+    "más videos en amara.org",
+    "subtitles by the amara.org community",
+    "thanks for watching!",
+    "thank you for watching!",
+    "thank you.",
+    "you",
+    "♪♪♪",
+    "[música]",
+    "[music]",
+    "(music)",
+}
+
+_DRIVER = """
+import json, sys
+import mlx_whisper
+media, repo, language = sys.argv[1], sys.argv[2], sys.argv[3]
+kwargs = {"path_or_hf_repo": repo}
+if language:
+    kwargs["language"] = language
+result = mlx_whisper.transcribe(media, **kwargs)
+json.dump(result, sys.stdout)
+"""
+
+
+def is_hallucinated_silence(text: str) -> bool:
+    """True when the WHOLE transcript is one of whisper's no-speech artefacts.
+
+    Whole-transcript match only: a video that MENTIONS Amara, or thanks its
+    viewers mid-sentence, is a real video with real speech.
+    """
+    return text.strip().strip('"“”').lower() in NO_SPEECH_ARTEFACTS
+
+
+def resolve_repo(model: str | None) -> str:
+    """The mlx repo id for a model name (an explicit `owner/repo` passes through)."""
+    name = (model or os.environ.get("WHISPER_MODEL") or "small").strip()
+    if "/" in name:
+        return name
+    return MLX_REPOS.get(name.lower(), MLX_REPOS["small"])
+
+
+def parse_args(args: list[str]) -> tuple[str, str | None, str]:
+    """Extract `(output_dir, model, media)` from xbrain's invocation."""
+    out_dir, model, positional = ".", None, []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--output-dir" and i + 1 < len(args):
+            out_dir, i = args[i + 1], i + 2
+        elif arg == "--model" and i + 1 < len(args):
+            model, i = args[i + 1], i + 2
+        elif arg.startswith("--"):
+            i += 2 if i + 1 < len(args) and not args[i + 1].startswith("--") else 1
+        else:
+            positional.append(arg)
+            i += 1
+    return out_dir, model, (positional[-1] if positional else "")
+
+
+def confirmed_no_audio(media: str) -> bool:
+    """True ONLY if ffprobe positively confirms `media` has no audio stream."""
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe or not media:
+        return False
+    probe = subprocess.run(
+        [ffprobe, "-v", "error", "-select_streams", "a",
+         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
+        capture_output=True, text=True,
+    )
+    if probe.returncode != 0:
+        return False
+    return "audio" not in probe.stdout
+
+
+def run_mlx(media: str, repo: str, language: str) -> dict | None:
+    """Transcribe via mlx-whisper inside a `uv run --with` environment, or None.
+
+    None means "this backend is not usable here" — no uv, no wheel, no model, a
+    crash. The caller exits non-zero without writing, so the router can fall back
+    to the CPU wrapper rather than the pipeline recording a failure.
+    """
+    uv = os.environ.get("XBRAIN_UV") or shutil.which("uv")
+    if not uv:
+        return None
+    with tempfile.TemporaryDirectory(prefix="xbrain-mlx-") as workdir:
+        driver = Path(workdir) / "driver.py"
+        driver.write_text(_DRIVER)
+        completed = subprocess.run(
+            [uv, "run", "--no-project", "--with", "mlx-whisper",
+             # The private FITIZENS index in ~/.config/pip/pip.conf needs auth and
+             # would hang the resolve waiting on stdin; pin the public one.
+             "--index-url", "https://pypi.org/simple",
+             "python", str(driver), media, repo, language],
+            capture_output=True, text=True,
+        )
+        if completed.returncode != 0 or not completed.stdout.strip():
+            print(f"xbrain-transcribe-mlx: mlx-whisper unavailable or failed "
+                  f"(rc={completed.returncode}): {completed.stderr.strip()[-400:]}",
+                  file=sys.stderr)
+            return None
+        try:
+            return json.loads(completed.stdout)
+        except ValueError:
+            print("xbrain-transcribe-mlx: mlx-whisper produced unreadable output",
+                  file=sys.stderr)
+            return None
+
+
+def normalise(raw: dict) -> dict:
+    """mlx-whisper's result → the `{text, language, segments, has_speech}` xbrain reads."""
+    text = (raw.get("text") or "").strip()
+    segments = [
+        {"start": s.get("start"), "end": s.get("end"), "text": (s.get("text") or "").strip()}
+        for s in raw.get("segments") or []
+    ]
+    if is_hallucinated_silence(text):
+        print(f"xbrain-transcribe-mlx: discarding known no-speech artefact ({text!r})",
+              file=sys.stderr)
+        text, segments = "", []
+    return {
+        "text": text,
+        "language": raw.get("language"),
+        "segments": segments,
+        "has_speech": bool(text),
+    }
+
+
+def main() -> int:
+    out_dir, model, media = parse_args(sys.argv[1:])
+    if not media:
+        print("xbrain-transcribe-mlx: no media file given", file=sys.stderr)
+        return 2
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    target = out / f"{Path(media).stem}.json"
+
+    if confirmed_no_audio(media):
+        target.write_text(
+            json.dumps({"text": "", "language": None, "segments": [], "has_speech": False})
+        )
+        return 0
+
+    language = (os.environ.get("WHISPER_LANGUAGE") or "").strip()
+    if language.lower() in ("auto", ""):
+        language = ""  # let the model detect
+    raw = run_mlx(media, resolve_repo(model), language)
+    if raw is None:
+        return 1  # NOT a transcription failure — an unusable backend. The router falls back.
+
+    target.write_text(json.dumps(normalise(raw), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/xbrain-transcribe-whisper
+++ b/scripts/xbrain-transcribe-whisper
@@ -28,9 +28,20 @@ import sys
 from pathlib import Path
 
 WHISPER_MODELS = {
-    "tiny", "base", "small", "medium", "large", "turbo",
-    "tiny.en", "base.en", "small.en", "medium.en",
-    "large-v1", "large-v2", "large-v3", "large-v3-turbo",
+    "tiny",
+    "base",
+    "small",
+    "medium",
+    "large",
+    "turbo",
+    "tiny.en",
+    "base.en",
+    "small.en",
+    "medium.en",
+    "large-v1",
+    "large-v2",
+    "large-v3",
+    "large-v3-turbo",
 }
 
 
@@ -71,9 +82,20 @@ def _confirmed_no_audio(media: str) -> bool:
     if not ffprobe or not media:
         return False
     probe = subprocess.run(
-        [ffprobe, "-v", "error", "-select_streams", "a",
-         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
-        capture_output=True, text=True,
+        [
+            ffprobe,
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_type",
+            "-of",
+            "csv=p=0",
+            media,
+        ],
+        capture_output=True,
+        text=True,
     )
     if probe.returncode != 0:
         return False
@@ -88,15 +110,18 @@ def main() -> int:
     while i < len(args):
         a = args[i]
         if a == "--output-dir" and i + 1 < len(args):
-            out_dir = args[i + 1]; i += 2
+            out_dir = args[i + 1]
+            i += 2
         elif a == "--model" and i + 1 < len(args):
-            model = args[i + 1]; i += 2
+            model = args[i + 1]
+            i += 2
         elif a == "--output-format" and i + 1 < len(args):
             i += 2  # siempre emitimos json
         elif a.startswith("--"):
             i += 2 if i + 1 < len(args) and not args[i + 1].startswith("--") else 1
         else:
-            positional.append(a); i += 1
+            positional.append(a)
+            i += 1
     if positional:
         media = positional[-1]
     if not media:
@@ -114,8 +139,18 @@ def main() -> int:
     # itself. The default is Spanish because that is what this wrapper was written
     # for, but forcing Spanish onto a clip whose language is UNKNOWN would just
     # reproduce, in the other direction, the bug it exists to fix.
-    argv = ["whisper", media, "--model", model,
-            "--output_format", "json", "--output_dir", str(out), "--verbose", "False"]
+    argv = [
+        "whisper",
+        media,
+        "--model",
+        model,
+        "--output_format",
+        "json",
+        "--output_dir",
+        str(out),
+        "--verbose",
+        "False",
+    ]
     if language and language.lower() != "auto":
         argv += ["--language", language]
     rc = subprocess.run(argv).returncode
@@ -125,11 +160,11 @@ def main() -> int:
     src = out / f"{Path(media).stem}.json"
     if not src.exists():
         if _confirmed_no_audio(media):
-            src.write_text(json.dumps(
-                {"text": "", "language": None, "segments": [], "has_speech": False}))
+            src.write_text(
+                json.dumps({"text": "", "language": None, "segments": [], "has_speech": False})
+            )
             return 0
-        print(f"xbrain-transcribe-whisper: whisper produced no output for {media}",
-              file=sys.stderr)
+        print(f"xbrain-transcribe-whisper: whisper produced no output for {media}", file=sys.stderr)
         return 1
 
     raw = json.loads(src.read_text())
@@ -139,15 +174,23 @@ def main() -> int:
         for s in raw.get("segments", [])
     ]
     if _is_hallucinated_silence(text):
-        print(f"xbrain-transcribe-whisper: discarding known no-speech artefact "
-              f"({text!r}) for {media}", file=sys.stderr)
+        print(
+            f"xbrain-transcribe-whisper: discarding known no-speech artefact "
+            f"({text!r}) for {media}",
+            file=sys.stderr,
+        )
         text, segments = "", []
-    src.write_text(json.dumps({
-        "text": text,
-        "language": raw.get("language"),
-        "segments": segments,
-        "has_speech": bool(text),
-    }, ensure_ascii=False))
+    src.write_text(
+        json.dumps(
+            {
+                "text": text,
+                "language": raw.get("language"),
+                "segments": segments,
+                "has_speech": bool(text),
+            },
+            ensure_ascii=False,
+        )
+    )
     return 0
 
 

--- a/scripts/xbrain-transcribe-whisper
+++ b/scripts/xbrain-transcribe-whisper
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""xbrain `[transcribe].command` alternativo — OpenAI Whisper (multilingüe real).
+
+Mismo contrato que `xbrain-transcribe` (parakeet): xbrain invoca
+`<cmd> [--model M] --output-format json --output-dir <DIR> <media>` y lee el
+primer `*.json` no vacío de `<DIR>`. Este wrapper traduce esa invocación al CLI
+de `whisper` (brew openai-whisper) y normaliza su JSON al shape que espera
+xbrain ({text, language, segments, has_speech}).
+
+Motivo: parakeet-tdt (v2 y v3) decodifica mal el audio en ESPAÑOL (salida
+inglesa rota, verificado 17-jul-2026 con clip de TV es-ES); whisper `small` lo
+transcribe limpio. Para media en español usa este wrapper:
+
+  config.toml → [transcribe] command = "~/.local/bin/xbrain-transcribe-whisper"
+  o por entorno:  XBRAIN_PARAKEET="xbrain-transcribe-whisper" (multi-token OK)
+
+Idioma: WHISPER_LANGUAGE (default: Spanish). Modelo: `--model` de la invocación
+si es un modelo whisper válido, si no WHISPER_MODEL (default: small).
+Silencio: si whisper no produce texto y ffprobe confirma que no hay pista de
+audio → JSON de empty-speech (has_speech=false), igual que el wrapper parakeet.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+WHISPER_MODELS = {
+    "tiny", "base", "small", "medium", "large", "turbo",
+    "tiny.en", "base.en", "small.en", "medium.en",
+    "large-v1", "large-v2", "large-v3", "large-v3-turbo",
+}
+
+
+# Whisper's canned hallucinations on audio with NO speech (silence, music, room
+# tone). Its training data was subtitle files, so on empty audio it emits the
+# boilerplate those files end with. This is not a theory: item 2082467662735507767
+# in the store is a screen recording whose entire "transcript" is the Amara credit
+# line, recorded with has_speech=true and passed downstream as something said.
+#
+# `ffprobe` cannot catch these — the file HAS an audio stream, it just has no
+# speech in it. Matching is on the WHOLE stripped transcript, never a substring:
+# a real video that says nothing but a subtitle credit does not meaningfully
+# exist, whereas one that MENTIONS Amara or thanks its viewers certainly does.
+_NO_SPEECH_ARTEFACTS = {
+    "subtítulos realizados por la comunidad de amara.org",
+    "subtítulos por la comunidad de amara.org",
+    "subtitulos realizados por la comunidad de amara.org",
+    "más videos en amara.org",
+    "subtitles by the amara.org community",
+    "thanks for watching!",
+    "thank you for watching!",
+    "thank you.",
+    "you",
+    "♪♪♪",
+    "[música]",
+    "[music]",
+    "(music)",
+}
+
+
+def _is_hallucinated_silence(text: str) -> bool:
+    """True when the WHOLE transcript is one of whisper's no-speech artefacts."""
+    return text.strip().strip('"“”').lower() in _NO_SPEECH_ARTEFACTS
+
+
+def _confirmed_no_audio(media: str) -> bool:
+    ffprobe = shutil.which("ffprobe")
+    if not ffprobe or not media:
+        return False
+    probe = subprocess.run(
+        [ffprobe, "-v", "error", "-select_streams", "a",
+         "-show_entries", "stream=codec_type", "-of", "csv=p=0", media],
+        capture_output=True, text=True,
+    )
+    if probe.returncode != 0:
+        return False
+    return "audio" not in probe.stdout
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    out_dir, model, media = ".", None, ""
+    i = 0
+    positional = []
+    while i < len(args):
+        a = args[i]
+        if a == "--output-dir" and i + 1 < len(args):
+            out_dir = args[i + 1]; i += 2
+        elif a == "--model" and i + 1 < len(args):
+            model = args[i + 1]; i += 2
+        elif a == "--output-format" and i + 1 < len(args):
+            i += 2  # siempre emitimos json
+        elif a.startswith("--"):
+            i += 2 if i + 1 < len(args) and not args[i + 1].startswith("--") else 1
+        else:
+            positional.append(a); i += 1
+    if positional:
+        media = positional[-1]
+    if not media:
+        print("xbrain-transcribe-whisper: no media file given", file=sys.stderr)
+        return 2
+
+    # Un --model de parakeet (p.ej. mlx-community/...) no es un modelo whisper: se ignora.
+    if model not in WHISPER_MODELS:
+        model = os.environ.get("WHISPER_MODEL", "small")
+    language = os.environ.get("WHISPER_LANGUAGE", "Spanish")
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    # WHISPER_LANGUAGE="auto" (or empty) omits --language so whisper detects for
+    # itself. The default is Spanish because that is what this wrapper was written
+    # for, but forcing Spanish onto a clip whose language is UNKNOWN would just
+    # reproduce, in the other direction, the bug it exists to fix.
+    argv = ["whisper", media, "--model", model,
+            "--output_format", "json", "--output_dir", str(out), "--verbose", "False"]
+    if language and language.lower() != "auto":
+        argv += ["--language", language]
+    rc = subprocess.run(argv).returncode
+    if rc != 0:
+        return rc
+
+    src = out / f"{Path(media).stem}.json"
+    if not src.exists():
+        if _confirmed_no_audio(media):
+            src.write_text(json.dumps(
+                {"text": "", "language": None, "segments": [], "has_speech": False}))
+            return 0
+        print(f"xbrain-transcribe-whisper: whisper produced no output for {media}",
+              file=sys.stderr)
+        return 1
+
+    raw = json.loads(src.read_text())
+    text = (raw.get("text") or "").strip()
+    segments = [
+        {"start": s.get("start"), "end": s.get("end"), "text": (s.get("text") or "").strip()}
+        for s in raw.get("segments", [])
+    ]
+    if _is_hallucinated_silence(text):
+        print(f"xbrain-transcribe-whisper: discarding known no-speech artefact "
+              f"({text!r}) for {media}", file=sys.stderr)
+        text, segments = "", []
+    src.write_text(json.dumps({
+        "text": text,
+        "language": raw.get("language"),
+        "segments": segments,
+        "has_speech": bool(text),
+    }, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -32,6 +32,7 @@ from xbrain.extract.extractor import RateLimitTruncated, extract_source
 from xbrain.extract.threads import expand_threads
 from xbrain.extract.graphql import items_needing_refetch
 from xbrain.fetch import (
+    FIRECRAWL_CREDENTIAL_PATHS,
     RetryPlan,
     fetch_pending,
     firecrawl_available,
@@ -611,14 +612,17 @@ def _echo_retry_plan(plan: RetryPlan, *, has_key: bool) -> None:
     reasons = ", ".join(f"{n} {reason}" for reason, n in sorted(plan.reasons.items()))
     typer.echo(f"Reintentables: {len(plan.retryable)} items" + (f" ({reasons})" if reasons else ""))
     if plan.blocked_on_firecrawl:
+        looked_in = "\n".join(f"    - {p}" for p in FIRECRAWL_CREDENTIAL_PATHS)
         typer.echo(
-            f"BLOQUEADOS por falta de FIRECRAWL_API_KEY: {len(plan.blocked_on_firecrawl)} items "
+            f"BLOQUEADOS por falta de clave Firecrawl: {len(plan.blocked_on_firecrawl)} items "
             "con fallos js_required/empty_content que NUNCA llegaron a pasar por el fallback "
-            "(attempts=1). Sin la clave, reintentarlos repite el mismo fallo. Configúrala y "
-            "vuelve a ejecutar."
+            "(attempts=1). Sin la clave, reintentarlos repite el mismo fallo.\n"
+            "  Se ha buscado en $FIRECRAWL_API_KEY y en las credenciales del CLI:\n"
+            f"{looked_in}\n"
+            "  Configúrala (o ejecuta `firecrawl login`) y vuelve a ejecutar."
         )
     elif has_key:
-        typer.echo("FIRECRAWL_API_KEY configurada — el fallback JS entra en los reintentos.")
+        typer.echo("Clave Firecrawl resuelta — el fallback JS entra en los reintentos.")
     typer.echo(
         f"Terminales (ningún extractor los arregla): {len(plan.terminal)} items. "
         "Su nota de guardarraíl ya nombra la causa."

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -2425,6 +2425,16 @@ def verify_entities_command(
         f"({summary['entities']} entidades); "
         f"{summary['unanimous_pass_but_ungrounded']} de ellas con PASS UNÁNIME de los jueces."
     )
+    # The uncertain tier gets its own line rather than being folded into the headline:
+    # it has lower precision, and merging it would let a reader quote one number for two
+    # instruments. Printed unconditionally when non-empty, because a finding the check
+    # made and the terminal never showed is the failure mode this exists to close.
+    if summary["uncertain_only_flagged"]:
+        typer.echo(
+            f"+ {summary['uncertain_only_flagged']} outputs cuyo ÚNICO indicio es del tier "
+            f"incierto (mayúscula ambigua, típicamente a principio de frase): menor "
+            f"precisión, y es donde se esconde un nombre inventado al abrir un resumen."
+        )
     typer.echo(f"Report: {cfg.data_dir / 'entity-report.md'}")
 
 

--- a/src/xbrain/dashboard.py
+++ b/src/xbrain/dashboard.py
@@ -31,6 +31,7 @@ from xbrain.models import (
     MediaVideoPending,
     TopicPage,
 )
+from xbrain.verification import ALL_TARGETS, fingerprint_output, verdict_is_current
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,8 @@ _VIDEO_TYPES = (MediaVideoPending, MediaVideoDownloaded, MediaVideoFailed)
 # corpus of described photos vanishes from the dashboard. Mirrors the isinstance
 # grouping in `generate._render_media_lines`.
 _DOWNLOADED_PHOTO_TYPES = (MediaPhotoDownloaded, MediaPhotoDescribed)
+# Verdicts reported on the dashboard, worst last so the bar reads left to right.
+_VERDICT_ORDER = ("PASS", "REVIEW", "FAIL")
 
 
 def humanize_topic(slug: str) -> str:
@@ -346,6 +349,46 @@ _META_LONGFORM_KEYS = (
 )
 
 
+def _verification(items: list[Item], language: str) -> dict[str, Any]:
+    """Coverage and verdict mix of the LLM-as-judge pass (`xbrain verify`).
+
+    Counts OUTPUTS, not items: one post can carry a summary, a topics assignment
+    and a video digest, and each is judged separately against its own source.
+
+    A stored verdict counts as coverage only while it is CURRENT. Re-generating
+    the output it judged (or changing the rubric or the source) invalidates it,
+    and a stale verdict says nothing about what a reader sees today — so it is
+    reported in its own bucket instead of being folded into the verdict mix.
+    Reading `judged` as "verified" without `unjudged` next to it is exactly the
+    misreading this block exists to prevent, which is why coverage ships as a
+    percentage of the whole population rather than as a bare count.
+    """
+    outputs = 0
+    current: "Counter[str]" = Counter()
+    stale = 0
+    for item in items:
+        for target in ALL_TARGETS:
+            if fingerprint_output(item, target) is None:
+                continue
+            outputs += 1
+            verdict = (item.verification or {}).get(target)
+            if verdict is None:
+                continue
+            if verdict_is_current(item, target, language):
+                current[verdict.verdict] += 1
+            else:
+                stale += 1
+    judged = sum(current.values())
+    return {
+        "outputs": outputs,
+        "judged": judged,
+        "unjudged": outputs - judged,
+        "stale": stale,
+        "coverage_pct": round(judged / outputs * 100, 1) if outputs else 0.0,
+        "verdicts": {v: current.get(v, 0) for v in _VERDICT_ORDER},
+    }
+
+
 def _meta(
     items: list[Item],
     topic_freq: "Counter[str]",
@@ -374,12 +417,15 @@ def compute_dashboard_data(
     id2note: dict[str, str],
     thumbs: list[dict[str, Any]],
     updated: str,
+    language: str,
 ) -> dict[str, Any]:
     """Assemble the full JSON blob the dashboard template consumes.
 
     Pure: no file or network IO (photo thumbnails are computed by
     `collect_thumbnails` and injected via `thumbs`). `updated` is a display
-    string (the caller stamps the generation date).
+    string (the caller stamps the generation date). `language` is the configured
+    output language — the verification block needs it because a verdict is bound
+    to the rubric contract it was judged under, and that contract is per-language.
     """
     growth = _growth(items)
     per_month: dict[str, list[Item]] = growth.pop("_per_month")
@@ -419,6 +465,7 @@ def compute_dashboard_data(
             "samples": _recent(rows(photo_posts), 6),
         },
         "videos": {"count": media["videos"], "items": _videos(items, id2note)},
+        "verification": _verification(items, language),
         "sources": {
             "bookmark": {"count": len(bookmark_items), "samples": _recent(rows(bookmark_items), 6)},
             "own_tweet": {"count": len(own_items), "samples": _recent(rows(own_items), 6)},

--- a/src/xbrain/entity_grounding.py
+++ b/src/xbrain/entity_grounding.py
@@ -181,6 +181,26 @@ _LEXICON = {
 }
 _LEXICON |= {v: k for k, v in _LEXICON.items()}  # both directions
 
+# Names the corpus renders with SEVERAL shapes on the other side, so a 1:1 pair cannot
+# carry them. `Estados Unidos` is the single most-flagged entity in the store (12 of 239
+# confident flags, 5%) and NOT ONE of those sources says "united states" — they say `usa`,
+# `u.s`, `america`, or bare `us`.
+#
+# `us` is deliberately absent. It would ground the name off the English pronoun, present in
+# almost every transcript, which does not fix a false alarm — it blinds the check to every
+# invented mention of the country. This module resolves ambiguity towards flagging, so the
+# 8 sources whose only evidence is bare `us` stay flagged and stay wrong. Grounding those
+# needs case-sensitive matching against the unfolded evidence, which ASR (all lowercase)
+# cannot support anyway.
+_LEXICON_MULTI: dict[str, frozenset[str]] = {
+    "estadosunidos": frozenset({"unitedstates", "usa", "america"}),
+    "corea": frozenset({"korea"}),
+    "alemania": frozenset({"germany"}),
+}
+_LEXICON_MULTI |= {  # both directions, same as the 1:1 table
+    form: frozenset({key}) for key, forms in dict(_LEXICON_MULTI).items() for form in forms
+}
+
 # Not names at all: units, currencies, file formats, quarters, generic acronyms. Flagging
 # them is pure noise, and a report drowned in noise stops being read — which is its own kind
 # of false negative. The other class no threshold touches.
@@ -203,10 +223,23 @@ def _norm_tokens(text: str) -> list[str]:
     return _WORD.findall(_POSSESSIVE.sub("", fold(text)))
 
 
+# Speech disfluencies the ASR transcribes literally. They land INSIDE names — the evidence
+# for `Application Default Credentials` reads "the application default uh credential" — and
+# a name is matched as a contiguous window, so one filler is enough to break it: no window
+# of the transcript ever spells the name. Dropped from the EVIDENCE side only. The output
+# is written text and has none of these; stripping them there would corrupt real names.
+_DISFLUENCIES = frozenset({"uh", "um", "erm", "eh", "hmm", "mmm", "ah", "er"})
+
+
+def _evidence_tokens(text: str) -> list[str]:
+    """Evidence tokens with speech disfluencies removed — see `_DISFLUENCIES`."""
+    return [t for t in _norm_tokens(_expand_compounds(text)) if t not in _DISFLUENCIES]
+
+
 def _translations(squashed: str) -> set[str]:
-    """The name as the OTHER language would render it, if we know the pair."""
+    """The name as the OTHER language would render it, if we know the pair(s)."""
     hit = _LEXICON.get(squashed)
-    return {hit} if hit else set()
+    return ({hit} if hit else set()) | set(_LEXICON_MULTI.get(squashed, ()))
 
 
 def _depluralise(token: str) -> str:
@@ -236,6 +269,14 @@ def _variants(tokens: list[str]) -> set[str]:
     plain = [_depluralise(t) for t in tokens]
     forms = {"".join(tokens), "".join(plain), "".join(t[0] for t in plain if t)}
     forms |= _translations("".join(plain)) | _translations("".join(tokens))
+    # Spanish puts the adjective after the noun and English before it, so a translated
+    # two-part name arrives REVERSED: `Revolución Industrial` against evidence that says
+    # "industrial revolution". Reversing the tokens is the whole rule — it needs no lexicon
+    # entry and generalises to every pair the corpus has not produced yet. Bounded to short
+    # names because beyond that the permutation stops being a translation and starts being
+    # a different phrase that happens to share words.
+    if 2 <= len(plain) <= 3:
+        forms |= {"".join(reversed(tokens)), "".join(reversed(plain))}
     if len(plain) <= 4:  # 2^4 shapes — bounded, and real handles are short
         for mask in range(1 << len(plain)):
             forms.add("".join(t if mask >> i & 1 else t[0] for i, t in enumerate(plain)))
@@ -286,13 +327,21 @@ def is_grounded(entity: str, evidence: str) -> bool:
     ent = _norm_tokens(entity)
     if not ent:
         return False
-    ev = _norm_tokens(_expand_compounds(evidence))
+    ev = _evidence_tokens(evidence)
     if not ev:
         return False
     forms = _variants(ent)
+    # A form of 1-3 characters may only match a SINGLE evidence token. Squashing erases
+    # word boundaries, so a short form collides with the joint of two ordinary words:
+    # "gives us a much better" contains the window `us`+`a` = "usa", which grounded
+    # `Estados Unidos` off a pronoun and an article. Same shape as `_FUZZY_MIN_LEN` —
+    # below a few characters, a match is coincidence rather than evidence.
+    short, long = {f for f in forms if len(f) <= 3}, {f for f in forms if len(f) > 3}
+    if short & _windows(ev, 1):
+        return True
     # Exact/variant: any squashed window of 1..len+1 tokens equal to any form of the name.
     for size in range(1, min(len(ent) + 2, len(ev) + 1)):
-        if forms & _windows(ev, size):
+        if long & _windows(ev, size):
             return True
     # Acronym→expansion: `HIIT` vs "high intensity interval training".
     squashed = "".join(_depluralise(t) for t in ent)
@@ -300,9 +349,16 @@ def is_grounded(entity: str, evidence: str) -> bool:
         acronyms = {"".join(w[0] for w in ev[i : i + size]) for i in range(len(ev) - size + 1)}
         if squashed in acronyms:
             return True
-    # ASR corruption: `Mustafa Suleyman` vs "mustafa sullivan".
-    raw = "".join(ent)
-    return _fuzzy_hit(raw, _windows(ev, len(ent)) | _windows(ev, max(1, len(ent) - 1)))
+    # ASR corruption: `Mustafa Suleyman` vs "mustafa sullivan". The REVERSED form is fuzzed
+    # too, and the two rules compose into the translated-name case that neither solves
+    # alone: reversal puts `Revolución Industrial` in the evidence's order, and the fuzzy
+    # threshold absorbs the one word that is actually a different language
+    # ("industrialrevolucion" vs "industrialrevolution").
+    windows = _windows(ev, len(ent)) | _windows(ev, max(1, len(ent) - 1))
+    raws = {"".join(ent)}
+    if 2 <= len(ent) <= 3:
+        raws.add("".join(reversed(ent)))
+    return any(_fuzzy_hit(raw, windows) for raw in raws)
 
 
 def _is_version_code(core: str) -> bool:

--- a/src/xbrain/entity_grounding.py
+++ b/src/xbrain/entity_grounding.py
@@ -590,12 +590,26 @@ def _is_unanimous_pass(record: dict) -> bool:
 
 def summarise_scan(records: list[EntityRecord], verdicts: dict[str, dict]) -> dict:
     """The headline numbers, including the one the ensemble cannot see about itself."""
+    # The UNCERTAIN tier, counted before the headline filter narrows to confident flags.
+    # A candidate is uncertain when its position makes the capital ambiguous — chiefly
+    # sentence-initial, where Spanish orthography capitalises the first word whether or
+    # not it is a name. That is precisely where this corpus puts names: summaries open
+    # with them ("Suhail afirma…", "Ethan Mollick destaca…"). The one fabricated name the
+    # LLM judges caught lived in this tier, ungrounded, while the terminal line and the
+    # report table showed neither — so the check HAD the finding and no reader could see
+    # it. Reported separately rather than merged, because the tiers have different
+    # precision and averaging them would hide both.
+    uncertain_only = [r for r in records if r.uncertain and not r.ungrounded]
+    uncertain_total = sum(len(r.uncertain) for r in records)
+
     records = [r for r in records if r.ungrounded]  # headline counts CONFIDENT flags only
     judged = [r for r in records if r.item_id in verdicts]
     missed = [r for r in judged if _is_unanimous_pass(verdicts[r.item_id])]
     return {
         "flagged": len(records),
         "entities": sum(len(r.ungrounded) for r in records),
+        "uncertain_only_flagged": len(uncertain_only),
+        "uncertain_entities": uncertain_total,
         "judged_by_ensemble": len(judged),
         "unanimous_pass_but_ungrounded": len(missed),
         # NOT "false negatives": at the precision this check has been measured at, most of
@@ -645,4 +659,25 @@ def render_entity_report(
         for r in records
         if r.ungrounded
     ]
+    uncertain_only = [r for r in records if r.uncertain and not r.ungrounded]
+    if uncertain_only:
+        lines += [
+            "",
+            f"## Uncertain tier — {summary['uncertain_only_flagged']} outputs "
+            f"({summary['uncertain_entities']} candidates across all records)",
+            "",
+            "> A candidate lands here when its POSITION makes the capital ambiguous — "
+            "chiefly sentence-initial, where Spanish capitalises the first word whether or "
+            "not it is a name. Lower precision than the table above by construction, and "
+            "listed anyway: this corpus opens summaries with the subject's name, so the "
+            "tier is where fabricated names are most likely to hide. Judge these, do not "
+            "count them.",
+            "",
+            "| item | author | uncertain candidates |",
+            "| --- | --- | --- |",
+            *(
+                f"| `{r.item_id}` | @{r.handle} | {', '.join(r.uncertain)} |"
+                for r in uncertain_only
+            ),
+        ]
     return json.dumps(payload, indent=2, ensure_ascii=False), "\n".join(lines) + "\n"

--- a/src/xbrain/extract/article.py
+++ b/src/xbrain/extract/article.py
@@ -7,8 +7,24 @@ This module turns that payload into the ordered `list[ArticleBlock]` carried on
 `ContentSourceSuccess.blocks` (#39 PR3): text runs become `ArticleTextBlock`
 (with `## `/`- ` markdown prefixes baked in for headings/lists), inline images
 become `ArticleImageBlock`s wrapping a `MediaPhotoPending` (so the existing
-`xbrain media` engine downloads them later, PR4), IN DOCUMENT ORDER. The lead
-`cover_media` image is prepended as the first block.
+`xbrain media` engine downloads them later, PR4), and inline VIDEO becomes an
+`ArticleVideoBlock` wrapping a `MediaVideoPending`, IN DOCUMENT ORDER. The lead
+`cover_media` (image or video) is prepended as the first block.
+
+NOTHING IS DROPPED SILENTLY. Two whole classes of content used to be, and both
+were invisible in the note rather than reported — measured over 23 real Articles:
+
+  - **video**, because `MEDIA` was assumed to mean photo. An `ApiVideo` keeps its
+    poster one level deeper (`media_info.preview_image.original_img_url`) and its
+    bitrate under `bit_rate`, not the `bitrate` a tweet uses — so the lookup
+    returned nothing and the block went to the drop log.
+  - **entity-borne text**: 20 `MARKDOWN` (whole code listings), 48 `DIVIDER`
+    (section rules), 1 `TWEET` (an embedded post). Their block is `atomic` with
+    `text: " "`, which fails `.strip()`, so the "no text run ⇒ no content"
+    assumption deleted them. `_entity_text` recovers these, and sweeps unknown
+    entity types carrying `markdown`/`text`/`html` for the same reason the wall
+    detector over-rejects: surfacing something skippable costs a line, dropping
+    content is permanent and invisible.
 
 VALIDATION / RESILIENCE: the key path is validated against three REAL captured
 bookmarked-Article GraphQL payloads (`tests/test_article_real.py` +
@@ -37,26 +53,39 @@ import json
 import logging
 from typing import Any, TypeGuard
 
+from xbrain.extract.video import build_video_media
 from xbrain.models import (
     ARTICLE_PARAGRAPH_SEP,
     ArticleBlock,
     ArticleImageBlock,
     ArticleTextBlock,
+    ArticleVideoBlock,
     MediaPhotoPending,
+    MediaVideoPending,
 )
+
+# The two pending media states an article body can carry. `_media_index` resolves
+# a `mediaId` to one of them, and `_media_block` wraps it in the matching block
+# variant — so "is this a photo or a video" is decided ONCE, at the index, from
+# the payload's own shape, not re-guessed at every use site.
+MediaPending = MediaPhotoPending | MediaVideoPending
 
 logger = logging.getLogger(__name__)
 
 # Draft.js entity `type`s that denote an inline image (case-insensitive). A
 # LINK / TWEET / MENTION entity is explicitly NOT one, so an inline-link
 # paragraph keeps its text rather than being mistaken for an image.
-_IMAGE_ENTITY_TYPES = frozenset({"IMAGE", "MEDIA"})
+_MEDIA_ENTITY_TYPES = frozenset({"IMAGE", "MEDIA"})
 # Ordered key names that may carry an image's CDN URL directly on the entity /
 # media-item `data` (the defensive/constructed shape; the live shape resolves
 # via `media_entities` instead). Anchoring on the key name keeps it drift-tolerant.
 _IMAGE_URL_KEYS = ("media_url_https", "mediaUrl", "media_url", "mediaURL", "url")
 # Ordered key names that may carry an image's alt text.
 _ALT_KEYS = ("altText", "alt_text", "alt", "description")
+# Ordered key names under an entity's `data` that may carry its TEXT, for a block
+# whose own `text` run is empty (see `_entity_text`). `markdown` first: it is the
+# real key on the live shape, and the others are drift tolerance.
+_ENTITY_TEXT_KEYS = ("markdown", "text", "html")
 
 # Draft.js block `type`s whose text run carries a markdown prefix, baked into
 # the run AFTER the `\n\n` separator so the flattened-text invariant still holds
@@ -91,7 +120,7 @@ def parse_article_content_state(payload: Any) -> tuple[str | None, list[ArticleB
     media_index = _media_index(container)
     blocks = _build_blocks(raw_blocks, entity_by_key, media_index)
     blocks = _prepend_cover(blocks, container)
-    _warn_if_media_unresolved(raw_blocks, container, media_index, blocks)
+    _warn_if_media_unresolved(raw_blocks, entity_by_key, container, media_index, blocks)
     return _find_title(payload), blocks
 
 
@@ -194,7 +223,14 @@ def _entity_by_key(content_state: dict[str, Any]) -> dict[str, Any]:
 
 
 def _media_info_url(node: Any) -> str | None:
-    """The `media_info.original_img_url` CDN URL on a media node, or None.
+    """The still-image CDN URL on a media node, or None.
+
+    Two real shapes: a PHOTO stores it at `media_info.original_img_url`; a VIDEO
+    (`__typename: "ApiVideo"`) has no such key and stores its poster one level
+    deeper, at `media_info.preview_image.original_img_url`. Reading only the
+    first is what dropped every embedded video from an article body — the
+    lookup returned None, the entity resolved to nothing, and the block was
+    logged as a drop.
 
     Shared by the inline `media_entities[]` index and the `cover_media` reader.
     Null-safe: a missing `media_info` / URL (or a non-http value) yields None.
@@ -202,23 +238,77 @@ def _media_info_url(node: Any) -> str | None:
     if not isinstance(node, dict):
         return None
     info = node.get("media_info")
-    if isinstance(info, dict):
-        url = info.get("original_img_url")
-        if isinstance(url, str) and url.startswith("http"):
-            return url
+    if not isinstance(info, dict):
+        return None
+    for holder in (info, info.get("preview_image")):
+        if isinstance(holder, dict):
+            url = holder.get("original_img_url")
+            if isinstance(url, str) and url.startswith("http"):
+                return url
     return None
 
 
-def _media_index(container: dict[str, Any] | None) -> dict[str, str]:
-    """Map `str(media_id)` → CDN URL from the container's `media_entities[]`.
+def _video_media(node: Any) -> MediaVideoPending | None:
+    """Build a playable `MediaVideoPending` from a `media_entities[]` VIDEO entry.
 
-    A `MEDIA` entity carries only a `mediaId`; the CDN URL lives on the sibling
-    `media_entities[]` array keyed by `media_id`. This builds that lookup so
-    `_item_url` can turn a `mediaId` into a real image URL. Keys are stringified
-    so an int `media_id` and a str `mediaId` still match. Null-safe: a missing /
-    non-list `media_entities` yields an empty index.
+    An article video carries the same `variants` array as a tweet video, just
+    under `media_info` instead of `video_info` — so the entry is re-keyed and
+    handed to the SHARED `build_video_media`, keeping the "highest-bitrate mp4,
+    else the HLS manifest" rule in one place rather than reimplementing it here
+    (that centralisation is `extract.video`'s stated reason to exist).
+
+    Returns None for a photo (no `variants`), so the caller can fall through to
+    the image path. An EMPTY `variants` list counts as "not a video" for the same
+    reason: `build_video_media` falls back to `media_url_https` when it finds no
+    playable stream, and here that key holds the POSTER — so a variant-less entry
+    would yield a "video" whose url is a JPEG, rendered as a `🎥 Ver vídeo` link
+    to a still. Falling through to the image path is both truthful and useful.
     """
-    index: dict[str, str] = {}
+    if not isinstance(node, dict):
+        return None
+    info = node.get("media_info")
+    if not isinstance(info, dict) or not info.get("variants"):
+        return None
+    if not isinstance(info["variants"], list):
+        return None
+    return build_video_media(
+        {
+            "video_info": {**info, "variants": [_normalise_variant(v) for v in info["variants"]]},
+            "media_url_https": _media_info_url(node),
+        },
+    )
+
+
+def _normalise_variant(variant: Any) -> Any:
+    """Rename an article variant's `bit_rate` to the `bitrate` `select_variant` reads.
+
+    The two X shapes disagree on ONE character: a tweet's
+    `video_info.variants[]` uses `bitrate`, an article's `media_info.variants[]`
+    uses `bit_rate`. Without this, every article video silently resolved to the
+    FIRST mp4 in the list (measured: a 480x270 stream where a 1920x1080 one was
+    offered) because `max(..., key=lambda v: v.get("bitrate") or 0)` compared a
+    list of zeros. It kept working, just badly — which is why it needed a real
+    payload to catch.
+    """
+    if not isinstance(variant, dict) or "bitrate" in variant or "bit_rate" not in variant:
+        return variant
+    renamed = {k: v for k, v in variant.items() if k != "bit_rate"}
+    renamed["bitrate"] = variant["bit_rate"]
+    return renamed
+
+
+def _media_index(container: dict[str, Any] | None) -> dict[str, MediaPending]:
+    """Map `str(media_id)` → the resolved media from the container's `media_entities[]`.
+
+    A `MEDIA` entity carries only a `mediaId`; the payload lives on the sibling
+    `media_entities[]` array keyed by `media_id`. This builds that lookup so
+    `_item_media` can turn a `mediaId` into a real photo OR video. Keys are
+    stringified so an int `media_id` and a str `mediaId` still match. Video is
+    checked FIRST: a video entry also has a poster image, and resolving it as a
+    photo would silently demote a demo clip to a still frame. Null-safe: a
+    missing / non-list `media_entities` yields an empty index.
+    """
+    index: dict[str, MediaPending] = {}
     if not isinstance(container, dict):
         return index
     entities = container.get("media_entities")
@@ -228,105 +318,171 @@ def _media_index(container: dict[str, Any] | None) -> dict[str, str]:
         if not isinstance(entity, dict):
             continue
         media_id = entity.get("media_id")
+        if media_id is None:
+            continue
+        video = _video_media(entity)
+        if video is not None:
+            index[str(media_id)] = video
+            continue
         url = _media_info_url(entity)
-        if media_id is not None and url:
-            index[str(media_id)] = url
+        if url:
+            index[str(media_id)] = MediaPhotoPending(url=url)
     return index
 
 
 def _build_blocks(
-    raw_blocks: list[Any], entity_by_key: dict[str, Any], media_index: dict[str, str]
+    raw_blocks: list[Any], entity_by_key: dict[str, Any], media_index: dict[str, MediaPending]
 ) -> list[ArticleBlock]:
-    """Turn Draft.js blocks into ordered `ArticleBlock`s (images + text runs).
+    """Turn Draft.js blocks into ordered `ArticleBlock`s (media + text runs).
 
-    A block that references an image entity is resolved to one or more
-    `ArticleImageBlock`s (a `mediaItems` gallery yields one per resolvable item)
-    and NEVER falls through to the text branch — so a caption-bearing atomic
-    block whose media fails to resolve is logged as a drop rather than silently
-    demoted to text. Headings/list items get their markdown prefix baked in.
+    A block that references a media entity is resolved to one or more image /
+    video blocks (a `mediaItems` gallery yields one per resolvable item) and
+    NEVER falls through to the text branch — so a caption-bearing atomic block
+    whose media fails to resolve is logged as a drop rather than silently demoted
+    to text. Headings/list items get their markdown prefix baked in.
+
+    A block whose text lives on its ENTITY rather than in its `text` run
+    (`MARKDOWN`, `DIVIDER`, `TWEET` — see `_entity_text`) is recovered before the
+    empty-`text` drop: those are real prose, code blocks and embedded tweets, and
+    treating "no text run" as "no content" is what deleted them from the body.
     """
     blocks: list[ArticleBlock] = []
     have_text = False
+
+    def _append_text(value: str) -> None:
+        nonlocal have_text
+        separator = ARTICLE_PARAGRAPH_SEP if have_text else ""
+        blocks.append(ArticleTextBlock(text=separator + value))
+        have_text = True
+
     for raw in raw_blocks:
         if not isinstance(raw, dict):
             continue
         entity = _first_entity(raw, entity_by_key)
-        if _is_image_entity(entity):
-            images, unresolved = _resolve_image_blocks(entity, media_index)
-            if images:
-                blocks.extend(images)
+        if _is_media_entity(entity):
+            media, unresolved = _resolve_media_blocks(entity, media_index)
+            if media:
+                blocks.extend(media)
                 if unresolved:
-                    _log_partial_gallery(len(images), unresolved)
+                    _log_partial_gallery(len(media), unresolved)
             else:
                 _log_dropped_block(raw, entity_by_key)
             continue
         text = raw.get("text")
         if isinstance(text, str) and text.strip():
-            separator = ARTICLE_PARAGRAPH_SEP if have_text else ""
-            blocks.append(ArticleTextBlock(text=separator + _block_prefix(raw.get("type")) + text))
-            have_text = True
+            _append_text(_block_prefix(raw.get("type")) + text)
+            continue
+        recovered = _entity_text(entity)
+        if recovered:
+            _append_text(recovered)
             continue
         _log_dropped_block(raw, entity_by_key)
     return blocks
 
 
-def _is_image_entity(entity: dict[str, Any] | None) -> TypeGuard[dict[str, Any]]:
-    """True when `entity` is an inline-image entity (`IMAGE`/`MEDIA` type).
+def _is_media_entity(entity: dict[str, Any] | None) -> TypeGuard[dict[str, Any]]:
+    """True when `entity` is an inline-media entity (`IMAGE`/`MEDIA` type).
 
     A `TypeGuard` so callers narrow `entity` to a non-optional dict afterwards.
     """
-    return isinstance(entity, dict) and str(entity.get("type", "")).upper() in _IMAGE_ENTITY_TYPES
+    return isinstance(entity, dict) and str(entity.get("type", "")).upper() in _MEDIA_ENTITY_TYPES
 
 
-def _resolve_image_blocks(
-    entity: dict[str, Any], media_index: dict[str, str]
-) -> tuple[list[ArticleImageBlock], int]:
-    """Resolve an image entity to `(image_blocks, unresolved_item_count)`.
+def _media_block(media: MediaPending, alt: str | None) -> ArticleBlock:
+    """Wrap a resolved photo/video in its matching block variant."""
+    if isinstance(media, MediaVideoPending):
+        return ArticleVideoBlock(media=media, alt=alt)
+    return ArticleImageBlock(media=media, alt=alt)
+
+
+def _resolve_media_blocks(
+    entity: dict[str, Any], media_index: dict[str, MediaPending]
+) -> tuple[list[ArticleBlock], int]:
+    """Resolve a media entity to `(media_blocks, unresolved_item_count)`.
 
     Two shapes, tried in order: (1) the REAL X gallery — `data.mediaItems[]`,
-    each item resolved via `_item_url` (its `mediaId` looked up in `media_index`,
-    or a URL stored on the item), yielding ONE `ArticleImageBlock` per resolvable
-    item so a multi-image gallery is not truncated to its first image; a
-    `mediaItems` present but partially/wholly unresolvable does NOT fall through
-    to a stray `data`-level URL (which could be a click-through link) — it reports
-    the miss instead. (2) the defensive shape — no `mediaItems`, so a single URL
-    stored directly on the entity `data` (`media_url_https`, `mediaUrl`, …).
+    each item resolved via `_item_media` (its `mediaId` looked up in
+    `media_index`, or a URL stored on the item), yielding ONE block per
+    resolvable item so a multi-image gallery is not truncated to its first
+    image; a `mediaItems` present but partially/wholly unresolvable does NOT fall
+    through to a stray `data`-level URL (which could be a click-through link) —
+    it reports the miss instead. (2) the defensive shape — no `mediaItems`, so a
+    single URL stored directly on the entity `data` (`media_url_https`,
+    `mediaUrl`, …), which is always a photo (a video is never expressed that way).
     """
     data = entity.get("data")
     if not isinstance(data, dict):
         return [], 0
     items = data.get("mediaItems")
     if isinstance(items, list) and items:
-        images: list[ArticleImageBlock] = []
+        blocks: list[ArticleBlock] = []
         unresolved = 0
         for item in items:
             if not isinstance(item, dict):
                 continue
-            url = _item_url(item, media_index)
-            if url:
-                images.append(
-                    ArticleImageBlock(
-                        media=MediaPhotoPending(url=url), alt=_alt_text(item) or _alt_text(data)
-                    )
-                )
+            media = _item_media(item, media_index)
+            if media is not None:
+                blocks.append(_media_block(media, _alt_text(item) or _alt_text(data)))
             else:
                 unresolved += 1
-        return images, unresolved
+        return blocks, unresolved
     url = _find_url_by_key(data)
     if url:
         return [ArticleImageBlock(media=MediaPhotoPending(url=url), alt=_alt_text(data))], 0
     return [], 0
 
 
-def _item_url(item: dict[str, Any], media_index: dict[str, str]) -> str | None:
-    """One `mediaItems[i]`'s CDN URL: its `mediaId` in `media_index`, else a URL
-    stored directly on the item (the defensive/constructed shape)."""
+def _item_media(item: dict[str, Any], media_index: dict[str, MediaPending]) -> MediaPending | None:
+    """One `mediaItems[i]`'s media: its `mediaId` in `media_index`, else a URL
+    stored directly on the item (the defensive/constructed shape, always a photo)."""
     media_id = item.get("mediaId") or item.get("media_id")
     if media_id is not None:
-        url = media_index.get(str(media_id))
-        if url:
-            return url
-    return _find_url_by_key(item)
+        media = media_index.get(str(media_id))
+        if media is not None:
+            return media
+    url = _find_url_by_key(item)
+    return MediaPhotoPending(url=url) if url else None
+
+
+def _entity_text(entity: dict[str, Any] | None) -> str | None:
+    """Recover the text an entity carries when its BLOCK has no text run, else None.
+
+    X puts several kinds of real content on the entity rather than in the Draft.js
+    `text`; the referencing block is `atomic` with `text: " "`, which fails the
+    `text.strip()` check and used to fall straight into the drop log. Measured on
+    the real corpus over 23 Articles: 20 `MARKDOWN`, 1 `TWEET`, 48 `DIVIDER`.
+
+      - `MARKDOWN` → `data.markdown`, a fenced code block. Whole listings were
+        being deleted from articles that are largely ABOUT their code.
+      - `TWEET` → `data.tweetId`, an embedded post. Only the pointer is in this
+        payload (the quoted body is not), so the canonical URL is what there is
+        to keep — and `x.com/i/status/<id>` is the same handle-less form
+        `extract.graphql` already uses.
+      - `DIVIDER` → an empty `data`: a horizontal rule, i.e. the author's own
+        section break. `---` reproduces it exactly.
+
+    The trailing generic sweep is deliberate drift-tolerance: an entity type we
+    have never seen that carries `markdown`/`text`/`html` is recovered instead of
+    dropped. The asymmetry is the same one that governs the wall detector —
+    surfacing content we could have skipped costs a stray line; dropping content
+    is invisible and permanent. Anything still unrecovered reaches
+    `_log_dropped_block`, so a genuinely new shape is reported, never silent.
+    """
+    if not isinstance(entity, dict):
+        return None
+    entity_type = str(entity.get("type", "")).upper()
+    data = entity.get("data")
+    data = data if isinstance(data, dict) else {}
+    if entity_type == "DIVIDER":
+        return "---"
+    if entity_type == "TWEET":
+        tweet_id = data.get("tweetId") or data.get("tweet_id")
+        return f"https://x.com/i/status/{tweet_id}" if tweet_id else None
+    for key in _ENTITY_TEXT_KEYS:
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
 
 def _block_prefix(block_type: Any) -> str:
@@ -348,35 +504,55 @@ def _prepend_cover(
     """
     if not isinstance(container, dict):
         return blocks
-    url = _media_info_url(container.get("cover_media"))
-    if not url:
+    cover_media = container.get("cover_media")
+    video = _video_media(cover_media)
+    poster = _media_info_url(cover_media)
+    cover: ArticleImageBlock | ArticleVideoBlock
+    if video is not None:
+        cover = ArticleVideoBlock(media=video, alt=None)
+    elif poster:
+        cover = ArticleImageBlock(media=MediaPhotoPending(url=poster), alt=None)
+    else:
         return blocks
+    # Dedup against the POSTER url for a video cover too: the same clip appearing
+    # inline is the same lead media, however each occurrence resolved.
+    identities = {poster, getattr(cover.media, "thumbnail_url", None), cover.media.url} - {None}
     for block in blocks:
-        if isinstance(block, ArticleImageBlock) and block.media.url == url:
-            return blocks
-    cover = ArticleImageBlock(media=MediaPhotoPending(url=url), alt=None)
+        if isinstance(block, (ArticleImageBlock, ArticleVideoBlock)):
+            existing = {getattr(block.media, "thumbnail_url", None), block.media.url}
+            if existing & identities:
+                return blocks
     return [cover, *blocks]
 
 
 def _warn_if_media_unresolved(
     raw_blocks: list[Any],
+    entity_by_key: dict[str, Any],
     container: dict[str, Any] | None,
-    media_index: dict[str, str],
+    media_index: dict[str, MediaPending],
     blocks: list[ArticleBlock],
 ) -> None:
-    """WARN when the payload carried media but the body resolved ZERO images.
+    """WARN when the payload carried media but the body resolved ZERO of it.
 
     The original #39 defect was exactly this: media present (atomic blocks +
     `media_entities` + `cover_media`) yet every image silently dropped. A
     genuinely text-only article (no atomic blocks, no media siblings) is NOT
     flagged — so this fires only on a real media-resolution drift, not on every
     prose-only piece.
+
+    "Had media" is judged by the atomic blocks that reference a MEDIA/IMAGE
+    ENTITY, not by the presence of any atomic block: `MARKDOWN`, `DIVIDER` and
+    `TWEET` are atomic too, so an article that is all prose, code and section
+    breaks used to trip this warning every single time — and a warning that
+    cries wolf on ordinary input is one nobody reads when it is real.
     """
-    if any(isinstance(b, ArticleImageBlock) for b in blocks):
+    if any(isinstance(b, (ArticleImageBlock, ArticleVideoBlock)) for b in blocks):
         return
-    had_atomic = any(isinstance(r, dict) and r.get("type") == "atomic" for r in raw_blocks)
+    had_media_block = any(
+        _is_media_entity(_first_entity(r, entity_by_key)) for r in raw_blocks if isinstance(r, dict)
+    )
     cover = container.get("cover_media") if isinstance(container, dict) else None
-    if had_atomic or media_index or _media_info_url(cover):
+    if had_media_block or media_index or _media_info_url(cover):
         logger.warning(
             "article: content_state has media indicators (atomic blocks / "
             "media_entities / cover_media) but resolved 0 images — media "

--- a/src/xbrain/fetch.py
+++ b/src/xbrain/fetch.py
@@ -43,6 +43,7 @@ import urllib.error
 import urllib.request
 from collections import Counter
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Callable, Union
 from urllib.parse import urlparse
 
@@ -63,6 +64,17 @@ _UA = "Mozilla/5.0 (compatible; XBrain/1.0)"
 _TIMEOUT = 20
 _FIRECRAWL_URL = "https://api.firecrawl.dev/v1/scrape"
 _FIRECRAWL_TIMEOUT = 60
+# Where the official `firecrawl` CLI stores the key its `login` wrote. Reading it
+# is the difference between the fallback being ON and it being silently OFF: an
+# operator who authenticated the CLI has configured Firecrawl on this machine, and
+# a pipeline that ignores that key marks repairable failures terminal (measured:
+# 39 of 61 items were repairable but sat at `attempts=1`, never having met the
+# second extractor). Env still wins, so a key can always be overridden per-run.
+FIRECRAWL_CREDENTIAL_PATHS = (
+    Path("~/Library/Application Support/firecrawl-cli/credentials.json"),  # macOS
+    Path("~/.config/firecrawl-cli/credentials.json"),  # XDG / Linux
+    Path("~/.firecrawl/credentials.json"),
+)
 
 # Pacing between items in a `--retry-failed` run. These are other people's servers, and the
 # corpus's one transient failure is a recorded HTTP 429 — a host that already rate-limited us.
@@ -187,15 +199,54 @@ def trafilatura_extract(
     return FetchSuccess(title=title, text=text, http_status=200, attempts=1)
 
 
+def _firecrawl_credential_key() -> str | None:
+    """The `apiKey` the official `firecrawl` CLI stored on this machine, or None.
+
+    Tries each known credentials location in order and returns the first usable
+    key. Every failure mode is silent-and-None on purpose: an absent file is the
+    normal "no Firecrawl here" case, and an unreadable / malformed one must not
+    take down a fetch run over an OPTIONAL fallback. The caller distinguishes the
+    two states it actually cares about — key or no key.
+    """
+    for candidate in FIRECRAWL_CREDENTIAL_PATHS:
+        path = candidate.expanduser()
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        key = payload.get("apiKey") if isinstance(payload, dict) else None
+        if isinstance(key, str) and key.strip():
+            return key.strip()
+    return None
+
+
+def firecrawl_key() -> str | None:
+    """The Firecrawl API key for this run: `FIRECRAWL_API_KEY`, else the CLI's stored one.
+
+    ONE resolver for the whole module, because the alternative already bit us: a
+    key the `firecrawl` CLI held was invisible to xbrain, so `_retryable_now` read
+    "no fallback configured" and called 39 repairable items terminal.
+
+    Precedence: `XBRAIN_NO_FIRECRAWL` (a hard opt-out, for running deliberately
+    without the fallback even on a machine that has a key) → `FIRECRAWL_API_KEY`
+    (a per-run override) → the stored CLI credentials. A set-but-EMPTY
+    `FIRECRAWL_API_KEY` is not a key and falls through to the file; use the
+    opt-out to mean "no Firecrawl".
+    """
+    if os.environ.get("XBRAIN_NO_FIRECRAWL"):
+        return None
+    return os.environ.get("FIRECRAWL_API_KEY") or _firecrawl_credential_key()
+
+
 def _firecrawl_extract(
     url: str, *, opener: Callable = urllib.request.urlopen
 ) -> FetchResult | None:
     """Second-attempt extraction via Firecrawl (renders JavaScript).
 
-    Returns `None` when `FIRECRAWL_API_KEY` is unset — the fallback is optional,
-    so XBrain users without a key simply do not get it.
+    Returns `None` when no key is resolvable (`firecrawl_key`) — the fallback is
+    optional, so XBrain users without a key simply do not get it.
     """
-    key = os.environ.get("FIRECRAWL_API_KEY")
+    key = firecrawl_key()
     if not key:
         return None
     body = json.dumps({"url": url, "formats": ["markdown"], "onlyMainContent": True}).encode()
@@ -582,9 +633,9 @@ def _retryable_now(src: ContentSourceFailure, *, firecrawl_configured: bool) -> 
 
 
 def firecrawl_available() -> bool:
-    """Is the JS-capable fallback extractor configured? (Mirrors `_firecrawl_extract`'s check —
-    one source of truth for "can a retry bring a different extractor".)"""
-    return bool(os.environ.get("FIRECRAWL_API_KEY"))
+    """Is the JS-capable fallback extractor configured? (Shares `_firecrawl_extract`'s
+    resolver — one source of truth for "can a retry bring a different extractor".)"""
+    return bool(firecrawl_key())
 
 
 def should_retry_failed(content: Content | None, *, firecrawl_configured: bool) -> bool:

--- a/src/xbrain/fetch_x.py
+++ b/src/xbrain/fetch_x.py
@@ -29,6 +29,7 @@ from xbrain.models import (
     ArticleBlock,
     ArticleImageBlock,
     ArticleTextBlock,
+    ArticleVideoBlock,
     Content,
     ContentSource,
     ContentSourceFailure,
@@ -216,10 +217,12 @@ def _structured_article(captured: list[dict], url: str) -> ContentSourceSuccess 
         )
     title, blocks = max(parsed, key=lambda item: len(item[1]))
     n_images = sum(1 for b in blocks if isinstance(b, ArticleImageBlock))
+    n_videos = sum(1 for b in blocks if isinstance(b, ArticleVideoBlock))
     logger.info(
-        "article: built structured body (%d blocks, %d images) for %s",
+        "article: built structured body (%d blocks, %d images, %d videos) for %s",
         len(blocks),
         n_images,
+        n_videos,
         url,
     )
     return ContentSourceSuccess(

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -212,7 +212,9 @@ def generate(
                 _mirror_item_article_images(item, media_root, vault_media_dir)
             _write_note(items_dir, item, strings, topic_style)
     try:
-        _write_dashboard(items, output_dir, items_dir, topic_pages or {}, media_root)
+        _write_dashboard(
+            items, output_dir, items_dir, topic_pages or {}, media_root, output_language
+        )
     except Exception:  # noqa: BLE001 - the dashboard is a best-effort secondary artifact
         logger.warning("Dashboard generation failed; item notes were written.", exc_info=True)
 
@@ -223,6 +225,7 @@ def _write_dashboard(
     items_dir: Path,
     topic_pages: dict[str, TopicPage],
     media_root: Path | None,
+    output_language: str,
 ) -> None:
     """Write the self-contained interactive `dashboard.html` from the store.
 
@@ -241,7 +244,7 @@ def _write_dashboard(
     thumbs = collect_thumbnails(items, media_root, id2note)
     now = datetime.now(timezone.utc)
     updated = f"{now:%b} {now.day}, {now.year}".upper()
-    data = compute_dashboard_data(items, topic_pages, id2note, thumbs, updated)
+    data = compute_dashboard_data(items, topic_pages, id2note, thumbs, updated, output_language)
     (output_dir / "dashboard.html").write_text(render_dashboard_html(data), encoding="utf-8")
 
 

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -17,6 +17,7 @@ from xbrain.models import (
     QUOTED_CONTENT_KINDS,
     ArticleImageBlock,
     ArticleTextBlock,
+    ArticleVideoBlock,
     ContentSourceFailure,
     ContentSourceSuccess,
     FailureReason,
@@ -628,6 +629,36 @@ def _article_image_lines(block: ArticleImageBlock) -> list[str]:
     return []
 
 
+def _article_video_lines(block: ArticleVideoBlock) -> list[str]:
+    """Render one inline Article VIDEO block — embed or clickable stream link.
+
+    Mirrors the video convention in `_render_media_lines` so an article-embedded
+    clip reads the same as a tweet's: a downloaded video embeds its local mp4, a
+    failed one leaves a visible ⚠ line, and a still-pending one surfaces the
+    playable stream as a link rather than vanishing. `alt` (when X carried any)
+    becomes a `> …` caption, one `>` per physical line.
+
+    Pending is NOT silent here, unlike a pending image: an article video has no
+    later pass that advances it (`xbrain media` downloads photos), so staying
+    silent would reproduce exactly the defect this block exists to fix — the
+    video invisible in the note.
+    """
+    entry = block.media
+    caption = [f"> {line}" for line in block.alt.splitlines()] if block.alt else []
+    if isinstance(entry, MediaVideoDownloaded):
+        return [f"![[{_VAULT_MEDIA_SUBDIR}/{entry.local_path}]]", *caption]
+    if isinstance(entry, MediaVideoFailed):
+        reason = _FAILURE_ES_MEDIA.get(entry.failure_reason, entry.failure_reason)
+        return [f"> ⚠ Vídeo no disponible ({reason}): <{entry.url}>", *caption]
+    if isinstance(entry, MediaVideoPending):
+        return [f"> 🎥 [Ver vídeo]({entry.url}) (pendiente de descarga)", *caption]
+    logger.warning(
+        "Article video carries an unexpected %s media variant; skipping its embed.",
+        type(entry).__name__,
+    )
+    return []
+
+
 def _article_caption_lines(
     block: ArticleImageBlock, entry: MediaPhotoDownloaded | MediaPhotoDescribed
 ) -> list[str]:
@@ -659,15 +690,23 @@ def _article_blocks_lines(source: ContentSourceSuccess, strings: Strings) -> lis
     """
     body: list[str] = []
     for block in source.blocks:
+        # Dispatch on EVERY variant explicitly, with `assert_never` closing it:
+        # an `else` catch-all would have quietly routed the new video block into
+        # the image renderer and produced wrong output instead of a type error.
         if isinstance(block, ArticleTextBlock):
             text = block.text.removeprefix(ARTICLE_PARAGRAPH_SEP)
             if text:
                 body += [text, ""]
+            continue
+        if isinstance(block, ArticleImageBlock):
+            media_lines = _article_image_lines(block)
+        elif isinstance(block, ArticleVideoBlock):
+            media_lines = _article_video_lines(block)
         else:
-            image_lines = _article_image_lines(block)
-            if image_lines:
-                body += image_lines
-                body.append("")
+            assert_never(block)
+        if media_lines:
+            body += media_lines
+            body.append("")
     if not body:
         return []
     heading = source.title or source.url

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -616,21 +616,48 @@ class ArticleImageBlock(BaseModel):
     alt: str | None = None
 
 
-# The ordered-block type — a discriminated union over the text and image
+class ArticleVideoBlock(BaseModel):
+    """One inline VIDEO of an X long-form Article body.
+
+    An article's `MEDIA` entity is not always a photo: X embeds native video
+    (`media_info.__typename == "ApiVideo"`, `mediaCategory: "AmplifyVideo"`) the
+    same way. The parser used to resolve a photo URL or nothing, so every
+    embedded video was dropped from the body — measured on the real corpus, and
+    invisible in the note: the reader saw prose with a hole where the author had
+    put a demo.
+
+    Wraps the SAME `MediaEntry` union as `ArticleImageBlock` (here a
+    `MediaVideoPending`), so the playable stream, the poster `thumbnail_url`, the
+    bitrate and the duration are all carried in the shape the rest of the
+    pipeline already understands. The discriminator is `kind` (`"video"`).
+
+    The video's bytes are NOT downloaded and its speech is NOT transcribed by
+    this block alone — `digest-video` selects from item-level media, not from
+    article bodies. What this variant guarantees is that the video is no longer
+    LOST: it is recorded, positioned and rendered where the author placed it.
+    """
+
+    kind: Literal["video"] = "video"
+    media: MediaEntry
+    alt: str | None = None
+
+
+# The ordered-block type — a discriminated union over the text, image and video
 # variants, tagged on `kind`. Same style as `_MediaTagged` /
 # `_ContentSourceTagged`. No `BeforeValidator` legacy shim is needed: `blocks`
 # is a brand-new field (#39), so there is no pre-existing on-wire shape to
-# migrate — a legacy record simply has no `blocks` key and defaults to `[]`.
+# migrate — a legacy record simply has no `blocks` key and defaults to `[]`,
+# and a legacy record with blocks simply has no `"video"`-tagged entry.
 ArticleBlock = Annotated[
-    Union[ArticleTextBlock, ArticleImageBlock],
+    Union[ArticleTextBlock, ArticleImageBlock, ArticleVideoBlock],
     Field(discriminator="kind"),
 ]
 
 
 # TypeAdapter for tests / ad-hoc validation of a single block outside an
 # `Item` context (mirrors `MediaEntryAdapter` / `ContentSourceAdapter`).
-ArticleBlockAdapter: TypeAdapter[Union[ArticleTextBlock, ArticleImageBlock]] = TypeAdapter(
-    ArticleBlock
+ArticleBlockAdapter: TypeAdapter[Union[ArticleTextBlock, ArticleImageBlock, ArticleVideoBlock]] = (
+    TypeAdapter(ArticleBlock)
 )
 
 

--- a/src/xbrain/resources/dashboard.template.html
+++ b/src/xbrain/resources/dashboard.template.html
@@ -75,6 +75,10 @@ body{background:var(--bg);color:var(--ink);font-family:var(--ui);font-size:15px;
 .phead .kick{font-family:var(--mono);font-size:10px;letter-spacing:.2em;text-transform:uppercase;color:var(--ink-faint);display:block;margin-bottom:7px}
 .phead h3{font-family:var(--display);font-weight:600;font-size:20px;letter-spacing:-.005em;line-height:1.1}
 .phead .sub{font-size:12px;color:var(--ink-faint);text-align:right;white-space:nowrap}
+/* verification caveat line — the numbers above are meaningless without it */
+.vnote{font-size:12.5px;color:var(--ink-muted);margin:2px 24px 22px;line-height:1.6}
+.vnote b{color:var(--ink);font-weight:600}
+.vnote .stale{color:var(--sand)}
 .chart{width:100%}
 
 /* topic controls */
@@ -210,6 +214,12 @@ footer{margin-top:40px;padding-top:22px;border-top:1px solid var(--hairline);
     <div class="panel">
       <div class="phead"><div><span class="kick">08 · Sources</span><h3>Top linked domains</h3></div><div class="sub">external · x.com excluded</div></div>
       <div class="chart" id="c-domains" style="height:340px"></div>
+    </div>
+
+    <div class="panel span2">
+      <div class="phead"><div><span class="kick">09 · Verification</span><h3>LLM-as-judge coverage</h3></div><div class="sub" id="verify-sub">outputs judged vs. unjudged</div></div>
+      <div class="chart" id="c-verify" style="height:220px"></div>
+      <p class="vnote" id="verify-note"></p>
     </div>
   </section>
 
@@ -385,6 +395,33 @@ chDom.setOption({
   label:{show:true,position:'right',color:C.faint,fontFamily:MONO,fontSize:11,formatter:p=>nf(p.value)}}]});
 chDom.on('click',p=>{if(p.data&&p.data.domain)openDomain(p.data.domain);});
 
+/* 09 · verification — coverage of `xbrain verify`, drawn as ONE full-width bar so
+   the judged slice is read against the whole population and never on its own. */
+const V=DATA.verification||{outputs:0,judged:0,unjudged:0,stale:0,coverage_pct:0,verdicts:{}};
+const vSeg=[['PASS',V.verdicts.PASS||0,C.saved],['REVIEW',V.verdicts.REVIEW||0,C.sand],
+            ['FAIL',V.verdicts.FAIL||0,C.failed],['UNJUDGED',V.unjudged||0,'#2A251C']];
+document.getElementById('verify-sub').textContent=
+ nf(V.judged)+' of '+nf(V.outputs)+' outputs · '+V.coverage_pct+'% coverage';
+const chVer=mk('c-verify');
+chVer.setOption({
+ grid:{left:16,right:16,top:34,bottom:10},
+ legend:{top:0,left:16,textStyle:{color:C.muted,fontFamily:MONO,fontSize:11},icon:'roundRect',
+   itemWidth:10,itemHeight:10},
+ tooltip:{...TIP,trigger:'item',formatter:p=>p.seriesName+' · '+nf(p.value)+
+   (V.outputs?' ('+(p.value/V.outputs*100).toFixed(1)+'%)':'')},
+ xAxis:{type:'value',max:V.outputs||1,show:false},
+ yAxis:{type:'category',data:[''],show:false},
+ series:vSeg.map(([name,value,color],i)=>({
+   name,type:'bar',stack:'v',data:[value],barWidth:44,
+   itemStyle:{color,borderRadius:i===0?[4,0,0,4]:(i===vSeg.length-1?[0,4,4,0]:0)}}))});
+document.getElementById('verify-note').innerHTML=
+ 'Each output — a summary, a topics assignment or a video digest — is judged separately '+
+ 'against its own source. <b>'+nf(V.unjudged)+'</b> carry no current verdict, so nothing '+
+ 'is known about them either way.'+
+ (V.stale?' <span class="stale">'+nf(V.stale)+' stored verdict'+(V.stale===1?'':'s')+
+  ' went stale</span> — the output was re-generated after being judged, so the verdict '+
+  'no longer describes what you read here and counts as unjudged.':'');
+
 /* ===== unified drill-down drawer ===== */
 const drawer=document.getElementById('drawer'),scrim=document.getElementById('scrim');
 function openDrawer(kick,title,meta,html){
@@ -432,7 +469,7 @@ scrim.onclick=closeDrawer;
 document.addEventListener('keydown',e=>{if(e.key==='Escape')closeDrawer();});
 /* headless screenshot hooks */
 Object.assign(window,{__openTopic:openTopic,__openMonth:openMonth,__openPhotos:openPhotos,__openLongform:openLongform,__openAuthor:openAuthor});
-addEventListener('resize',()=>{['c-growth','c-activity','c-sources','c-topics','c-longform','c-media','c-authors','c-domains'].forEach(id=>{const el=document.getElementById(id);if(el&&echarts.getInstanceByDom(el))echarts.getInstanceByDom(el).resize();});});
+addEventListener('resize',()=>{['c-growth','c-activity','c-sources','c-topics','c-longform','c-media','c-authors','c-domains','c-verify'].forEach(id=>{const el=document.getElementById(id);if(el&&echarts.getInstanceByDom(el))echarts.getInstanceByDom(el).resize();});});
 </script>
 </body>
 </html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,27 @@ fake can simulate a transient API failure mid-batch.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_firecrawl_credentials(monkeypatch, tmp_path):
+    """Point the Firecrawl credentials lookup at an empty temp dir, for EVERY test.
+
+    `fetch.firecrawl_key` falls back to the `firecrawl` CLI's stored credentials
+    when `FIRECRAWL_API_KEY` is unset. Without this fixture, "no key configured"
+    would mean "no key on the machine RUNNING the tests" — the suite would pass
+    in CI and fail on a developer laptop that has run `firecrawl login` (or the
+    reverse), and a `monkeypatch.delenv("FIRECRAWL_API_KEY")` would quietly stop
+    meaning what it says. Autouse because the risk is exactly in the tests that
+    do not think about Firecrawl at all.
+    """
+    monkeypatch.setattr(
+        "xbrain.fetch.FIRECRAWL_CREDENTIAL_PATHS",
+        (Path(tmp_path) / "no-such-credentials.json",),
+    )
 
 
 class FakeBlock:

--- a/tests/fixtures/art-Rich_Entities.json
+++ b/tests/fixtures/art-Rich_Entities.json
@@ -1,0 +1,133 @@
+{
+  "content_state": {
+    "blocks": [
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [],
+        "key": "d14a5",
+        "text": "\"¿Podría Madrid transformarse en un hub tecnológico?\"",
+        "type": "unstyled"
+      },
+      {
+        "data": {},
+        "entityRanges": [
+          {
+            "key": 1,
+            "length": 1,
+            "offset": 0
+          }
+        ],
+        "inlineStyleRanges": [],
+        "key": "e92an",
+        "text": " ",
+        "type": "atomic"
+      },
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [],
+        "key": "4utd3",
+        "text": "Unos meses después, tuve la idea de REFUGIO. Como vi que tuvo buena acogida y la gente tenía ganas de juntarse, me puse manos a la obra. Ya que he conseguido una audiencia y un alcance interesante a través de mi cuenta de tuiter, qué menos que usarlo para algo útil.",
+        "type": "unstyled"
+      },
+      {
+        "data": {},
+        "entityRanges": [
+          {
+            "key": 2,
+            "length": 1,
+            "offset": 0
+          }
+        ],
+        "inlineStyleRanges": [],
+        "key": "fq4ef",
+        "text": " ",
+        "type": "atomic"
+      },
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [],
+        "key": "7pd8f",
+        "text": "Una de mis motivaciones principales a la hora de montar REFUGIO venía de mi interés por conocer de primera mano cuál es el estado del ecosistema. Sabía que organizando una cosa de estas me iba a meter de lleno en las tripas de la industria. Creo que ha sido un éxito, gracias a la organización del evento, durante los últimos dos meses he podido conocer, charlar y colaborar con muchas de las personas con mayor influencia dentro del sector, he podido escuchar sus perspectivas y he trabajado con las empresas que están detrás de todo esto. En general, llevo dos meses empapándome de información sobre la situación actual del sector.",
+        "type": "unstyled"
+      },
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [],
+        "key": "3ecva",
+        "text": "Con el remoto, primo hermano del problema: una empresa extranjera sin entidad aquí que quiera contratar legalmente a un programador residente en España debe darse de alta como empleador en la Seguridad Social, sacar NIF, nombrar representante... la misma estructura para uno que para mil. El CEO de Vercel lo dijo tal cual: ",
+        "type": "unstyled"
+      },
+      {
+        "data": {},
+        "entityRanges": [
+          {
+            "key": 5,
+            "length": 1,
+            "offset": 0
+          }
+        ],
+        "inlineStyleRanges": [],
+        "key": "1s4gr",
+        "text": " ",
+        "type": "atomic"
+      },
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [],
+        "key": "5r8jp",
+        "text": "Al final una política fiscal pensada para recaudar más acaba expulsando justo los empleos que más impuestos dejarían aquí: los de sueldos altos, los que forman a la siguiente generación. ",
+        "type": "unstyled"
+      }
+    ],
+    "entityMap": [
+      {
+        "key": "5",
+        "value": {
+          "data": {
+            "tweetId": "1977779569114665339"
+          },
+          "mutability": "Immutable",
+          "type": "TWEET"
+        }
+      },
+      {
+        "key": "1",
+        "value": {
+          "data": {
+            "tweetId": "2025163295317958842"
+          },
+          "mutability": "Immutable",
+          "type": "TWEET"
+        }
+      },
+      {
+        "key": "2",
+        "value": {
+          "data": {
+            "tweetId": "2036510702010061149"
+          },
+          "mutability": "Immutable",
+          "type": "TWEET"
+        }
+      }
+    ]
+  },
+  "id": "QXJ0aWNsZUVudGl0eToyMDczMDMzMzU5MzU4NDA2NjU2",
+  "is_grok_summary_eligible": true,
+  "lifecycle_state": {
+    "modified_at_secs": 1783090566
+  },
+  "media_entities": [],
+  "metadata": {
+    "first_published_at_secs": 1783090110
+  },
+  "preview_text": "El fin de semana pasado organicé REFUGIO. Para quien no sepa de qué iba la vaina: un sábado a finales de junio encerré en Madrid a 47 tíos (y una tía, pero más de eso luego) seleccionados por mí",
+  "rest_id": "2073033359358406656",
+  "summary_text": "- Organicé REFUGIO juntando 47 top talentos técnicos de Madrid con fundadores, inversores y recruiters. El evento superó expectativas, generó networking de 4,8/5 y lanzó colaboraciones, contrataciones y nuevas iniciativas.\n\n- Madrid tiene buen talento universitario pero sufre fuga de cerebros, falta de centros de excelencia y valle de la muerte entre investigación e industria. La IA abre una ventana histórica de oportunidad.\n\n- Soy Pareto-extremalist: concentrar talento excepcional genera colisiones y reacciones en cadena exponenciales. Dispersarlo impide alcanzar masa crítica y regala potencial a otros ecosistemas.\n\n- Problemas clave: fiscalidad ahuyenta Big Tech de contratar seniors en España, mercado pequeño y dificultad para escalar startups más allá de rondas iniciales. Falta de \"empleados ricos\" frena el ecosistema.\n\n- Hace falta fichajes estrella, reformas fiscales, incentivos a transferencia, eventos de colisión y voluntad para retener y atraer talento. El talento y ganas existen; hay que empujar.",
+  "title": "Reflexiones sobre REFUGIO"
+}

--- a/tests/fixtures/art-Video_Embed.json
+++ b/tests/fixtures/art-Video_Embed.json
@@ -1,0 +1,259 @@
+{
+  "content_state": {
+    "blocks": [
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [
+          {
+            "length": 14,
+            "offset": 0,
+            "style": "Bold"
+          }
+        ],
+        "key": "d5893",
+        "text": "Users complain -- ask for things, find bugs, file feature requests → back to the team to add to the tracker",
+        "type": "unordered-list-item"
+      },
+      {
+        "data": {},
+        "entityRanges": [
+          {
+            "key": 32,
+            "length": 1,
+            "offset": 0
+          }
+        ],
+        "inlineStyleRanges": [],
+        "key": "c0efq",
+        "text": " ",
+        "type": "atomic"
+      },
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [],
+        "key": "acnlq",
+        "text": "And on and on. We haven't even hit AI yet, and there are already several loops in this picture.",
+        "type": "unstyled"
+      },
+      {
+        "data": {},
+        "entityRanges": [
+          {
+            "key": 64,
+            "length": 18,
+            "offset": 138
+          },
+          {
+            "key": 65,
+            "length": 10,
+            "offset": 215
+          }
+        ],
+        "inlineStyleRanges": [],
+        "key": "3ocu6",
+        "text": "I did a bunch of research on this topic and cooked up a bunch of visualizations to try to explain the parts that matter, but I found that Calvin French-Owen (MTS on the codex team, founder of Segment) did a talk at AI Council that did a much better and cleaner job, so I'm just gonna drop this animation here inspired by his slides:",
+        "type": "unstyled"
+      },
+      {
+        "data": {},
+        "entityRanges": [
+          {
+            "key": 66,
+            "length": 1,
+            "offset": 0
+          }
+        ],
+        "inlineStyleRanges": [],
+        "key": "2bv6i",
+        "text": " ",
+        "type": "atomic"
+      },
+      {
+        "data": {},
+        "entityRanges": [],
+        "inlineStyleRanges": [],
+        "key": "f96v5",
+        "text": "To make a model better at coding, you're gonna:",
+        "type": "unstyled"
+      }
+    ],
+    "entityMap": [
+      {
+        "key": "66",
+        "value": {
+          "data": {
+            "entityKey": "b383536d-b470-40cf-9d11-fffa01b3b97a",
+            "mediaItems": [
+              {
+                "localMediaId": "43",
+                "mediaCategory": "AmplifyVideo",
+                "mediaId": "2080401322218758144"
+              }
+            ]
+          },
+          "mutability": "Immutable",
+          "type": "MEDIA"
+        }
+      },
+      {
+        "key": "32",
+        "value": {
+          "data": {
+            "entityKey": "bb5eff3d-8190-417f-bc2f-824ede7aaf09",
+            "mediaItems": [
+              {
+                "localMediaId": "13",
+                "mediaCategory": "AmplifyVideo",
+                "mediaId": "2080400367033217024"
+              }
+            ]
+          },
+          "mutability": "Immutable",
+          "type": "MEDIA"
+        }
+      },
+      {
+        "key": "64",
+        "value": {
+          "data": {
+            "entityKey": "b7b49284-8499-4329-89c7-00ed32b342e4",
+            "url": "https://x.com/calvinfo"
+          },
+          "mutability": "Mutable",
+          "type": "LINK"
+        }
+      }
+    ]
+  },
+  "id": "QXJ0aWNsZUVudGl0eToyMDc4NzEwNDEzMzQ1NDAyODgw",
+  "is_grok_summary_eligible": true,
+  "lifecycle_state": {
+    "modified_at_secs": 1785184178
+  },
+  "media_entities": [
+    {
+      "id": "QXBpTWVkaWE6DAAECgABHN8R+ukaIAAKAAIAAAAAAAAAAAAA",
+      "media_id": "2080401322218758144",
+      "media_info": {
+        "__typename": "ApiVideo",
+        "aspect_ratio": {
+          "denominator": 9,
+          "numerator": 16
+        },
+        "duration_millis": 24016,
+        "preview_image": {
+          "color_info": {
+            "palette": [
+              {
+                "percentage": 98.96,
+                "rgb": {
+                  "blue": 255,
+                  "green": 255,
+                  "red": 255
+                }
+              },
+              {
+                "percentage": 1.04,
+                "rgb": {
+                  "blue": 222,
+                  "green": 193,
+                  "red": 104
+                }
+              }
+            ]
+          },
+          "original_img_height": 1080,
+          "original_img_url": "https://pbs.twimg.com/amplify_video_thumb/2080401322218758144/img/f7ow19XebOIFqSPf.jpg",
+          "original_img_width": 1920
+        },
+        "variants": [
+          {
+            "bit_rate": 832000,
+            "content_type": "video/mp4",
+            "url": "https://video.twimg.com/amplify_video/2080401322218758144/vid/avc1/640x360/ieMny60NfIFpFCnY.mp4?tag=29"
+          },
+          {
+            "bit_rate": 256000,
+            "content_type": "video/mp4",
+            "url": "https://video.twimg.com/amplify_video/2080401322218758144/vid/avc1/480x270/U8clvtz68MBDyeqc.mp4?tag=29"
+          },
+          {
+            "content_type": "application/x-mpegURL",
+            "url": "https://video.twimg.com/amplify_video/2080401322218758144/pl/HEuqqVaAUiRalZOb.m3u8?tag=29"
+          },
+          {
+            "bit_rate": 10368000,
+            "content_type": "video/mp4",
+            "url": "https://video.twimg.com/amplify_video/2080401322218758144/vid/avc1/1920x1080/TAmphZindte_e56f.mp4?tag=29"
+          },
+          {
+            "bit_rate": 2176000,
+            "content_type": "video/mp4",
+            "url": "https://video.twimg.com/amplify_video/2080401322218758144/vid/avc1/1280x720/O7DfVZoV5MnpknSq.mp4?tag=29"
+          }
+        ]
+      },
+      "media_key": "13_2080401322218758144"
+    },
+    {
+      "id": "QXBpTWVkaWE6DAAECgABHN8RHIObcAAKAAIAAAAAAAAAAAAA",
+      "media_id": "2080400367033217024",
+      "media_info": {
+        "__typename": "ApiVideo",
+        "aspect_ratio": {
+          "denominator": 9,
+          "numerator": 16
+        },
+        "duration_millis": 41520,
+        "preview_image": {
+          "color_info": {
+            "palette": [
+              {
+                "percentage": 100,
+                "rgb": {
+                  "blue": 255,
+                  "green": 255,
+                  "red": 255
+                }
+              }
+            ]
+          },
+          "original_img_height": 720,
+          "original_img_url": "https://pbs.twimg.com/amplify_video_thumb/2080400367033217024/img/fzKh_OaEyf3OqYzU.jpg",
+          "original_img_width": 1280
+        },
+        "variants": [
+          {
+            "bit_rate": 256000,
+            "content_type": "video/mp4",
+            "url": "https://video.twimg.com/amplify_video/2080400367033217024/vid/avc1/480x270/AoeZ2rE0NMo1hWiL.mp4?tag=29"
+          },
+          {
+            "bit_rate": 832000,
+            "content_type": "video/mp4",
+            "url": "https://video.twimg.com/amplify_video/2080400367033217024/vid/avc1/640x360/sA5abyY6xyWcnyKI.mp4?tag=29"
+          },
+          {
+            "bit_rate": 2176000,
+            "content_type": "video/mp4",
+            "url": "https://video.twimg.com/amplify_video/2080400367033217024/vid/avc1/1280x720/ZCzXM0TiRECKMZwi.mp4?tag=29"
+          },
+          {
+            "content_type": "application/x-mpegURL",
+            "url": "https://video.twimg.com/amplify_video/2080400367033217024/pl/Wvsenc7q_7n4kQ5d.m3u8?tag=29"
+          }
+        ]
+      },
+      "media_key": "13_2080400367033217024"
+    }
+  ],
+  "metadata": {
+    "first_published_at_secs": 1784911887
+  },
+  "preview_text": "or: the harness is not enough\nUpdate - the talk version of this post is live on youtube: https://www.youtube.com/watch?v=Ib5GBkD555M \nPart 1 in a series. \nPart 2 is here: https://x.com/dexhorthy/status/2081058573556306030 \nPart 3 is here:",
+  "rest_id": "2078710413345402880",
+  "summary_text": "- We're racing to lights-off AI software factories but they fail: codebases degrade, bugs and incidents rise, maintainability collapses.\n- Models ace benchmarks yet produce slop because RL training penalizes nothing for bad design or shotgun surgery.\n- No amount of harness engineering, loops, or token-maxxing fixes this core model-training limitation.\n- I tried full lights-off and ended up rewriting after repeated outages and claude spaghetti.\n- Human steering remains essential for complex production codebases to avoid setting them on fire.",
+  "title": "Why Software Factories Fail"
+}

--- a/tests/test_article.py
+++ b/tests/test_article.py
@@ -18,7 +18,13 @@ from __future__ import annotations
 import json
 
 from xbrain.extract.article import parse_article_content_state
-from xbrain.models import ArticleImageBlock, ArticleTextBlock, MediaPhotoPending
+from xbrain.models import (
+    ArticleImageBlock,
+    ArticleTextBlock,
+    ArticleVideoBlock,
+    MediaPhotoPending,
+    MediaVideoPending,
+)
 
 _IMAGE_URL = "https://pbs.twimg.com/media/ABC123.jpg"
 
@@ -130,7 +136,14 @@ def test_image_url_resolves_from_nested_media_items():
     assert blocks[0].alt == "nested alt"
 
 
-def test_non_image_atomic_entity_is_skipped_and_inline_link_text_kept():
+def test_embedded_tweet_keeps_its_url_and_inline_link_text_kept():
+    """An embedded TWEET is not an image — but it is not nothing either.
+
+    This used to assert the tweet was DROPPED. That was the defect: the atomic
+    block carries `text: " "`, which fails `.strip()`, so the only pointer to the
+    embedded post (`data.tweetId`) went in the bin. The article said "look at
+    this post" and the note showed a hole.
+    """
     content_state = {
         "blocks": [
             {
@@ -152,9 +165,92 @@ def test_non_image_atomic_entity_is_skipped_and_inline_link_text_kept():
         },
     }
     _title, blocks = parse_article_content_state(_payload(content_state))
-    # The embedded tweet is not an image (dropped); the link paragraph's text
-    # is kept as a text run (a LINK entity is never mistaken for an image).
-    assert blocks == [ArticleTextBlock(text="see this link")]
+    # The tweet survives as its canonical handle-less URL; the link paragraph's
+    # text is kept as a text run (a LINK entity is never mistaken for an image).
+    assert blocks == [
+        ArticleTextBlock(text="https://x.com/i/status/123"),
+        ArticleTextBlock(text="\n\nsee this link"),
+    ]
+
+
+def test_markdown_entity_recovers_its_code_block():
+    """A `MARKDOWN` entity holds real prose/code on `data.markdown`, not in `text`.
+
+    Measured on the real corpus: 20 such blocks across 23 Articles, ~3.9 KB of
+    code listings in the 9 captured payloads alone — deleted from articles that
+    are largely ABOUT their code.
+    """
+    code = "```python\nprint('hi')\n```"
+    content_state = {
+        "blocks": [
+            {"key": "p", "text": "before", "type": "unstyled"},
+            {
+                "key": "md",
+                "text": " ",
+                "type": "atomic",
+                "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+            },
+        ],
+        "entityMap": {"0": {"type": "MARKDOWN", "data": {"markdown": code}}},
+    }
+    _title, blocks = parse_article_content_state(_payload(content_state))
+    assert blocks == [
+        ArticleTextBlock(text="before"),
+        ArticleTextBlock(text=f"\n\n{code}"),
+    ]
+
+
+def test_divider_entity_becomes_a_horizontal_rule():
+    """A `DIVIDER` carries an empty `data` — it IS the author's section break."""
+    content_state = {
+        "blocks": [
+            {"key": "p", "text": "before", "type": "unstyled"},
+            {
+                "key": "hr",
+                "text": " ",
+                "type": "atomic",
+                "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+            },
+            {"key": "q", "text": "after", "type": "unstyled"},
+        ],
+        "entityMap": {"0": {"type": "DIVIDER", "data": {}}},
+    }
+    _title, blocks = parse_article_content_state(_payload(content_state))
+    assert [b.text for b in blocks] == ["before", "\n\n---", "\n\nafter"]
+
+
+def test_unknown_entity_carrying_text_is_recovered_not_dropped():
+    """Drift tolerance: an entity type we have never seen still yields its text."""
+    content_state = {
+        "blocks": [
+            {
+                "key": "x",
+                "text": " ",
+                "type": "atomic",
+                "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+            },
+        ],
+        "entityMap": {"0": {"type": "SOME_FUTURE_THING", "data": {"text": "kept anyway"}}},
+    }
+    _title, blocks = parse_article_content_state(_payload(content_state))
+    assert blocks == [ArticleTextBlock(text="kept anyway")]
+
+
+def test_entity_text_never_overrides_a_real_text_run():
+    """A block WITH text uses its own run — the entity is not a second source."""
+    content_state = {
+        "blocks": [
+            {
+                "key": "x",
+                "text": "the real paragraph",
+                "type": "unstyled",
+                "entityRanges": [{"offset": 0, "length": 3, "key": 0}],
+            },
+        ],
+        "entityMap": {"0": {"type": "MARKDOWN", "data": {"markdown": "SHOULD NOT APPEAR"}}},
+    }
+    _title, blocks = parse_article_content_state(_payload(content_state))
+    assert blocks == [ArticleTextBlock(text="the real paragraph")]
 
 
 def test_image_only_article_yields_blocks_with_empty_flattened_text():
@@ -491,3 +587,89 @@ def test_heading_list_and_quote_block_prefixes_are_baked_in():
     _title, blocks = parse_article_content_state(_payload(content_state))
     texts = [b.text for b in blocks if isinstance(b, ArticleTextBlock)]
     assert texts == ["# H1", "\n\n### H3", "\n\n1. step", "\n\n> quote"]
+
+
+def test_a_video_entry_with_no_variants_falls_back_to_its_poster_image():
+    """No playable stream ⇒ it is an IMAGE block, never a video linking to a JPEG.
+
+    `build_video_media` falls back to `media_url_https` when it finds no variant,
+    and on the article shape that key holds the poster — so treating a
+    variant-less entry as a video would render `🎥 Ver vídeo` pointing at a still.
+    """
+    poster = "https://pbs.twimg.com/amplify_video_thumb/1/img/p.jpg"
+    payload = _payload(
+        {
+            "blocks": [
+                {
+                    "key": "v",
+                    "text": " ",
+                    "type": "atomic",
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                }
+            ],
+            "entityMap": [
+                {"key": 0, "value": {"type": "MEDIA", "data": {"mediaItems": [{"mediaId": "77"}]}}}
+            ],
+        }
+    )
+    container = payload["data"]["article"]["article_results"]["result"]
+    container["media_entities"] = [
+        {
+            "media_id": "77",
+            "media_info": {
+                "__typename": "ApiVideo",
+                "variants": [],
+                "preview_image": {"original_img_url": poster},
+            },
+        }
+    ]
+
+    _title, blocks = parse_article_content_state(payload)
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], ArticleImageBlock)
+    assert blocks[0].media.url == poster
+
+
+def test_a_real_video_entry_becomes_a_video_block_pointing_at_the_stream():
+    """The positive counterpart: with variants present it IS a video."""
+    poster = "https://pbs.twimg.com/amplify_video_thumb/1/img/p.jpg"
+    stream = "https://video.twimg.com/amplify_video/1/vid/avc1/1920x1080/s.mp4"
+    payload = _payload(
+        {
+            "blocks": [
+                {
+                    "key": "v",
+                    "text": " ",
+                    "type": "atomic",
+                    "entityRanges": [{"offset": 0, "length": 1, "key": 0}],
+                }
+            ],
+            "entityMap": [
+                {"key": 0, "value": {"type": "MEDIA", "data": {"mediaItems": [{"mediaId": "77"}]}}}
+            ],
+        }
+    )
+    container = payload["data"]["article"]["article_results"]["result"]
+    container["media_entities"] = [
+        {
+            "media_id": "77",
+            "media_info": {
+                "__typename": "ApiVideo",
+                "duration_millis": 24016,
+                "preview_image": {"original_img_url": poster},
+                "variants": [
+                    {"content_type": "video/mp4", "bit_rate": 256000, "url": "https://v/low.mp4"},
+                    {"content_type": "video/mp4", "bit_rate": 10368000, "url": stream},
+                    {"content_type": "application/x-mpegURL", "url": "https://v/x.m3u8"},
+                ],
+            },
+        }
+    ]
+
+    _title, blocks = parse_article_content_state(payload)
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], ArticleVideoBlock)
+    assert isinstance(blocks[0].media, MediaVideoPending)
+    assert blocks[0].media.url == stream  # the HIGHEST bit_rate mp4, not the first
+    assert blocks[0].media.thumbnail_url == poster
+    assert blocks[0].media.duration_millis == 24016

--- a/tests/test_article_real.py
+++ b/tests/test_article_real.py
@@ -26,7 +26,9 @@ from xbrain.models import (
     ARTICLE_PARAGRAPH_SEP,
     ArticleImageBlock,
     ArticleTextBlock,
+    ArticleVideoBlock,
     ContentSourceSuccess,
+    MediaVideoPending,
 )
 
 _FIXTURES = Path(__file__).parent / "fixtures"
@@ -204,3 +206,111 @@ def test_missing_media_entities_drops_image_but_keeps_text() -> None:
 def test_foreign_payload_degrades_to_none_empty(payload: Any) -> None:
     """Any non-Article / empty-body shape degrades to `(None, [])`, never a crash."""
     assert parse_article_content_state(payload) == (None, [])
+
+
+# --------------------------------------------------------------------------
+# Embedded VIDEO and entity-borne text — real payloads for the block-drop fix.
+#
+# `art-Video_Embed` is trimmed from an Article whose body embeds two native X
+# videos; `art-Rich_Entities` from one whose body carries `MARKDOWN` code blocks,
+# `DIVIDER` rules and `TWEET` embeds. Both used to lose that content entirely:
+# the parser resolved a photo URL or nothing, and every non-photo atomic block
+# went to the drop log.
+# --------------------------------------------------------------------------
+
+
+def test_video_embed_resolves_native_videos_not_their_posters() -> None:
+    """An article `MEDIA` entity can be an `ApiVideo` — it must stay a video.
+
+    Its poster lives one level deeper than a photo's URL
+    (`media_info.preview_image.original_img_url`), which is why the lookup
+    returned None and the block was dropped. Resolving it as a PHOTO would be
+    just as wrong: a demo clip silently demoted to a still frame.
+    """
+    _title, blocks = parse_article_content_state(_load("Video_Embed"))
+    videos = [b for b in blocks if isinstance(b, ArticleVideoBlock)]
+
+    assert len(videos) == 2
+    assert _image_urls(blocks) == []  # the posters must NOT become image blocks
+    for video in videos:
+        assert isinstance(video.media, MediaVideoPending)
+        # The playable stream, never the poster.
+        assert video.media.url.startswith("https://video.twimg.com/")
+        assert video.media.url.endswith(".mp4") or ".mp4?" in video.media.url
+        assert (video.media.thumbnail_url or "").startswith("https://pbs.twimg.com/")
+        assert video.media.duration_millis
+
+
+def test_video_embed_picks_the_highest_bitrate_variant() -> None:
+    """X spells it `bit_rate` here and `bitrate` on a tweet — one character apart.
+
+    Reading the tweet key against an article payload made every bitrate compare
+    as 0, so `max()` returned the FIRST mp4: a 480x270 stream where a 1920x1080
+    one was on offer. It kept working, just badly.
+    """
+    _title, blocks = parse_article_content_state(_load("Video_Embed"))
+    videos = [b for b in blocks if isinstance(b, ArticleVideoBlock)]
+
+    best = max(videos, key=lambda b: b.media.bitrate or 0)
+    assert best.media.bitrate == 10368000
+    assert "1920x1080" in best.media.url
+
+
+def test_video_blocks_sit_in_document_order_between_text() -> None:
+    """The clip stays where the author put it, not appended at the end."""
+    _title, blocks = parse_article_content_state(_load("Video_Embed"))
+    first_video = next(i for i, b in enumerate(blocks) if isinstance(b, ArticleVideoBlock))
+
+    assert any(isinstance(b, ArticleTextBlock) for b in blocks[:first_video])
+    assert any(isinstance(b, ArticleTextBlock) for b in blocks[first_video + 1 :])
+
+
+def test_rich_entities_recovers_markdown_dividers_and_tweets() -> None:
+    """Entity-borne content survives: code blocks, rules and embedded posts."""
+    _title, blocks = parse_article_content_state(_load("Rich_Entities"))
+    texts = [b.text for b in blocks if isinstance(b, ArticleTextBlock)]
+    body = "".join(texts)
+
+    # Three embedded posts, each kept as its canonical handle-less URL.
+    assert body.count("https://x.com/i/status/") == 3
+    # And the article's own prose is still there, in order, around them.
+    assert texts[0].startswith('"¿Podría Madrid')
+    assert len(texts) == len(blocks)  # this fixture is text-only once recovered
+
+
+def test_recovered_blocks_keep_the_flattened_text_invariant() -> None:
+    """`text` must still equal the concatenation of the text blocks.
+
+    The recovery adds NEW `ArticleTextBlock`s mid-body, so the `\\n\\n` separator
+    bookkeeping has to hold for them too — otherwise the flattened body that
+    `enrich`/`topics` read drifts from what the note renders.
+    """
+    for name in ("Rich_Entities", "Video_Embed"):
+        _title, blocks = parse_article_content_state(_load(name))
+        source = ContentSourceSuccess(
+            kind="x_article",
+            url="https://x.com/i/article/1",
+            text=_flatten_blocks(blocks),
+            blocks=blocks,
+            http_status=200,
+            attempts=1,
+        )
+        assert source.text == "".join(
+            b.text for b in source.blocks if isinstance(b, ArticleTextBlock)
+        )
+        # The first text run never carries a leading separator.
+        first = next(b for b in blocks if isinstance(b, ArticleTextBlock))
+        assert not first.text.startswith(ARTICLE_PARAGRAPH_SEP)
+
+
+def test_entity_borne_text_does_not_trip_the_media_warning(caplog) -> None:
+    """`MARKDOWN`/`DIVIDER`/`TWEET` blocks are atomic but are NOT media.
+
+    Counting any atomic block as "had media" made every prose-and-code article
+    log a media-drift warning, and a warning that cries wolf on ordinary input
+    is one nobody reads when it is real.
+    """
+    with caplog.at_level("WARNING", logger="xbrain.extract.article"):
+        _title, blocks = parse_article_content_state(_load("Rich_Entities"))
+    assert blocks
+    assert not any("resolved 0 images" in r.message for r in caplog.records)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3640,7 +3640,12 @@ def test_fetch_retry_failed_dry_run_reports_the_plan_and_never_touches_the_store
     out = _plain_output(result.output)
 
     assert "Reintentables: 1 items" in out  # only the transient one
-    assert "BLOQUEADOS por falta de FIRECRAWL_API_KEY: 1 items" in out
+    assert "BLOQUEADOS por falta de clave Firecrawl: 1 items" in out
+    # It must say WHERE it looked: the key already existed on this machine once,
+    # stored by the `firecrawl` CLI, and a message naming only the env var sent
+    # the operator hunting for a key they already had.
+    assert "$FIRECRAWL_API_KEY" in out
+    assert "credentials.json" in out
     assert "Terminales" in out and "1 items" in out
     assert items_path.read_bytes() == before  # not a byte touched
     assert not (tmp_path / "data" / "snapshots").exists()
@@ -3662,7 +3667,7 @@ def test_fetch_retry_failed_without_the_key_does_not_replay_the_identical_failur
 
     result = runner.invoke(app, ["fetch", "--retry-failed"])
     assert result.exit_code == 0, result.output
-    assert "BLOQUEADOS por falta de FIRECRAWL_API_KEY: 1 items" in _plain_output(result.output)
+    assert "BLOQUEADOS por falta de clave Firecrawl: 1 items" in _plain_output(result.output)
     assert calls == []  # the fetch never ran — nothing to gain, so nothing was requested
 
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -102,7 +102,7 @@ def test_compute_counts_topics_authors_and_deep_links():
         _item("102", "own_tweet", "claude-code", "vgonpa"),
     ]
     id2note = {"100": "/v/items/100.md", "101": "/v/items/101.md", "102": "/v/items/102.md"}
-    data = compute_dashboard_data(items, {}, id2note, [], "JUN 1, 2026")
+    data = compute_dashboard_data(items, {}, id2note, [], "JUN 1, 2026", "Spanish")
 
     m = data["meta"]
     assert (m["total"], m["bookmarks"], m["own"], m["enriched"], m["topics_count"]) == (
@@ -163,7 +163,7 @@ def test_long_form_and_media_counts():
         ),
         _item("4", media=[MediaPhotoPending(url="https://p2")]),
     ]
-    data = compute_dashboard_data(items, {}, {}, [], "JUN 1, 2026")
+    data = compute_dashboard_data(items, {}, {}, [], "JUN 1, 2026", "Spanish")
 
     lf = data["meta"]["longform"]
     assert (lf["ext_saved"], lf["ext_failed"], lf["saved"], lf["total"]) == (1, 1, 1, 2)
@@ -240,7 +240,7 @@ def test_growth_is_cumulative_across_months_with_month_slices():
             created=datetime(2026, 6, 5, tzinfo=timezone.utc),
         ),
     ]
-    data = compute_dashboard_data(items, {}, {}, [], "x")
+    data = compute_dashboard_data(items, {}, {}, [], "x", "Spanish")
     assert data["months"] == ["2026-05", "2026-06"]
     assert data["new_total"] == [1, 2]
     assert data["cum_total"] == [1, 3]
@@ -257,12 +257,12 @@ def test_domains_exclude_x_com():
         _item("1", links=[Link(url="https://x.com/a", domain="x.com")]),
         _item("2", links=[Link(url="https://ex.com/b", domain="ex.com")]),
     ]
-    data = compute_dashboard_data(items, {}, {}, [], "x")
+    data = compute_dashboard_data(items, {}, {}, [], "x", "Spanish")
     assert [d["domain"] for d in data["domains"]] == ["ex.com"]
 
 
 def test_empty_store_does_not_crash():
-    data = compute_dashboard_data([], {}, {}, [], "x")
+    data = compute_dashboard_data([], {}, {}, [], "x", "Spanish")
     assert data["meta"]["total"] == 0
     assert data["topics_sorted"] == [] and data["authors"] == [] and data["months"] == []
     assert data["meta"]["longform"]["saved_pct"] == 0.0  # ZeroDivisionError guard
@@ -285,7 +285,7 @@ def test_videos_row_content():
             ],
         )
     ]
-    data = compute_dashboard_data(items, {}, {}, [], "x")
+    data = compute_dashboard_data(items, {}, {}, [], "x", "Spanish")
     v = data["videos"]["items"][0]
     assert v["dur"] == 95 and v["poster"] == "https://poster"
 
@@ -326,7 +326,7 @@ def test_described_photos_count_as_downloaded_and_populate_photo_posts():
         _item("2", media=[_described_photo("2/0.png", decorative=True)]),
         _item("3", media=[MediaPhotoPending(url="https://p")]),
     ]
-    data = compute_dashboard_data(items, {}, {}, [], "JUN 1, 2026")
+    data = compute_dashboard_data(items, {}, {}, [], "JUN 1, 2026", "Spanish")
     md = data["meta"]["media"]
     assert (md["photos_downloaded"], md["photos_pending"]) == (2, 1)  # both described counted
     assert data["photos"]["downloaded"] == 2
@@ -368,3 +368,85 @@ def test_generate_writes_dashboard_with_valid_blob_and_links_it(tmp_path):
     data = json.loads(blob)
     assert data["meta"]["total"] == 2
     assert data["meta"]["bookmarks"] == 1 and data["meta"]["own"] == 1
+
+
+def _judged(item, target, verdict, *, language="Spanish"):
+    """Stamp a stored verdict on `item`, bound to the contract it was judged under.
+
+    Mirrors the write path in `verify --write-verdicts`: the verdict carries the
+    fingerprint of the output text and of the full contract (output + source +
+    rubrics). To make one go stale, re-generate the output afterwards — do not
+    hand-forge a hash, or the test passes on a fingerprint the product never writes.
+    """
+    from xbrain.models import VerificationVerdict
+    from xbrain.verification import contract_fingerprint, fingerprint_output
+
+    item.verification = dict(item.verification or {})
+    item.verification[target] = VerificationVerdict(
+        verdict=verdict,
+        faithfulness="PASS" if verdict != "FAIL" else "FAIL",
+        adherence="PASS",
+        output_fingerprint=fingerprint_output(item, target),
+        contract_fingerprint=contract_fingerprint(item, target, language),
+        verified_at=DT,
+        flags=[],
+    )
+    return item
+
+
+def test_verification_counts_outputs_not_items():
+    """One post carries several judgeable outputs; coverage is per output."""
+    data = compute_dashboard_data([_item("1"), _item("2")], {}, {}, [], "x", "Spanish")
+
+    v = data["verification"]
+    # Two enriched posts → two summaries + two topics assignments, no digests.
+    assert v["outputs"] == 4
+    assert v["judged"] == 0 and v["unjudged"] == 4
+    assert v["coverage_pct"] == 0.0
+    assert v["verdicts"] == {"PASS": 0, "REVIEW": 0, "FAIL": 0}
+
+
+def test_verification_reports_verdict_mix_and_coverage():
+    items = [
+        _judged(_item("1"), "summary", "PASS"),
+        _judged(_item("2"), "summary", "REVIEW"),
+        _item("3"),
+    ]
+
+    v = compute_dashboard_data(items, {}, {}, [], "x", "Spanish")["verification"]
+
+    assert v["outputs"] == 6 and v["judged"] == 2 and v["unjudged"] == 4
+    assert v["verdicts"] == {"PASS": 1, "REVIEW": 1, "FAIL": 0}
+    assert v["coverage_pct"] == 33.3
+
+
+def test_verification_treats_a_stale_verdict_as_unjudged():
+    """Re-generating a judged output invalidates its verdict — it stops counting.
+
+    A stale FAIL must not appear in the mix either: it describes text nobody
+    reads any more, so claiming a current failure would be as wrong as claiming
+    a current pass.
+    """
+    item = _judged(_item("1"), "summary", "FAIL")
+    # What actually happens: the summary is re-written after being judged.
+    item.enriched = item.enriched.model_copy(update={"summary": "resumen corregido"})
+    items = [item]
+
+    v = compute_dashboard_data(items, {}, {}, [], "x", "Spanish")["verification"]
+
+    assert v["stale"] == 1
+    assert v["judged"] == 0 and v["unjudged"] == 2
+    assert v["verdicts"]["FAIL"] == 0
+
+
+def test_verification_on_an_empty_store_does_not_divide_by_zero():
+    v = compute_dashboard_data([], {}, {}, [], "x", "Spanish")["verification"]
+
+    assert v == {
+        "outputs": 0,
+        "judged": 0,
+        "unjudged": 0,
+        "stale": 0,
+        "coverage_pct": 0.0,
+        "verdicts": {"PASS": 0, "REVIEW": 0, "FAIL": 0},
+    }

--- a/tests/test_entity_grounding.py
+++ b/tests/test_entity_grounding.py
@@ -502,3 +502,45 @@ def test_an_output_with_both_tiers_is_not_double_counted_as_uncertain_only():
     assert summary["uncertain_only_flagged"] == 0
     # ...but the tier's own entity count still sees it: nothing is hidden, only re-bucketed.
     assert summary["uncertain_entities"] == len(records[0].uncertain)
+
+
+def test_a_speech_disfluency_inside_a_name_no_longer_breaks_the_match():
+    """Measured on the store: the evidence for `Application Default Credentials` reads
+    "the application default uh credential". All three words are there and adjacent — one
+    ASR filler between them meant no window of the transcript ever spelled the name, and
+    the check reported a fabricated entity that the generator had recovered correctly."""
+    evidence = "the application default uh credential, which automatically finds credentials"
+
+    assert is_grounded("Application Default Credentials", evidence)
+
+
+def test_disfluencies_are_stripped_from_evidence_only():
+    """The output is written text: an "Ah" in it is a name or a word, never a filler.
+    Stripping there would silently ground `Ah Counting` off evidence about counting."""
+    assert not is_grounded("Uh Huh Industries", "a company that makes industrial widgets")
+
+
+def test_a_translated_name_matches_with_the_words_in_the_other_order():
+    """Spanish puts the adjective after the noun, English before it, so a translated name
+    arrives reversed: `Revolución Industrial` against "the industrial revolution". Needs no
+    lexicon entry, and generalises to pairs the corpus has not produced yet."""
+    assert is_grounded("Revolución Industrial", "kicked off by the industrial revolution")
+    # ...and the reversal is bounded: an unrelated long phrase sharing words stays flagged.
+    assert not is_grounded(
+        "Default Application Credentials Manager", "a manager for tokens and secrets"
+    )
+
+
+@pytest.mark.parametrize("evidence", ["rolled out in the USA", "across America", "United States"])
+def test_estados_unidos_grounds_on_the_forms_sources_actually_use(evidence):
+    """The most-flagged entity in the store (12 of 239 confident flags) and NOT ONE source
+    said "united states" — they said usa, u.s, america."""
+    assert is_grounded("Estados Unidos", evidence)
+
+
+def test_estados_unidos_is_not_grounded_by_the_english_pronoun():
+    """`us` is deliberately absent from the lexicon. Adding it would ground the country off
+    a pronoun present in nearly every transcript — that does not remove a false alarm, it
+    blinds the check to every invented mention of the US. 8 sources stay flagged because
+    of this, on purpose."""
+    assert not is_grounded("Estados Unidos", "this gives us a much better result")

--- a/tests/test_entity_grounding.py
+++ b/tests/test_entity_grounding.py
@@ -448,3 +448,57 @@ def test_the_gate_counts_only_the_confident_bucket():
     records = scan_store(store, "digest")
     assert {r.item_id for r in records} == {"1", "2"}, "both are still REPORTED"
     assert [r.item_id for r in gate_failures(records)] == ["1"], "only the confident one GATES"
+
+
+def test_summarise_scan_reports_the_uncertain_tier_it_sets_aside():
+    """`scan_store` was fixed to KEEP uncertain-only records; the summary then dropped them
+    again, so the terminal line and the report table showed neither. The one fabricated
+    name the LLM judges caught ("Suhail", opening a summary) lives in exactly this tier —
+    the check had the finding and no reader could reach it."""
+    from xbrain.entity_grounding import summarise_scan
+
+    confident = _item(digest="Clip de entrevista a Anthropic sobre software.")
+    uncertain = _item("2", digest="- Arranca con una pantalla en blanco.")
+
+    summary = summarise_scan(scan_store({"1": confident, "2": uncertain}, "digest"), {})
+
+    # The headline stays CONFIDENT-only — the tiers have different precision and one
+    # number for two instruments is how a reader ends up quoting the wrong one.
+    assert summary["flagged"] == 1 and summary["entities"] == 1
+    assert summary["uncertain_only_flagged"] == 1
+    assert summary["uncertain_entities"] == 1
+
+
+def test_report_lists_the_uncertain_candidates_instead_of_only_counting_them():
+    """A count with no rows cannot be judged, and judging is the only thing this tier is
+    good for at its precision."""
+    from xbrain.entity_grounding import render_entity_report, summarise_scan
+
+    records = scan_store(
+        {"2": _item("2", digest="- Arranca con una pantalla en blanco.")}, "digest"
+    )
+    summary = summarise_scan(records, {})
+
+    _, md = render_entity_report(records, summary, 1, "digest")
+
+    assert "## Uncertain tier" in md
+    assert "Arranca" in md, "the candidate itself must be listed, not just tallied"
+    assert "Judge these, do not count them." in md
+
+
+def test_an_output_with_both_tiers_is_not_double_counted_as_uncertain_only():
+    """`uncertain_only` means the uncertain tier is the ONLY signal. An output already
+    visible through a confident flag needs no second entry — it would inflate the tally
+    of findings a reader cannot otherwise see, which is the number's whole purpose."""
+    from xbrain.entity_grounding import summarise_scan
+
+    both = _item(digest="Arranca el clip de entrevista a Anthropic sobre software.")
+    records = scan_store({"1": both}, "digest")
+    assert records[0].ungrounded and records[0].uncertain, "fixture must carry both tiers"
+
+    summary = summarise_scan(records, {})
+
+    assert summary["flagged"] == 1
+    assert summary["uncertain_only_flagged"] == 0
+    # ...but the tier's own entity count still sees it: nothing is hidden, only re-bucketed.
+    assert summary["uncertain_entities"] == len(records[0].uncertain)

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -3,6 +3,8 @@ import socket
 import urllib.error
 from datetime import datetime, timezone
 
+import pytest
+
 from xbrain.enrich import items_pending_enrichment
 from xbrain.executors.api import links_content_unfetched, unfetched_links_note
 from xbrain.fetch import (
@@ -216,6 +218,133 @@ def test_firecrawl_extract_returns_none_without_api_key(monkeypatch):
 
     monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
     assert _firecrawl_extract("https://e.com/a") is None
+
+
+def _write_credentials(tmp_path, payload: str):
+    """Write a `firecrawl` CLI credentials file and point the lookup at it."""
+    path = tmp_path / "credentials.json"
+    path.write_text(payload)
+    return path
+
+
+def test_firecrawl_key_falls_back_to_cli_credentials(monkeypatch, tmp_path):
+    """A key the `firecrawl` CLI stored counts as configured — the measured defect.
+
+    39 repairable items sat at `attempts=1` because a key that WAS on the machine
+    was invisible to xbrain, so `_retryable_now` read "no fallback" and called
+    them terminal.
+    """
+    import json
+
+    from xbrain import fetch
+
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    path = _write_credentials(tmp_path, json.dumps({"apiKey": "fc-from-cli"}))
+    monkeypatch.setattr(fetch, "FIRECRAWL_CREDENTIAL_PATHS", (path,))
+
+    assert fetch.firecrawl_key() == "fc-from-cli"
+    assert fetch.firecrawl_available() is True
+
+
+def test_firecrawl_key_env_wins_over_credentials_file(monkeypatch, tmp_path):
+    import json
+
+    from xbrain import fetch
+
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-from-env")
+    path = _write_credentials(tmp_path, json.dumps({"apiKey": "fc-from-cli"}))
+    monkeypatch.setattr(fetch, "FIRECRAWL_CREDENTIAL_PATHS", (path,))
+
+    assert fetch.firecrawl_key() == "fc-from-env"
+
+
+def test_firecrawl_key_opt_out_beats_every_source(monkeypatch, tmp_path):
+    """`XBRAIN_NO_FIRECRAWL` is the hard "run without the fallback" switch."""
+    import json
+
+    from xbrain import fetch
+
+    monkeypatch.setenv("XBRAIN_NO_FIRECRAWL", "1")
+    monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-from-env")
+    path = _write_credentials(tmp_path, json.dumps({"apiKey": "fc-from-cli"}))
+    monkeypatch.setattr(fetch, "FIRECRAWL_CREDENTIAL_PATHS", (path,))
+
+    assert fetch.firecrawl_key() is None
+    assert fetch.firecrawl_available() is False
+
+
+def test_firecrawl_key_tries_each_location_in_order(monkeypatch, tmp_path):
+    """A missing first location must not stop the search at the first candidate."""
+    import json
+
+    from xbrain import fetch
+
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    second = tmp_path / "second.json"
+    second.write_text(json.dumps({"apiKey": "fc-second"}))
+    monkeypatch.setattr(fetch, "FIRECRAWL_CREDENTIAL_PATHS", (tmp_path / "absent.json", second))
+
+    assert fetch.firecrawl_key() == "fc-second"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["not json at all", "[]", "{}", '{"apiKey": ""}', '{"apiKey": "   "}', '{"apiKey": 42}'],
+)
+def test_firecrawl_key_survives_a_malformed_credentials_file(monkeypatch, tmp_path, payload):
+    """An unreadable / keyless credentials file yields None — it never raises.
+
+    The fallback is OPTIONAL; a corrupt file must not take down a fetch run.
+    """
+    from xbrain import fetch
+
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    path = _write_credentials(tmp_path, payload)
+    monkeypatch.setattr(fetch, "FIRECRAWL_CREDENTIAL_PATHS", (path,))
+
+    assert fetch.firecrawl_key() is None
+
+
+def test_firecrawl_key_strips_surrounding_whitespace(monkeypatch, tmp_path):
+    """A key with a trailing newline is still a key (a hand-edited file)."""
+    import json
+
+    from xbrain import fetch
+
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    path = _write_credentials(tmp_path, json.dumps({"apiKey": "  fc-padded\n"}))
+    monkeypatch.setattr(fetch, "FIRECRAWL_CREDENTIAL_PATHS", (path,))
+
+    assert fetch.firecrawl_key() == "fc-padded"
+
+
+def test_firecrawl_extract_uses_the_credentials_file_key(monkeypatch, tmp_path):
+    """End to end: the stored key actually reaches the Authorization header."""
+    import io
+    import json
+
+    from xbrain import fetch
+
+    monkeypatch.delenv("FIRECRAWL_API_KEY", raising=False)
+    path = _write_credentials(tmp_path, json.dumps({"apiKey": "fc-from-cli"}))
+    monkeypatch.setattr(fetch, "FIRECRAWL_CREDENTIAL_PATHS", (path,))
+    seen: dict = {}
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _opener(req, timeout=None):
+        seen["auth"] = req.headers.get("Authorization")
+        return _Resp(json.dumps({"data": {"markdown": "cuerpo"}}).encode())
+
+    result = fetch._firecrawl_extract("https://e.com/a", opener=_opener)
+
+    assert seen["auth"] == "Bearer fc-from-cli"
+    assert result.text == "cuerpo"
 
 
 def test_firecrawl_extract_parses_markdown(monkeypatch):

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1668,3 +1668,70 @@ def test_generate_does_not_badge_a_LEGACY_verdict_with_no_contract(tmp_path: Pat
     body = _note_body(tmp_path)
     assert "❌" not in body
     assert "Verification: FAIL" not in body
+
+
+def test_article_video_block_renders_a_playable_link(tmp_path: Path):
+    """A pending article video surfaces its stream — it must not render silently.
+
+    A pending IMAGE is silent because `xbrain media` will download it later. No
+    such pass exists for an article-embedded video, so silence here would
+    reproduce the very defect the video block was added to fix: a hole in the
+    prose where the author put a demo.
+    """
+    from xbrain.generate import _article_blocks_lines
+    from xbrain.i18n import strings_for
+    from xbrain.models import ArticleTextBlock, ArticleVideoBlock, MediaVideoPending
+
+    blocks = [
+        ArticleTextBlock(text="Watch this."),
+        ArticleVideoBlock(
+            media=MediaVideoPending(
+                url="https://video.twimg.com/amplify_video/1/vid/avc1/1920x1080/x.mp4",
+                thumbnail_url="https://pbs.twimg.com/amplify_video_thumb/1/img/y.jpg",
+                bitrate=10368000,
+                duration_millis=24016,
+            ),
+            alt="the demo",
+        ),
+    ]
+    source = ContentSourceSuccess(
+        kind="x_article",
+        url="https://x.com/i/article/99",
+        title="T",
+        text="".join(b.text for b in blocks if isinstance(b, ArticleTextBlock)),
+        blocks=blocks,
+    )
+    lines = _article_blocks_lines(source, strings_for("English"))
+    body = "\n".join(lines)
+
+    assert "https://video.twimg.com/amplify_video/1/vid/avc1/1920x1080/x.mp4" in body
+    assert "🎥" in body
+    assert "> the demo" in lines  # the alt becomes a caption
+    # The poster is NOT what we link: a still frame is not the video.
+    assert "amplify_video_thumb" not in body
+
+
+def test_article_markdown_code_block_renders_with_its_fences(tmp_path: Path):
+    """A recovered `MARKDOWN` block is multi-line by nature — its newlines survive.
+
+    Every other article text block is a single paragraph, so this is the first
+    one that spans lines. The fences have to reach the note intact or a code
+    listing renders as mangled prose.
+    """
+    from xbrain.generate import _article_blocks_lines
+    from xbrain.i18n import strings_for
+    from xbrain.models import ArticleTextBlock
+
+    code = "```python\nprint('hi')\nprint('bye')\n```"
+    blocks = [ArticleTextBlock(text="Before."), ArticleTextBlock(text=f"\n\n{code}")]
+    source = ContentSourceSuccess(
+        kind="x_article",
+        url="https://x.com/i/article/99",
+        title="T",
+        text="".join(b.text for b in blocks),
+        blocks=blocks,
+    )
+    body = "\n".join(_article_blocks_lines(source, strings_for("English")))
+
+    assert code in body
+    assert body.count("```") == 2  # opening and closing fence, both intact

--- a/tests/test_xbrain_transcribe_auto.py
+++ b/tests/test_xbrain_transcribe_auto.py
@@ -1,0 +1,238 @@
+# tests/test_xbrain_transcribe_auto.py — the scripts/xbrain-transcribe-auto ASR router.
+"""The routing decision is the whole point, so these tests pin the DECISION.
+
+parakeet does not fail on Spanish audio, it fabricates: exit 0, fluent broken
+English, nothing that was actually said. That failure is invisible downstream, so
+"which backend" must be settled before transcription and must fail toward whisper
+on every uncertainty.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "xbrain-transcribe-auto"
+_LOADER = SourceFileLoader("xbrain_transcribe_auto", str(_PATH))
+_SPEC = importlib.util.spec_from_loader("xbrain_transcribe_auto", _LOADER)
+xta = importlib.util.module_from_spec(_SPEC)
+_LOADER.exec_module(xta)
+
+
+@pytest.mark.parametrize(
+    "language,expected",
+    [
+        ("en", "parakeet"),
+        ("english", "parakeet"),
+        ("EN", "parakeet"),  # normalised by the caller, but the set is lowercase
+        ("es", "whisper"),
+        ("fr", "whisper"),
+        ("", "whisper"),
+        (None, "whisper"),  # UNDETECTED must never reach parakeet
+    ],
+)
+def test_pick_backend_routes_non_english_and_unknown_to_whisper(language, expected):
+    assert xta.pick_backend(language.lower() if isinstance(language, str) else language) == expected
+
+
+def _stub_tools(monkeypatch, *, ffmpeg=True, whisper=True):
+    monkeypatch.setattr(
+        xta.shutil,
+        "which",
+        lambda name: {
+            "ffmpeg": "/bin/ffmpeg" if ffmpeg else None,
+            "whisper": "/bin/whisper" if whisper else None,
+            "ffprobe": "/bin/ffprobe",
+        }.get(name),
+    )
+
+
+def test_detect_language_reads_whispers_reported_language(monkeypatch, tmp_path):
+    """Detection is whisper run WITHOUT `--language` — the omission is the request."""
+    _stub_tools(monkeypatch)
+    monkeypatch.setattr(xta.tempfile, "mkdtemp", lambda **k: str(tmp_path))
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, *a, **k):
+        seen.append(cmd)
+        if cmd[0] == "/bin/ffmpeg":
+            (tmp_path / "probe.wav").write_bytes(b"x")
+        else:
+            (tmp_path / "probe.json").write_text(json.dumps({"language": "Spanish"}))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(xta.subprocess, "run", fake_run)
+    monkeypatch.setattr(xta.shutil, "rmtree", lambda *a, **k: None)
+
+    assert xta.detect_language("/clips/a.mp4") == "spanish"
+    whisper_cmd = next(c for c in seen if c[0] == "/bin/whisper")
+    assert "--language" not in whisper_cmd
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["no_ffmpeg", "no_whisper", "ffmpeg_fails", "whisper_fails", "no_output", "bad_json"],
+)
+def test_detect_language_returns_none_on_every_failure(monkeypatch, tmp_path, scenario):
+    """Every uncertainty collapses to None — and None routes to whisper."""
+    _stub_tools(monkeypatch, ffmpeg=scenario != "no_ffmpeg", whisper=scenario != "no_whisper")
+    monkeypatch.setattr(xta.tempfile, "mkdtemp", lambda **k: str(tmp_path))
+    monkeypatch.setattr(xta.shutil, "rmtree", lambda *a, **k: None)
+
+    def fake_run(cmd, *a, **k):
+        if cmd[0] == "/bin/ffmpeg":
+            if scenario == "ffmpeg_fails":
+                return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+            (tmp_path / "probe.wav").write_bytes(b"x")
+            return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        if scenario == "whisper_fails":
+            return types.SimpleNamespace(returncode=1, stdout="", stderr="")
+        if scenario == "bad_json":
+            (tmp_path / "probe.json").write_text("{not json")
+        elif scenario != "no_output":
+            (tmp_path / "probe.json").write_text(json.dumps({"language": "es"}))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(xta.subprocess, "run", fake_run)
+
+    assert xta.detect_language("/clips/a.mp4") is None
+    assert xta.pick_backend(xta.detect_language("/clips/a.mp4")) == "whisper"
+
+
+def _drive(monkeypatch, tmp_path, *, language, no_audio=False, force=None, codes=None):
+    """Run main() with detection stubbed; return (rc, all_delegated_argvs, last_env).
+
+    `codes` maps a backend-script suffix to the exit code it should return, so a
+    test can make the GPU backend unavailable and watch the fallback.
+    """
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    calls: list[list[str]] = []
+    envs: list[dict] = []
+
+    monkeypatch.setattr(xta, "_confirmed_no_audio", lambda m: no_audio)
+    monkeypatch.setattr(xta, "detect_language", lambda m: language)
+    monkeypatch.delenv("XBRAIN_ASR_FORCE", raising=False)
+    if force:
+        monkeypatch.setenv("XBRAIN_ASR_FORCE", force)
+
+    def fake_run(cmd, *a, **k):
+        calls.append(cmd)
+        envs.append(k.get("env", {}))
+        code = 0
+        for suffix, value in (codes or {}).items():
+            if cmd[1].endswith(suffix):
+                code = value
+        return types.SimpleNamespace(returncode=code, stdout="", stderr="")
+
+    monkeypatch.setattr(xta.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "xbrain-transcribe-auto",
+            "--output-format",
+            "json",
+            "--output-dir",
+            str(tmp_path),
+            str(media),
+        ],
+    )
+    return xta.main(), calls, (envs[-1] if envs else {})
+
+
+def _last_backend(calls):
+    return calls[-1][1] if calls else None
+
+
+def test_english_is_delegated_to_parakeet(monkeypatch, tmp_path):
+    rc, calls, _env = _drive(monkeypatch, tmp_path, language="en")
+    assert rc == 0
+    assert len(calls) == 1
+    assert _last_backend(calls).endswith("xbrain-transcribe")
+
+
+def test_spanish_is_delegated_to_a_whisper_backend_with_its_language(monkeypatch, tmp_path):
+    """The measured bug: this exact clip used to reach parakeet and come back
+    as fabricated English."""
+    rc, calls, env = _drive(monkeypatch, tmp_path, language="es")
+    assert rc == 0
+    assert _last_backend(calls).endswith("xbrain-transcribe-mlx")  # GPU first
+    assert env["WHISPER_LANGUAGE"] == "es"
+
+
+def test_gpu_backend_failure_falls_back_to_the_cpu_one(monkeypatch, tmp_path):
+    """A missing accelerator must degrade to SLOW, never to wrong.
+
+    `xbrain-transcribe-mlx` exits non-zero without writing when it cannot run, so
+    the CPU wrapper gets a clean output dir and the same arguments.
+    """
+    rc, calls, env = _drive(
+        monkeypatch, tmp_path, language="es", codes={"xbrain-transcribe-mlx": 1}
+    )
+    assert rc == 0
+    assert [Path(c[1]).name for c in calls] == [
+        "xbrain-transcribe-mlx",
+        "xbrain-transcribe-whisper",
+    ]
+    assert env["WHISPER_LANGUAGE"] == "es"
+
+
+def test_both_whisper_backends_failing_surfaces_a_failure(monkeypatch, tmp_path):
+    """Nothing left to try is a real failure — never a silent success."""
+    rc, calls, _env = _drive(
+        monkeypatch,
+        tmp_path,
+        language="es",
+        codes={"xbrain-transcribe-mlx": 1, "xbrain-transcribe-whisper": 3},
+    )
+    assert rc == 3
+    assert len(calls) == 2
+
+
+def test_undetected_language_goes_to_whisper_on_autodetect(monkeypatch, tmp_path):
+    """Not Spanish-by-default: forcing a guessed language is the same class of bug."""
+    _rc, calls, env = _drive(monkeypatch, tmp_path, language=None)
+    assert _last_backend(calls).endswith("xbrain-transcribe-mlx")
+    assert env["WHISPER_LANGUAGE"] == "auto"
+
+
+def test_original_arguments_are_passed_through_untouched(monkeypatch, tmp_path):
+    _rc, calls, _env = _drive(monkeypatch, tmp_path, language="en")
+    assert calls[-1][2:] == [
+        "--output-format",
+        "json",
+        "--output-dir",
+        str(tmp_path),
+        str(tmp_path / "clip.mp4"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "force,name", [("parakeet", "xbrain-transcribe"), ("whisper", "xbrain-transcribe-mlx")]
+)
+def test_force_env_skips_detection(monkeypatch, tmp_path, force, name):
+    """An operator override must not pay for a detection pass it is overriding."""
+    called: list[str] = []
+    monkeypatch.setattr(xta, "detect_language", lambda m: called.append(m) or "es")
+    _rc, calls, _env = _drive(monkeypatch, tmp_path, language="es", force=force)
+    assert Path(_last_backend(calls)).name == name
+    assert called == []  # detection never ran
+
+
+def test_silent_video_short_circuits_before_any_detection(monkeypatch, tmp_path):
+    """A clip with no audio track needs no ASR and no language — just the signal."""
+    rc, calls, _env = _drive(monkeypatch, tmp_path, language="en", no_audio=True)
+    assert rc == 0
+    assert calls == []  # nothing was delegated
+    written = json.loads((tmp_path / "clip.json").read_text())
+    assert written == {"text": "", "language": None, "segments": [], "has_speech": False}
+
+
+def test_missing_media_is_a_clean_usage_error(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "argv", ["xbrain-transcribe-auto"])
+    assert xta.main() == 2

--- a/tests/test_xbrain_transcribe_mlx.py
+++ b/tests/test_xbrain_transcribe_mlx.py
@@ -1,0 +1,199 @@
+# tests/test_xbrain_transcribe_mlx.py — the scripts/xbrain-transcribe-mlx GPU backend.
+"""The GPU multilingual backend.
+
+Its reason to exist is a measurement, not a preference: the CPU whisper CLI took
+7 min 25 s on a 68-second Spanish clip from the store (six times slower than
+realtime) where mlx-whisper took 17.7 s for a character-identical transcript. The
+behaviour these tests pin is what makes that swap safe — when the accelerator is
+not available the script must fail LOUDLY and write NOTHING, so the router falls
+back instead of the pipeline recording a transcription failure.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "xbrain-transcribe-mlx"
+_LOADER = SourceFileLoader("xbrain_transcribe_mlx", str(_PATH))
+_SPEC = importlib.util.spec_from_loader("xbrain_transcribe_mlx", _LOADER)
+xtm = importlib.util.module_from_spec(_SPEC)
+_LOADER.exec_module(xtm)
+
+_RESULT = {
+    "text": " Hola, esto es una prueba. ",
+    "language": "es",
+    "segments": [{"start": 0.0, "end": 2.0, "text": " Hola, esto es una prueba. ", "tokens": [1]}],
+}
+
+
+def _drive(monkeypatch, tmp_path, *, result=_RESULT, uv=True, rc=0, no_audio=False, env=None):
+    """Run main() with the uv/mlx subprocess mocked; return (code, argv, out_path)."""
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    seen: dict = {}
+    for key, value in (env or {}).items():
+        monkeypatch.setenv(key, value)
+
+    monkeypatch.setattr(xtm.shutil, "which", lambda n: "/bin/uv" if uv else None)
+    monkeypatch.setattr(xtm, "confirmed_no_audio", lambda m: no_audio)
+
+    def fake_run(cmd, *a, **k):
+        seen["argv"] = cmd
+        stdout = json.dumps(result) if (rc == 0 and result is not None) else ""
+        return types.SimpleNamespace(returncode=rc, stdout=stdout, stderr="boom")
+
+    monkeypatch.setattr(xtm.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "xbrain-transcribe-mlx",
+            "--output-format",
+            "json",
+            "--output-dir",
+            str(tmp_path),
+            str(media),
+        ],
+    )
+    return xtm.main(), seen.get("argv"), tmp_path / "clip.json"
+
+
+def test_output_is_normalised_to_the_shape_xbrain_reads(monkeypatch, tmp_path):
+    code, _argv, out = _drive(monkeypatch, tmp_path)
+    assert code == 0
+    written = json.loads(out.read_text())
+    assert written["text"] == "Hola, esto es una prueba."
+    assert written["language"] == "es"
+    assert written["has_speech"] is True
+    # Extra model fields (tokens, avg_logprob…) are dropped; the shape is fixed.
+    assert written["segments"] == [{"start": 0.0, "end": 2.0, "text": "Hola, esto es una prueba."}]
+
+
+@pytest.mark.parametrize(
+    "reason,kwargs",
+    [
+        ("no uv on PATH", {"uv": False}),
+        ("uv/mlx exited non-zero", {"rc": 1}),
+        ("no output at all", {"result": None}),
+    ],
+)
+def test_unusable_backend_fails_without_writing_anything(monkeypatch, tmp_path, reason, kwargs):
+    """The fallback contract. A written file would make the router think it worked."""
+    code, _argv, out = _drive(monkeypatch, tmp_path, **kwargs)
+    assert code == 1, reason
+    assert not out.exists(), reason
+
+
+def test_unreadable_output_is_a_failure_not_a_crash(monkeypatch, tmp_path):
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    monkeypatch.setattr(xtm.shutil, "which", lambda n: "/bin/uv")
+    monkeypatch.setattr(xtm, "confirmed_no_audio", lambda m: False)
+    monkeypatch.setattr(
+        xtm.subprocess,
+        "run",
+        lambda *a, **k: types.SimpleNamespace(returncode=0, stdout="{not json", stderr=""),
+    )
+    monkeypatch.setattr(sys, "argv", ["x", "--output-dir", str(tmp_path), str(media)])
+    assert xtm.main() == 1
+    assert not (tmp_path / "clip.json").exists()
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        (None, "mlx-community/whisper-small-mlx"),
+        ("small", "mlx-community/whisper-small-mlx"),
+        ("large-v3-turbo", "mlx-community/whisper-large-v3-turbo"),
+        ("someone/custom-mlx-repo", "someone/custom-mlx-repo"),  # explicit repo passes through
+        ("mlx-community/parakeet-tdt-0.6b-v2", "mlx-community/parakeet-tdt-0.6b-v2"),
+        ("not-a-model", "mlx-community/whisper-small-mlx"),  # unknown name → the default
+    ],
+)
+def test_resolve_repo_maps_names_and_passes_repos_through(monkeypatch, model, expected):
+    monkeypatch.delenv("WHISPER_MODEL", raising=False)
+    assert xtm.resolve_repo(model) == expected
+
+
+def test_language_is_forwarded_to_the_model(monkeypatch, tmp_path):
+    _code, argv, _out = _drive(monkeypatch, tmp_path, env={"WHISPER_LANGUAGE": "es"})
+    assert argv is not None and argv[-1] == "es"
+
+
+@pytest.mark.parametrize("value", ["auto", "AUTO", ""])
+def test_auto_language_lets_the_model_detect(monkeypatch, tmp_path, value):
+    """An empty language is the detection request — never a guessed default."""
+    _code, argv, _out = _drive(monkeypatch, tmp_path, env={"WHISPER_LANGUAGE": value})
+    assert argv is not None and argv[-1] == ""
+
+
+def test_public_index_is_pinned_on_the_uv_resolve(monkeypatch, tmp_path):
+    """The machine's pip.conf points at a private index that needs auth and would
+    hang the resolve waiting on stdin."""
+    _code, argv, _out = _drive(monkeypatch, tmp_path)
+    assert argv is not None
+    assert argv[argv.index("--index-url") + 1] == "https://pypi.org/simple"
+
+
+def test_confirmed_silent_video_yields_empty_speech_without_running_the_model(
+    monkeypatch, tmp_path
+):
+    code, argv, out = _drive(monkeypatch, tmp_path, no_audio=True)
+    assert code == 0
+    assert argv is None  # the model never ran
+    assert json.loads(out.read_text())["has_speech"] is False
+
+
+@pytest.mark.parametrize(
+    "artefact",
+    [
+        "Subtítulos realizados por la comunidad de Amara.org",
+        "Thanks for watching!",
+        "[Música]",
+    ],
+)
+def test_no_speech_hallucinations_are_discarded_here_too(monkeypatch, tmp_path, artefact):
+    """Both whisper backends wrap the same model family, so both inherit the
+    artefact — a guard on only one would make the vault's protection depend on
+    which machine ran the nightly."""
+    _code, _argv, out = _drive(
+        monkeypatch,
+        tmp_path,
+        result={
+            "text": artefact,
+            "language": "es",
+            "segments": [{"start": 0.0, "end": 1.0, "text": artefact}],
+        },
+    )
+    written = json.loads(out.read_text())
+    assert written["text"] == ""
+    assert written["segments"] == []
+    assert written["has_speech"] is False
+
+
+def test_real_speech_mentioning_an_artefact_phrase_survives(monkeypatch, tmp_path):
+    real = "Thanks for watching! Now here is the actual demo."
+    _code, _argv, out = _drive(
+        monkeypatch, tmp_path, result={"text": real, "language": "en", "segments": []}
+    )
+    assert json.loads(out.read_text())["text"] == real
+
+
+def test_missing_media_is_a_clean_usage_error(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["xbrain-transcribe-mlx", "--output-dir", "/tmp"])
+    assert xtm.main() == 2
+
+
+def test_hallucination_lists_are_identical_across_both_whisper_backends():
+    """One drifting list would silently reopen the hole on one backend only."""
+    other = Path(__file__).resolve().parent.parent / "scripts" / "xbrain-transcribe-whisper"
+    loader = SourceFileLoader("xbrain_transcribe_whisper_cmp", str(other))
+    spec = importlib.util.spec_from_loader("xbrain_transcribe_whisper_cmp", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    assert xtm.NO_SPEECH_ARTEFACTS == module._NO_SPEECH_ARTEFACTS

--- a/tests/test_xbrain_transcribe_whisper.py
+++ b/tests/test_xbrain_transcribe_whisper.py
@@ -1,0 +1,226 @@
+# tests/test_xbrain_transcribe_whisper.py — the scripts/xbrain-transcribe-whisper wrapper.
+"""The multilingual backend. It lived untested outside the repo for a month.
+
+That is not incidental to the bug it was written to fix: it was authored on
+17-jul-2026 after parakeet was measured fabricating Spanish, and then never wired
+into `config.toml`, so every Spanish video in the nightly kept going to parakeet.
+A backend that is not in the repo is a backend nobody can see is unused.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+
+import pytest
+
+_PATH = Path(__file__).resolve().parent.parent / "scripts" / "xbrain-transcribe-whisper"
+_LOADER = SourceFileLoader("xbrain_transcribe_whisper", str(_PATH))
+_SPEC = importlib.util.spec_from_loader("xbrain_transcribe_whisper", _LOADER)
+xtw = importlib.util.module_from_spec(_SPEC)
+_LOADER.exec_module(xtw)
+
+_WHISPER_JSON = {
+    "text": "  Hola, esto es una prueba.  ",
+    "language": "spanish",
+    "segments": [{"start": 0.0, "end": 2.0, "text": " Hola, esto es una prueba. ", "extra": 1}],
+}
+
+
+def _drive(monkeypatch, tmp_path, *, whisper_json=_WHISPER_JSON, rc=0, no_audio=False, env=None):
+    """Run main() with the `whisper` CLI mocked; return (exit_code, argv, out_path)."""
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    seen: dict = {}
+    for key, value in (env or {}).items():
+        monkeypatch.setenv(key, value)
+
+    def fake_run(cmd, *a, **k):
+        seen["argv"] = cmd
+        if rc == 0 and whisper_json is not None:
+            (tmp_path / "clip.json").write_text(json.dumps(whisper_json))
+        return types.SimpleNamespace(returncode=rc, stdout="", stderr="")
+
+    monkeypatch.setattr(xtw.subprocess, "run", fake_run)
+    monkeypatch.setattr(xtw, "_confirmed_no_audio", lambda m: no_audio)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "xbrain-transcribe-whisper",
+            "--output-format",
+            "json",
+            "--output-dir",
+            str(tmp_path),
+            str(media),
+        ],
+    )
+    return xtw.main(), seen.get("argv"), tmp_path / "clip.json"
+
+
+def test_output_is_normalised_to_the_shape_xbrain_reads(monkeypatch, tmp_path):
+    """xbrain reads {text, language, segments, has_speech} — whisper emits its own."""
+    code, _argv, out = _drive(monkeypatch, tmp_path)
+    assert code == 0
+    written = json.loads(out.read_text())
+    assert written["text"] == "Hola, esto es una prueba."  # stripped
+    assert written["language"] == "spanish"
+    assert written["has_speech"] is True
+    assert written["segments"] == [{"start": 0.0, "end": 2.0, "text": "Hola, esto es una prueba."}]
+
+
+def test_language_defaults_to_spanish(monkeypatch, tmp_path):
+    monkeypatch.delenv("WHISPER_LANGUAGE", raising=False)
+    _code, argv, _out = _drive(monkeypatch, tmp_path)
+    assert argv is not None
+    assert argv[argv.index("--language") + 1] == "Spanish"
+
+
+@pytest.mark.parametrize("value", ["auto", "AUTO", ""])
+def test_auto_language_omits_the_flag_so_whisper_detects(monkeypatch, tmp_path, value):
+    """The router passes "auto" when it could not identify the clip.
+
+    Forcing the Spanish default onto an UNKNOWN language would be the same class
+    of error as sending it to parakeet — an assumption presented as a transcript.
+    """
+    _code, argv, _out = _drive(monkeypatch, tmp_path, env={"WHISPER_LANGUAGE": value})
+    assert argv is not None
+    assert "--language" not in argv
+
+
+def test_a_parakeet_model_id_is_ignored_not_passed_to_whisper(monkeypatch, tmp_path):
+    """`--model mlx-community/...` is meaningless here; fall back to WHISPER_MODEL."""
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    seen: dict = {}
+
+    def fake_run(cmd, *a, **k):
+        seen["argv"] = cmd
+        (tmp_path / "clip.json").write_text(json.dumps(_WHISPER_JSON))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(xtw.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "xbrain-transcribe-whisper",
+            "--model",
+            "mlx-community/parakeet-tdt-0.6b-v2",
+            "--output-dir",
+            str(tmp_path),
+            str(media),
+        ],
+    )
+    assert xtw.main() == 0
+    assert seen["argv"][seen["argv"].index("--model") + 1] == "small"
+
+
+def test_a_real_whisper_model_id_is_honoured(monkeypatch, tmp_path):
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"x")
+    seen: dict = {}
+
+    def fake_run(cmd, *a, **k):
+        seen["argv"] = cmd
+        (tmp_path / "clip.json").write_text(json.dumps(_WHISPER_JSON))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(xtw.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "xbrain-transcribe-whisper",
+            "--model",
+            "large-v3-turbo",
+            "--output-dir",
+            str(tmp_path),
+            str(media),
+        ],
+    )
+    assert xtw.main() == 0
+    assert seen["argv"][seen["argv"].index("--model") + 1] == "large-v3-turbo"
+
+
+def test_confirmed_silent_video_yields_empty_speech_not_a_failure(monkeypatch, tmp_path):
+    code, _argv, out = _drive(monkeypatch, tmp_path, whisper_json=None, no_audio=True)
+    assert code == 0
+    assert json.loads(out.read_text())["has_speech"] is False
+
+
+def test_no_output_with_audio_present_is_a_real_failure(monkeypatch, tmp_path):
+    """Unverifiable silence must NOT be masked as a silent video."""
+    code, _argv, _out = _drive(monkeypatch, tmp_path, whisper_json=None, no_audio=False)
+    assert code == 1
+
+
+def test_whisper_nonzero_exit_propagates(monkeypatch, tmp_path):
+    code, _argv, _out = _drive(monkeypatch, tmp_path, rc=3)
+    assert code == 3
+
+
+def test_empty_transcript_reports_no_speech(monkeypatch, tmp_path):
+    _code, _argv, out = _drive(
+        monkeypatch, tmp_path, whisper_json={"text": "   ", "language": "es", "segments": []}
+    )
+    assert json.loads(out.read_text())["has_speech"] is False
+
+
+def test_missing_media_is_a_clean_usage_error(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["xbrain-transcribe-whisper", "--output-dir", "/tmp"])
+    assert xtw.main() == 2
+
+
+@pytest.mark.parametrize(
+    "artefact",
+    [
+        "Subtítulos realizados por la comunidad de Amara.org",  # the REAL store case
+        "subtitles by the Amara.org community",
+        "Thanks for watching!",
+        "  ♪♪♪  ",
+        "[Música]",
+    ],
+)
+def test_whisper_no_speech_hallucinations_are_discarded(monkeypatch, tmp_path, artefact):
+    """Whisper invents subtitle boilerplate on silent audio — it is not speech.
+
+    `ffprobe` cannot catch this: the file HAS an audio stream, it just carries no
+    speech. Item 2082467662735507767 reached the vault as a "transcript" reading
+    only the Amara credit line, recorded `has_speech=true`.
+    """
+    _code, _argv, out = _drive(
+        monkeypatch,
+        tmp_path,
+        whisper_json={
+            "text": artefact,
+            "language": "spanish",
+            "segments": [{"start": 0.0, "end": 1.0, "text": artefact}],
+        },
+    )
+    written = json.loads(out.read_text())
+    assert written["text"] == ""
+    assert written["segments"] == []
+    assert written["has_speech"] is False
+
+
+@pytest.mark.parametrize(
+    "real",
+    [
+        "Thanks for watching! Now let me show you the actual demo.",
+        "En este vídeo hablo de Amara.org y de cómo funciona la comunidad.",
+        "Music theory is what this whole talk is about.",
+    ],
+)
+def test_real_speech_mentioning_an_artefact_phrase_survives(monkeypatch, tmp_path, real):
+    """Whole-transcript match only — a video that MENTIONS these is a real video."""
+    _code, _argv, out = _drive(
+        monkeypatch,
+        tmp_path,
+        whisper_json={"text": real, "language": "en", "segments": []},
+    )
+    written = json.loads(out.read_text())
+    assert written["text"] == real
+    assert written["has_speech"] is True


### PR DESCRIPTION
Five commits, one theme: the pipeline was dropping content and saying nothing about it.

## What was being lost

**Article blocks.** X serialises long-form Articles as Draft.js `blocks` + `entityMap`. The parser understood exactly two shapes — plain text and an `atomic` IMAGE — and silently discarded everything else: MARKDOWN/TEXT/HTML paragraph bodies, DIVIDER section breaks, embedded TWEETs, and embedded VIDEOs. Built against 29 real captured payloads, not a guess at the schema, which is the only reason the `bit_rate` vs `bitrate` bug turned up: X spells the key one way and `select_variant` reads the other, so **every** article video was silently resolving to the lowest-quality mp4.

**Transcripts.** `parakeet-mlx` is English-only and does not fail on Spanish — it fabricates fluent English. On a bilingual corpus that is the worst failure mode available: a confident transcript nobody can tell is invented, feeding the digest and every summary downstream. `xbrain-transcribe-auto` detects the language on the first 30s and dispatches; any uncertainty goes to whisper, never to parakeet. Also fixes a real hallucination already in the vault (whisper's subtitle-credit boilerplate over near-silent audio, stored as `has_speech=true`, which ffprobe cannot catch because the file does have an audio stream).

**Articles that could have been recovered.** The Firecrawl key was read only from `$FIRECRAWL_API_KEY`, so anyone logged in via the Firecrawl CLI had a working key on disk and still got the fallback extractor. No error, fewer articles, nothing to grep for.

## And one thing that was being over-claimed

The dashboard showed `Enriched 100%` with no way to tell enriched from **checked**. Panel 09 now draws one full-width bar across the whole population — PASS / REVIEW / FAIL / UNJUDGED — so the judged slice can only be read against the total. On the current corpus that is 51 of 4,843 outputs: **1.1% coverage**, which is the honest number and looks nothing like "96% PASS".

Stale verdicts count as unjudged, not as their stored verdict. Re-generating a judged output invalidates it, and this is not hypothetical — the two FAILs from the last pass went stale the moment their summaries were fixed.

## Notes for review

- `tests/conftest.py` gains an autouse fixture that points Firecrawl credential lookup at `tmp_path`. Without it, the existing "no key" tests would read the reviewer's own machine and pass or fail depending on whether they happen to be logged into Firecrawl.
- The last commit is the fail-closed quality gate catching all three new scripts on its first outing: ruff does not discover extensionless `#!/usr/bin/env python3` files from a directory, so it had been walking past them. Listing them surfaced 3 real E702s.
- `config.toml` is gitignored, so the ASR wiring is documented in `config.toml.example`.

Gate: 1724 passed · ruff clean · mypy clean on 48 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)