### PR TITLE
fix(ci): install from uv.lock, and stop the format guard counting Markdown

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -43,10 +43,29 @@ jobs:
         uses: astral-sh/setup-uv@v3
       - name: Set up Python
         run: uv python install 3.12
-      - name: Create venv and install dependencies
-        run: |
-          uv venv
-          uv pip install -e ".[dev]"
+      # `uv pip install` is uv's pip-COMPATIBILITY mode: it resolves fresh from
+      # pyproject.toml and never reads uv.lock. With `ruff>=0.5` declared, every run
+      # installed whatever ruff had shipped that morning, and the lockfile committed in
+      # this repo — pinning 0.15.13 — was decorative.
+      #
+      # Measured, this repo, same tree: `uv venv` + `uv pip install -e ".[dev]"` gives
+      # `uv run ruff` == 0.16.5 today (0.16.2 on 2026-08-13); `uv sync --extra dev
+      # --locked` gives 0.15.13. And `uv run` inside check.sh does NOT rescue it: ruff
+      # lives in `optional-dependencies.dev`, an EXTRA, which is not in uv run's default
+      # sync set, so it leaves the pip-installed build exactly where it is.
+      #
+      # The cost was not hypothetical. ruff 0.16 turned UP017 on by default and taught the
+      # formatter to open Markdown, so `develop` went red without a single commit landing
+      # on it: 618 lint errors, plus a gate-integrity test failing on a file-count skew it
+      # was never written to police. develop's last green push run is 2026-07-14 and
+      # nothing had run since, so the drift stayed invisible until the next PR inherited
+      # it and looked like its own fault.
+      #
+      # `--locked` fails the build if uv.lock is stale against pyproject.toml, so the lock
+      # cannot silently rot either. Upgrading stays deliberate and is one command:
+      # `uv lock --upgrade-package ruff`.
+      - name: Install dependencies from the lockfile
+        run: uv sync --extra dev --locked
       - name: Quality gate
         run: bash scripts/check.sh
 

--- a/tests/test_quality_gate_integrity.py
+++ b/tests/test_quality_gate_integrity.py
@@ -1088,7 +1088,7 @@ def _ruff_argv(subcommand: str) -> list[str]:
 
 
 def test_ruff_format_examines_every_file_ruff_check_does() -> None:
-    """`ruff format` must open exactly as many files as `ruff check` does.
+    """`ruff format` must open exactly the files `ruff check` opens.
 
     The formatter has its own exclusion list. `[tool.ruff.format] exclude = ["src/xbrain/*"]`
     leaves `ruff check` — and therefore test_quality_gate_scope.py's `--show-files` audit —
@@ -1101,6 +1101,36 @@ def test_ruff_format_examines_every_file_ruff_check_does() -> None:
     the question the other way round: count the files each mode actually opens, and demand
     they agree. Both numbers come from ruff; neither is hardcoded.
 
+    Why the file LIST and not the two trees
+    ---------------------------------------
+    An earlier version handed both modes the same three directories and compared the counts.
+    That silently assumed the two modes discover the same LANGUAGES, and ruff 0.16 broke the
+    assumption: `ruff format` learned to format Python inside Markdown, so it began opening
+    the 8 `src/xbrain/rubrics/*.md` files that `ruff check` does not. Measured on ruff 0.16.5:
+    format 122 vs check 114, all 8 of the skew in `src/` (tests 62==62, scripts 4==4). The
+    gate went red over a feature addition, in the OPPOSITE direction from the attack it
+    guards — the assertion could not tell "the formatter sees less" from "the formatter
+    learned a new language" — and its message blamed a `[tool.ruff.format] exclude` that does
+    not exist in this repo.
+
+    So the formatter is now handed the linter's OWN file list rather than re-discovering the
+    trees. The population is identical by construction, no matter what ruff learns to open
+    next; a future non-Python language is simply never in the list.
+
+    `--force-exclude` is load-bearing, not decorative. Ruff does not apply `exclude` to paths
+    named explicitly on the command line unless it is passed, so WITHOUT it this test would
+    hand ruff 114 files, ruff would format all 114 regardless of `format.exclude`, and the
+    exact attack the test exists to catch would report a clean 114 == 114. Measured, with a
+    `format.exclude` hiding the 3 files in `src/xbrain/executors/`:
+
+        ruff 0.15.13   without --force-exclude: 114  (attack MISSED)
+                       with    --force-exclude: 111  (attack caught)
+        ruff 0.16.5    without --force-exclude: 114  (attack MISSED)
+                       with    --force-exclude: 111  (attack caught)
+
+    Same verdict on both versions, in both directions — the check is now version-independent
+    and strictly no weaker than the one it replaces.
+
     A TOP-LEVEL `exclude` shrinks both counts equally and slips past this — that one is
     caught behaviourally by test_quality_gate_scope.py, which compares ruff's file list
     against `git ls-files`. The two tests are complements: it owns "ruff opens every file",
@@ -1108,9 +1138,18 @@ def test_ruff_format_examines_every_file_ruff_check_does() -> None:
     """
     linted = _run_tool("ruff", [*_ruff_argv("check"), "--show-files"])
     assert linted.returncode == 0, f"ruff --show-files failed:\n{linted.stderr}"
-    lint_count = len([line for line in linted.stdout.splitlines() if line.strip()])
+    lint_files = [line.strip() for line in linted.stdout.splitlines() if line.strip()]
+    lint_count = len(lint_files)
 
-    formatted = _run_tool("ruff", _ruff_argv("format"))
+    format_argv = _ruff_argv("format")
+    flags = [arg for arg in format_argv[1:] if arg.startswith("-")]
+    assert flags == ["--check"], (
+        f"`ruff format` is invoked as {format_argv!r}. This test rebuilds that invocation "
+        f"with an explicit file list, and only knows how to do so for a bare `--check` — a "
+        f"flag that takes a separate value would be silently dropped along with the paths. "
+        f"Teach this test the new flag rather than relaxing the assertion below."
+    )
+    formatted = _run_tool("ruff", ["format", *flags, "--force-exclude", *lint_files])
     # "113 files already formatted" / "1 file would be reformatted, 112 files already formatted"
     format_count = sum(
         int(number)
@@ -1121,14 +1160,17 @@ def test_ruff_format_examines_every_file_ruff_check_does() -> None:
     )
 
     assert format_count == lint_count, (
-        f"`ruff format` opens {format_count} files; `ruff check` opens {lint_count}. The "
-        f"formatter is examining {lint_count - format_count} fewer file(s) than the linter.\n"
+        f"`ruff format` opens {format_count} of the {lint_count} files `ruff check` opens — "
+        f"{lint_count - format_count} of the linter's own files are invisible to the "
+        f"formatter.\n"
         f"\n"
-        f"Almost certainly `[tool.ruff.format] exclude` in pyproject.toml. It is invisible to "
-        f"every other guard in this repo: `ruff check` still opens everything, the poe targets "
-        f"still read `src tests scripts`, and test_quality_gate_scope.py — which audits ruff's "
-        f"file list — still passes, because it audits the LINTER. Meanwhile `ruff format "
-        f"--check` exits 0 over unformatted code and the gate prints ✅ Ruff (format) PASS.\n"
+        f"Both modes were handed the SAME explicit file list, so discovery cannot explain "
+        f"this: something is excluding files from the formatter alone. Almost certainly "
+        f"`[tool.ruff.format] exclude` in pyproject.toml. It is invisible to every other "
+        f"guard in this repo: `ruff check` still opens everything, the poe targets still read "
+        f"`src tests scripts`, and test_quality_gate_scope.py — which audits ruff's file list "
+        f"— still passes, because it audits the LINTER. Meanwhile `ruff format --check` exits "
+        f"0 over unformatted code and the gate prints ✅ Ruff (format) PASS.\n"
         f"\n"
         f"The formatter and the linter must examine the same tree. If they legitimately must "
         f"not, that is a deliberate weakening of the gate and belongs in a PR that argues it."


### PR DESCRIPTION
## Qué pasaba

`develop` está rojo desde hace semanas **sin que haya aterrizado un solo commit en él**. El último run verde de `push` es del 2026-07-14; desde entonces no ha corrido nada, así que la deriva era invisible. El primer PR que se abrió después ([#134](https://github.com/VGonPa/xbrain/pull/134)) heredó las dos roturas y parecía el culpable.

```
❌ Ruff (linting)   FAIL   ← 618 errores
❌ Tests            FAIL   ← test_ruff_format_examines_every_file_ruff_check_does
```

Verificado sobre `origin/develop` limpio, sin una línea de #134: **los mismos 618 errores y el mismo 114 vs 122.**

## Rotura 1 — CI ignora el lockfile

`uv pip install` es el modo compatibilidad-pip de uv: resuelve de cero desde `pyproject.toml` y **nunca lee `uv.lock`**. Con `ruff>=0.5` declarado, cada run instalaba el ruff que hubiera salido esa mañana, y el lockfile commiteado en el repo — que fija **0.15.13** — era decorativo.

Y `uv run` dentro de `check.sh` **no** lo rescata: `ruff` vive en `optional-dependencies.dev`, un **extra**, que no entra en el conjunto que `uv run` sincroniza por defecto, así que deja intacto el build que puso pip. Medido sobre este árbol:

| | `uv run ruff` |
|---|---|
| `uv venv` + `uv pip install -e ".[dev]"` | **0.16.5** (0.16.2 el 13-ago) |
| `uv sync --extra dev --locked` | **0.15.13** |

ruff 0.16 activó `UP017` por defecto → 618 errores, 429 de esa sola regla.

`--locked` además falla el build si el lock queda obsoleto respecto a `pyproject.toml`, así que tampoco puede pudrirse en silencio. **No se pinea nada**: `pyproject.toml` conserva su `ruff>=0.5` intacto, y subir versión sigue siendo un comando deliberado, `uv lock --upgrade-package ruff`.

## Rotura 2 — el guard del formato contaba Markdown

`test_ruff_format_examines_every_file_ruff_check_does` daba a los dos modos los mismos tres directorios y comparaba los recuentos. Eso asumía en silencio que **ambos modos descubren los mismos LENGUAJES**. ruff 0.16 rompió la premisa: `ruff format` aprendió a formatear Python dentro de Markdown y empezó a abrir los 8 `src/xbrain/rubrics/*.md` que `ruff check` no abre.

```
format 122   vs   check 114
  src:     56  vs  48   ← los 8
  tests:   62  vs  62
  scripts:  4  vs   4
```

El guard disparó **en la dirección contraria a su modelo de amenaza**: no sabía distinguir *"el formateador ve menos"* de *"el formateador aprendió un lenguaje nuevo"*. Imprimía `"-8 fewer file(s)"` (un negativo) y culpaba a un `[tool.ruff.format] exclude` que este repo no tiene.

## El arreglo, y por qué no es un debilitamiento

Al formateador se le pasa ahora **la lista de ficheros del propio linter** en vez de dejarle redescubrir los árboles. La población es idéntica por construcción, abra ruff lo que abra en el futuro.

`--force-exclude` es **load-bearing, no decorativo**. Ruff no aplica `exclude` a rutas nombradas explícitamente en la línea de comandos si no se pasa — sin él el test formatearía los 114 pase lo que pase y reportaría un `114 == 114` limpio sobre el ataque exacto que existe para cazar.

Las cuatro celdas medidas, con un `format.exclude` escondiendo los 3 ficheros de `src/xbrain/executors/`:

| | limpio | con `format.exclude` |
|---|---|---|
| **ruff 0.15.13** | PASS ✔ | **FAIL** ✔ `111 != 114` |
| **ruff 0.16.5** | PASS ✔ | **FAIL** ✔ `111 != 114` |

Antes, `0.16.5` + limpio era **FAIL** — un falso positivo sobre una feature del upstream. El check queda **independiente de versión y estrictamente no más débil** que el que sustituye.

RED verificado inyectando el `[tool.ruff.format] exclude` de verdad en `pyproject.toml`, no simulado. Mensaje resultante:

> `ruff format` opens 111 of the 114 files `ruff check` opens — 3 of the linter's own files are invisible to the formatter.

## Puerta

`scripts/check.sh` con el ruff del lock, sobre este árbol: **11/11 en verde, 1627 tests, coverage 94%.**

## Desbloquea

[#134](https://github.com/VGonPa/xbrain/pull/134), que no tiene nada que ver con ninguna de las dos roturas: sus 4 ficheros no tocan `.github/` ni `pyproject.toml`, y las versiones base de esos mismos ficheros ya producían 90 errores de ruff 0.16 frente a los 83 de su HEAD. Cero solape, `merge-tree` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQ2AKawhLueogFRT8AYk8w