### PR TITLE
fix(media): skip byte-identical writes so a synced vault stops forking

### DIFF
--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import filecmp
 import logging
 import shutil
 from datetime import datetime, timezone
@@ -475,15 +476,32 @@ def _mirror_file(item_id: str, source: Path, destination: Path) -> None:
 def _already_mirrored(source: Path, destination: Path) -> bool:
     """True when `destination` already holds exactly `source`'s bytes.
 
-    Size is checked first so the common case settles from metadata alone,
-    without faulting in two files whose bytes may live only in the cloud. A
-    stat/read failure answers False: mirroring anyway is the safe direction —
+    `filecmp.cmp(shallow=False)` compares sizes from `stat` first and only then
+    reads, in 8 KB chunks with an early exit on the first differing byte. The
+    naive `source.read_bytes() == destination.read_bytes()` would hold BOTH
+    files in memory at once, and this walk mirrors `MediaVideoDownloaded` as
+    well as photos — one `download-videos` mp4 would be loaded twice over.
+
+    Do NOT read the size check as "the cloud-only case settles from metadata".
+    It settles the DIVERGENT case, which is the rare one; the common case here
+    is a destination that is already identical, whose size therefore matches
+    and whose bytes do get read. On an evicted iCloud file that read faults the
+    bytes back in. That is inherent to answering "are these the same bytes" —
+    the alternative (trusting size+mtime, rsync-style) would silently leave a
+    corrupted same-size copy in place, which the sibling test forbids. Reading
+    is still far cheaper than the rewrite it replaces, and it happens once per
+    run instead of writing every run.
+
+    `filecmp`'s result cache is keyed on both paths AND both stat signatures,
+    so a file that changed gets a new key. It cannot go stale here anyway: a
+    given (source, destination) pair is compared at most once per `generate`
+    run.
+
+    A stat/read failure answers False: mirroring anyway is the safe direction —
     it costs a redundant copy, never a stale or missing embed.
     """
     try:
-        if source.stat().st_size != destination.stat().st_size:
-            return False
-        return source.read_bytes() == destination.read_bytes()
+        return filecmp.cmp(source, destination, shallow=False)
     except OSError:
         return False
 

--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -448,6 +448,16 @@ def _mirror_file(item_id: str, source: Path, destination: Path) -> None:
     generator; the Obsidian embed then renders as a broken image, the right signal.
     Shared by the photo/video block and the `x_video` slide-frame embeds so the
     self-contained-vault mirroring has ONE implementation.
+
+    A destination that already holds the source bytes is left alone. `generate`
+    re-mirrors the WHOLE media tree on every run and the nightly job runs it
+    nightly, so without this the vault sees thousands of no-op rewrites a night.
+    On a cloud-synced vault that is not free: each rewrite is a modification the
+    sync client must reconcile, and iCloud resolves a clash with a not-yet-uploaded
+    version by keeping BOTH — the loser as a `name N.ext` sibling. The x-knowledge
+    vault accumulated 8.41 GB across 50,020 such copies, every one byte-identical
+    to the file beside it. Comparing before writing is far cheaper than the
+    rewrite it replaces.
     """
     if not source.exists():
         logger.warning(
@@ -456,8 +466,26 @@ def _mirror_file(item_id: str, source: Path, destination: Path) -> None:
             source,
         )
         return
+    if _already_mirrored(source, destination):
+        return
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, destination)
+
+
+def _already_mirrored(source: Path, destination: Path) -> bool:
+    """True when `destination` already holds exactly `source`'s bytes.
+
+    Size is checked first so the common case settles from metadata alone,
+    without faulting in two files whose bytes may live only in the cloud. A
+    stat/read failure answers False: mirroring anyway is the safe direction —
+    it costs a redundant copy, never a stale or missing embed.
+    """
+    try:
+        if source.stat().st_size != destination.stat().st_size:
+            return False
+        return source.read_bytes() == destination.read_bytes()
+    except OSError:
+        return False
 
 
 def _mirror_item_media(item: Item, media_root: Path, vault_media_dir: Path) -> None:

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -707,19 +707,29 @@ def _write_bytes(path: Path, data: bytes) -> None:
     `download_all` entry — see `_sweep_part_orphans`.
 
     A byte-identical rewrite returns early instead of replacing the file.
-    `os.replace` installs a fresh inode even when nothing changed, and on a
-    cloud-synced vault (iCloud Drive, and the same class of conflict handling
-    in Dropbox/OneDrive) that counts as an overwrite: the sync client keeps
-    the version it had not finished uploading as a `name N.ext` sibling.
-    `download_all` is idempotent at the item level, but a full refresh rebuilds
-    the item state and so re-downloads every photo — thousands of no-op
-    overwrites within minutes, one conflict copy each. The skip keeps the
-    inode, so the sync client sees nothing to reconcile.
+    `os.replace` installs a fresh inode even when nothing changed, and
+    `download_all` — idempotent at the item level — re-downloads every photo
+    on a full refresh, because the refresh rebuilds the item state. That is
+    thousands of no-op overwrites within minutes.
 
-    The size check short-circuits the comparison, which matters on a synced
-    tree: it settles most calls from metadata alone instead of faulting in a
-    file whose bytes live only in the cloud. A stat/read failure is not fatal
-    here — we fall through and write, preserving the previous behaviour.
+    What this skip is NOT: the cause of the conflict copies that filled the
+    Obsidian vault. That damage is `generate._mirror_file`'s alone, and the
+    measurement separates them cleanly — `data/media/`, the tree THIS function
+    writes, held 0 files matching iCloud's `name N.ext` conflict pattern, while
+    the vault's `_media/` held 43,791. `data_dir` is a path under the repo, not
+    under the synced vault, so no sync client has ever watched these writes.
+
+    It is still worth skipping. The writes are pure waste either way, and the
+    function makes no assumption about where `data_dir` points: someone whose
+    store DOES live in a synced or backed-up tree gets the same protection
+    `_mirror_file` gets, for free.
+
+    The size check short-circuits before the read, so a differing payload is
+    rejected from metadata alone. It does not spare the common case, which is
+    an identical file whose size matches and whose bytes are therefore read —
+    cheap here, because `data` is already in memory and only the on-disk side
+    is read. A stat/read failure is not fatal: we fall through and write,
+    preserving the previous behaviour.
     """
     try:
         if path.stat().st_size == len(data) and path.read_bytes() == data:

--- a/src/xbrain/media.py
+++ b/src/xbrain/media.py
@@ -695,7 +695,7 @@ def _decode_image(data: bytes) -> tuple[int, int, str] | None:
 
 
 def _write_bytes(path: Path, data: bytes) -> None:
-    """Write `data` to `path` atomically (tmp file + rename).
+    """Write `data` to `path` atomically (tmp file + rename), skipping no-ops.
 
     Atomic write mirrors `xbrain.store._atomic_write`: a Ctrl-C between
     `open` and `write_bytes` would leave a zero-byte partial file that the
@@ -705,7 +705,27 @@ def _write_bytes(path: Path, data: bytes) -> None:
     Orphan `.part` files left behind by a hard interruption (SIGKILL, OOM)
     that bypassed our `except BaseException` cleanup are swept on the next
     `download_all` entry — see `_sweep_part_orphans`.
+
+    A byte-identical rewrite returns early instead of replacing the file.
+    `os.replace` installs a fresh inode even when nothing changed, and on a
+    cloud-synced vault (iCloud Drive, and the same class of conflict handling
+    in Dropbox/OneDrive) that counts as an overwrite: the sync client keeps
+    the version it had not finished uploading as a `name N.ext` sibling.
+    `download_all` is idempotent at the item level, but a full refresh rebuilds
+    the item state and so re-downloads every photo — thousands of no-op
+    overwrites within minutes, one conflict copy each. The skip keeps the
+    inode, so the sync client sees nothing to reconcile.
+
+    The size check short-circuits the comparison, which matters on a synced
+    tree: it settles most calls from metadata alone instead of faulting in a
+    file whose bytes live only in the cloud. A stat/read failure is not fatal
+    here — we fall through and write, preserving the previous behaviour.
     """
+    try:
+        if path.stat().st_size == len(data) and path.read_bytes() == data:
+            return
+    except OSError:
+        pass
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(path.suffix + ".part")
     try:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,4 +1,5 @@
 # tests/test_generate.py
+import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1721,11 +1722,22 @@ def test_mirror_file_rewrites_a_destination_that_drifted(tmp_path: Path):
     assert destination.read_bytes() == b"fresh pixels"
 
 
-def test_mirror_file_rewrites_when_sizes_match_but_bytes_differ(tmp_path: Path):
-    """Same-length but different content must still be repaired.
+def test_mirror_file_rewrites_when_the_whole_stat_matches_but_bytes_differ(tmp_path: Path):
+    """Identical size AND identical mtime, different content — still repaired.
 
-    Guards the size short-circuit: comparing lengths alone would silently
-    leave a corrupted same-size vault copy in place forever.
+    Guards the comparison against being satisfied by METADATA. An earlier
+    version of this test wrote the two files at different moments, so their
+    mtimes differed and any stat-only comparison already answered "different";
+    it passed against a `filecmp.cmp(..., shallow=True)` mutant that skips the
+    repair entirely. Measured: mutate the comparison to `shallow=True` and this
+    file's three tests all stayed green.
+
+    Copying the source's timestamps onto the destination makes the two stat
+    signatures identical, so nothing but reading the bytes can tell them apart.
+    That is the corrupted-vault-copy case: `copy2` restores the source's mtime
+    on every mirror, so a copy damaged in place — a truncating sync client, a
+    half-written file, bit rot — really can carry the source's timestamp and a
+    matching length while holding the wrong bytes.
     """
     source = tmp_path / "store" / "0.jpg"
     source.parent.mkdir(parents=True)
@@ -1733,6 +1745,10 @@ def test_mirror_file_rewrites_when_sizes_match_but_bytes_differ(tmp_path: Path):
     destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
     destination.parent.mkdir(parents=True)
     destination.write_bytes(b"BBBB")
+    stat = source.stat()
+    os.utime(destination, ns=(stat.st_atime_ns, stat.st_mtime_ns))
+    assert destination.stat().st_size == stat.st_size
+    assert destination.stat().st_mtime_ns == stat.st_mtime_ns
 
     _mirror_file("1", source, destination)
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,8 +1,9 @@
 # tests/test_generate.py
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.generate import generate
+from xbrain.generate import _mirror_file, generate
 from xbrain.models import (
     Author,
     Content,
@@ -1668,3 +1669,71 @@ def test_generate_does_not_badge_a_LEGACY_verdict_with_no_contract(tmp_path: Pat
     body = _note_body(tmp_path)
     assert "❌" not in body
     assert "Verification: FAIL" not in body
+
+
+def test_mirror_file_leaves_an_unchanged_destination_untouched(tmp_path: Path):
+    """Re-mirroring identical bytes must not rewrite the vault copy.
+
+    `generate` mirrors every photo, video and slide frame into the vault's
+    `_media/` tree on EVERY run, and the nightly job runs `generate` nightly.
+    `shutil.copy2` truncates and rewrites the destination even when nothing
+    changed, which a cloud-synced vault reads as a modification: iCloud keeps
+    the version it had not finished uploading as a `name N.ext` sibling. The
+    x-knowledge vault accumulated 8.41 GB of such conflict copies — 50,020
+    files, all byte-identical to the sibling they were forked from.
+
+    Asserted on `st_ctime_ns`, not mtime or inode: `copy2` truncates in place
+    (same inode) and `copystat` restores the source mtime, so both look
+    untouched after a rewrite. Only ctime records that the bytes were written
+    — which is exactly the "this file was modified" signal a sync client acts
+    on.
+    """
+    source = tmp_path / "store" / "0.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"pixels")
+    destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
+    _mirror_file("1", source, destination)
+    before = destination.stat()
+    time.sleep(0.01)
+
+    _mirror_file("1", source, destination)
+
+    after = destination.stat()
+    assert after.st_ctime_ns == before.st_ctime_ns
+    assert destination.read_bytes() == b"pixels"
+
+
+def test_mirror_file_rewrites_a_destination_that_drifted(tmp_path: Path):
+    """A destination whose bytes differ still gets overwritten.
+
+    The skip must not strand a stale vault copy: if the store's bytes changed,
+    or the vault copy was corrupted/edited, the mirror has to repair it.
+    """
+    source = tmp_path / "store" / "0.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"fresh pixels")
+    destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"stale")
+
+    _mirror_file("1", source, destination)
+
+    assert destination.read_bytes() == b"fresh pixels"
+
+
+def test_mirror_file_rewrites_when_sizes_match_but_bytes_differ(tmp_path: Path):
+    """Same-length but different content must still be repaired.
+
+    Guards the size short-circuit: comparing lengths alone would silently
+    leave a corrupted same-size vault copy in place forever.
+    """
+    source = tmp_path / "store" / "0.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"AAAA")
+    destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"BBBB")
+
+    _mirror_file("1", source, destination)
+
+    assert destination.read_bytes() == b"AAAA"

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -22,6 +22,7 @@ from xbrain.media import (
     _iter_eligible_article_images,
     _local_path,
     _url_with_name,
+    _write_bytes,
     download_all,
     emit_summary_line,
 )
@@ -777,6 +778,66 @@ def test_download_all_sweeps_part_orphans_on_entry(tmp_path: Path):
     )
     download_all({"123": item}, media_root=tmp_path, session=session, throttle_seconds=0)
     assert not orphan.exists()
+
+
+def test_write_bytes_leaves_an_identical_file_untouched(tmp_path: Path):
+    """Re-writing the same bytes must not replace the file on disk.
+
+    `os.replace` swaps a fresh inode into place even when the content is
+    byte-identical. On an iCloud-synced tree that reads as an overwrite, and
+    iCloud preserves the losing version as `name N.ext` rather than dropping
+    it. A full refresh re-downloads every photo, so ~3.2k such no-op
+    overwrites fired within minutes and forked the whole media tree — 8.41 GB
+    of conflict copies accumulated in the x-knowledge vault this way.
+
+    Skipping the write keeps the inode, so iCloud sees nothing to reconcile.
+    """
+    target = tmp_path / "0.jpg"
+    payload = _png_bytes()
+    _write_bytes(target, payload)
+    before = target.stat()
+
+    _write_bytes(target, payload)
+
+    after = target.stat()
+    assert after.st_ino == before.st_ino
+    assert after.st_mtime_ns == before.st_mtime_ns
+    assert target.read_bytes() == payload
+
+
+def test_write_bytes_replaces_a_file_whose_content_changed(tmp_path: Path):
+    """Differing bytes still overwrite — the skip must not mask a real update.
+
+    Guards the obvious failure mode of the identical-content check: a media
+    URL whose bytes legitimately changed (re-encode, corrected upload) has to
+    land on disk.
+    """
+    target = tmp_path / "0.jpg"
+    _write_bytes(target, b"old pixels")
+    before = target.stat()
+
+    _write_bytes(target, b"new and longer pixels")
+
+    assert target.read_bytes() == b"new and longer pixels"
+    assert target.stat().st_ino != before.st_ino
+
+
+def test_write_bytes_skips_without_reading_a_partial_sibling(tmp_path: Path):
+    """A leftover `.part` sibling must not confuse the identical-content skip.
+
+    `_write_bytes` writes through `<name>.part`; if the skip check ever looked
+    at the wrong path it would compare against stale junk and rewrite every
+    time, silently reinstating the conflict-copy problem.
+    """
+    target = tmp_path / "0.jpg"
+    payload = _png_bytes()
+    _write_bytes(target, payload)
+    (tmp_path / "0.jpg.part").write_bytes(b"stale junk")
+    before = target.stat()
+
+    _write_bytes(target, payload)
+
+    assert target.stat().st_ino == before.st_ino
 
 
 def test_download_all_partial_failure_summary_emits_line(capsys):

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -784,13 +784,17 @@ def test_write_bytes_leaves_an_identical_file_untouched(tmp_path: Path):
     """Re-writing the same bytes must not replace the file on disk.
 
     `os.replace` swaps a fresh inode into place even when the content is
-    byte-identical. On an iCloud-synced tree that reads as an overwrite, and
-    iCloud preserves the losing version as `name N.ext` rather than dropping
-    it. A full refresh re-downloads every photo, so ~3.2k such no-op
-    overwrites fired within minutes and forked the whole media tree — 8.41 GB
-    of conflict copies accumulated in the x-knowledge vault this way.
+    byte-identical, and a full refresh rebuilds the item state and so
+    re-downloads every photo — ~3.2k no-op overwrites within minutes, every
+    one of them pure waste.
 
-    Skipping the write keeps the inode, so iCloud sees nothing to reconcile.
+    Deliberately NOT claiming this is what forked the vault. It is not: the
+    8.41 GB of `name N.ext` conflict copies came through
+    `generate._mirror_file`, and the two paths separate cleanly when measured
+    — `data/media/`, which this function writes, held 0 files matching the
+    conflict pattern against the vault's 43,791. `data_dir` is under the repo,
+    not under the synced vault. The skip is here because the writes are waste,
+    and because nothing in this function assumes `data_dir` stays unsynced.
     """
     target = tmp_path / "0.jpg"
     payload = _png_bytes()


### PR DESCRIPTION
## Qué pasaba

`learnings/x-knowledge/_media/` en el vault pesaba 9,1 GB. De eso, **8,41 GB eran copias de conflicto de iCloud** — 50.020 ficheros `nombre N.ext`, todos byte-idénticos al fichero de al lado, ninguno referenciado por ninguna nota. El contenido real son 0,55 GB.

No era vídeo: `digest-video` descarta los bytes como debe. Era la misma imagen guardada hasta 17 veces.

## Por qué

`generate` re-mirrorea el árbol de media entero al vault en **cada** ejecución, y el job nocturno lanza `generate` cada noche. Miles de reescrituras de bytes idénticos por noche. Para iCloud cada reescritura es una modificación que reconciliar, y si choca con una versión que aún no ha subido, conserva **las dos**: la perdedora como `nombre N.ext`.

Los duplicados se agrupan en 9 fechas — las de los refresh grandes (25-jun, 4/5/6-jul, 12-ago), no las noches sueltas. Un pase masivo satura el sync y bifurca en bloque.

## El fix

Dos rutas de escritura, con firmas observables distintas:

| | mecanismo | inode | mtime | ctime |
|---|---|---|---|---|
| `generate._mirror_file` | `shutil.copy2` (trunca en sitio) | igual | igual (`copystat`) | **cambia** |
| `media._write_bytes` | `os.replace` | **cambia** | cambia | cambia |

La primera es la que llenó el vault. Ambas comparan ahora antes de escribir, con el tamaño como corto-circuito para no materializar bytes que sólo viven en la nube. Un fallo de `stat`/lectura cae a escribir: una copia redundante es barata, un embed roto no.

`download_all` ya era idempotente a nivel de ítem, pero un full refresh reconstruye el estado y re-descarga todas las fotos — por eso la idempotencia de arriba no bastaba.

## Tests

TDD, con el RED verificado en cada caso. El primer intento contra `_mirror_file` **pasó sin el fix**: asertaba sobre inode y mtime, que `copy2` no altera. Corregido a `st_ctime_ns`, que es el único campo que registra la escritura — y el que un cliente de sync interpreta como "esto ha cambiado".

- `_mirror_file`: no toca un destino idéntico · reescribe uno que divergió · reescribe cuando el tamaño coincide pero los bytes no
- `_write_bytes`: no toca un fichero idéntico · reescribe si el contenido cambió · no se confunde con un `.part` huérfano al lado

Suite completa: **1633 passed, 1 xfailed**. `scripts/check.sh`: las 11 puertas en verde, coverage 94%.

## Verificación contra el vault real

300 ficheros reales del vault re-mirrorados con el código nuevo → **0 tocados**. iCloud no vería nada que reconciliar.

Los 8,41 GB ya se han recuperado en local (el disco iba al 94%), verificando antes fichero a fichero: 50.020/50.020 confirmados byte-idénticos por md5 contra su base, 0 grupos sin fichero base, 0 referencias de notas rotas después.

🤖 Generated with [Claude Code](https://claude.com/claude-code)