### PR TITLE
fix(extract): X renamed UserTweets — the filter ate the whole timeline

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -28,7 +28,11 @@ from xbrain.enrich import apply_worksheet_judgments, enrich_with_executor, items
 from xbrain.executors.api import ApiExecutor
 from xbrain.extract.browser import login as run_login
 from xbrain.extract.browser import x_context
-from xbrain.extract.extractor import RateLimitTruncated, extract_source
+from xbrain.extract.extractor import (
+    OperationNotCaptured,
+    RateLimitTruncated,
+    extract_source,
+)
 from xbrain.extract.threads import expand_threads
 from xbrain.extract.graphql import items_needing_refetch
 from xbrain.fetch import (
@@ -301,6 +305,14 @@ def _run_extract(
                 typer.echo(f"ERROR: {exc} (no se guardó nada de {src})", err=True)
                 truncated.append(src)
                 continue
+            except OperationNotCaptured as exc:
+                # Nothing was captured at all — the run learned NOTHING about this
+                # source. Advancing `last_run` would make the next run look fresh
+                # and hide the breakage, so leave the cursor untouched and fail
+                # loud. Other sources still save: a rename hits one operation.
+                typer.echo(f"ERROR: {exc} (no se guardó nada de {src})", err=True)
+                truncated.append(src)
+                continue
             if not items and first_run:
                 typer.echo(
                     f"AVISO: {src} devolvió 0 items en una extracción inicial — "
@@ -316,7 +328,8 @@ def _run_extract(
     save_state(state, cfg.state_path)
     if truncated:
         raise RuntimeError(
-            f"Extracción truncada por rate-limit/bloqueo de X en: {', '.join(truncated)}. "
+            f"Extracción incompleta en: {', '.join(truncated)} (rate-limit, bloqueo, o "
+            "la operación GraphQL de X cambió de nombre — el mensaje de arriba lo dice). "
             "Las fuentes completadas se guardaron; reanuda más tarde para el resto."
         )
 

--- a/src/xbrain/extract/extractor.py
+++ b/src/xbrain/extract/extractor.py
@@ -18,7 +18,18 @@ from xbrain.models import Item, SourceName
 
 logger = logging.getLogger(__name__)
 
-_OPERATIONS = {"bookmark": "Bookmarks", "own_tweet": "UserTweets"}
+# X renames its internal timeline operations without notice: the own-tweets
+# timeline answered to `UserTweets` until X switched it to
+# `UserOriginalsTimeline` (measured 30-ago-2026). The PARSER survives such a
+# rename — it anchors on the `tweet_results` key, not on a path — but this
+# capture filter used to be a single literal, and a stale literal turns a rename
+# into SILENT data loss: every response is filtered out, `captured` stays empty,
+# and the run reports "0 nuevos items" with exit 0. So: a TUPLE of aliases per
+# source, newest first, keeping the old names (X A/B-tests these and rolls back).
+_OPERATIONS: dict[str, tuple[str, ...]] = {
+    "bookmark": ("Bookmarks",),
+    "own_tweet": ("UserOriginalsTimeline", "UserTweets"),
+}
 # Deliberately slow, human-paced scrolling — avoids X rate-limiting / account bans.
 _SETTLE_MS = 6000
 _SCROLL_PAUSE_MIN_MS = 5000
@@ -41,6 +52,28 @@ class RateLimitTruncated(RuntimeError):
     to the un-fetched middle. The caller must NOT merge or advance the cursor for a
     truncated source; re-run later to capture the window cleanly.
     """
+
+
+class OperationNotCaptured(RuntimeError):
+    """The scroll finished without ever seeing the source's timeline operation.
+
+    A healthy timeline ALWAYS answers its operation at least once — an account
+    with zero posts still gets an empty instruction list — so capturing nothing
+    means we were not listening for the right name (X renamed the operation) or
+    the page never served it. Either way the run learned nothing, and reporting
+    "0 nuevos items" would be a false negative that silently freezes the store.
+    Fail closed: the caller must not advance the cursor, and must say so loudly.
+    """
+
+
+def matches_operation(url: str, operations: tuple[str, ...]) -> bool:
+    """True when `url` is a GraphQL call for one of `operations`.
+
+    Pure helper — the unit-tested core of the capture filter. Scoped to
+    `/graphql/` so a REST path that happens to contain the operation name is
+    never mistaken for a GraphQL body.
+    """
+    return "/graphql/" in url and any(operation in url for operation in operations)
 
 
 def rate_limit_decision(
@@ -123,7 +156,7 @@ def extract_source(
     backoff budget, or 401/403) — a partial, non-contiguous batch must never be
     returned, since the caller would merge it and seal a permanent gap.
     """
-    operation = _OPERATIONS[source]
+    operations = _OPERATIONS[source]
     captured: list[dict] = []
     # Mutable counters shared with the response callback (a dict sidesteps
     # `nonlocal` in the hook). `hits` = 429s on the target operation; `blocked` =
@@ -135,7 +168,7 @@ def extract_source(
         # Scope every signal to the target operation: a 429 on a background poll
         # (notifications, typeahead) must not spuriously back off / abort an
         # otherwise-healthy scroll, and only the operation's body is a payload.
-        if "/graphql/" not in response.url or operation not in response.url:
+        if not matches_operation(response.url, operations):
             return
         if response.status == 429:
             rate_limit["hits"] += 1
@@ -165,7 +198,8 @@ def extract_source(
                 break
             if rate_limit["blocked"]:
                 raise RateLimitTruncated(
-                    f"{source}: X respondió {rate_limit['blocked']} en {operation} — "
+                    f"{source}: X respondió {rate_limit['blocked']} en "
+                    f"{'/'.join(operations)} — "
                     "extracción truncada a media timeline; reanuda más tarde."
                 )
             action = rate_limit_decision(
@@ -204,6 +238,20 @@ def extract_source(
         # discarding the PAYLOADS is not — they are id-addressable and idempotent.
         persist_payloads(captured, payload_dir)
         page.close()
+
+    # Fail CLOSED on an empty capture. Everything above this line reports success
+    # by saying nothing, so a filter that matched zero responses is
+    # indistinguishable from a timeline with no new posts — and the caller would
+    # print "0 nuevos items", advance nothing, and exit 0. That is how a rename of
+    # the X operation went unnoticed. An empty capture is never a valid outcome:
+    # even a zero-post account gets one response with an empty instruction list.
+    if not captured:
+        raise OperationNotCaptured(
+            f"{source}: 0 respuestas de {'/'.join(operations)} en toda la timeline — "
+            "no es que no haya items nuevos, es que no se capturó NADA. "
+            "Lo normal es que X haya renombrado la operación: mira las operaciones "
+            "GraphQL reales de la página y añade el nombre nuevo a `_OPERATIONS`."
+        )
 
     new_items, _ = collect_new_items(captured, source, known_ids)
     return _filter_in_range(new_items, since, until)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2023,6 +2023,57 @@ def test_extract_truncation_persists_nothing_and_exits_nonzero(tmp_path: Path, m
     assert load_state(tmp_path / "data" / "state.json").bookmarks.last_seen_id is None
 
 
+def test_extract_empty_capture_fails_loud_and_freezes_the_cursor(tmp_path: Path, monkeypatch):
+    """Capturing NOTHING must never read as "0 nuevos items" with exit 0.
+
+    The X operation rename (30-ago-2026) made every response fall through the
+    capture filter. The run reported success, the cursor kept its old value, and
+    four posts stayed out of the store for 18 days with no signal anywhere.
+    """
+    from xbrain.extract.extractor import OperationNotCaptured
+    from xbrain.store import load_state, load_store
+
+    _setup_repo(tmp_path, monkeypatch)
+
+    def _nothing_captured(*_a, **_k):
+        raise OperationNotCaptured("own_tweet: 0 respuestas de UserOriginalsTimeline/UserTweets")
+
+    _mock_browser(monkeypatch, _nothing_captured)
+
+    result = runner.invoke(app, ["extract", "--source", "tweets"])
+
+    assert result.exit_code == 1, result.output
+    assert "0 respuestas" in result.output
+    assert "0 nuevos items" not in result.output
+    assert load_store(tmp_path / "data" / "items.json") == {}
+    # The cursor must be untouched: advancing it would make the next run look
+    # fresh and bury the breakage under a second false negative.
+    assert load_state(tmp_path / "data" / "state.json").own_tweets.last_seen_id is None
+
+
+def test_extract_one_broken_source_still_saves_the_healthy_one(tmp_path: Path, monkeypatch):
+    """A rename hits ONE operation, so `--source all` must not lose the other."""
+    from xbrain.extract.extractor import OperationNotCaptured
+    from xbrain.store import load_state, load_store
+
+    _setup_repo(tmp_path, monkeypatch)
+
+    def _by_source(_context, source, *_a, **_k):
+        if source == "own_tweet":
+            raise OperationNotCaptured("own_tweet: 0 respuestas de UserOriginalsTimeline")
+        return [_linked_item("100")]
+
+    _mock_browser(monkeypatch, _by_source)
+
+    result = runner.invoke(app, ["extract", "--source", "all"])
+
+    assert result.exit_code == 1, result.output
+    state = load_state(tmp_path / "data" / "state.json")
+    assert list(load_store(tmp_path / "data" / "items.json")) == ["100"]
+    assert state.bookmarks.last_seen_id == "100"
+    assert state.own_tweets.last_seen_id is None
+
+
 # ------------------------------------------------------ list-videos / fetch-video
 
 

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -178,3 +178,54 @@ def test_a_rate_limited_run_keeps_the_payloads_it_already_captured(tmp_path):
 
     persist_payloads([_tweet_response("77"), _tweet_response("78")], tmp_path)
     assert stored_ids(tmp_path) == {"77", "78"}
+
+
+# --- Operation-name drift: X renames timeline operations without notice -------
+# Measured 30-ago-2026: the own-tweets timeline stopped answering to `UserTweets`
+# and now answers to `UserOriginalsTimeline`. The parser survived the rename (it
+# anchors on the `tweet_results` KEY, not on a path); the capture filter did not,
+# and a single stale literal turned the rename into silent data loss.
+
+
+def test_matches_operation_accepts_every_alias_for_a_source():
+    from xbrain.extract.extractor import _OPERATIONS, matches_operation
+
+    base = "https://x.com/i/api/graphql/abc123/"
+    assert matches_operation(base + "UserOriginalsTimeline", _OPERATIONS["own_tweet"])
+    # The pre-rename name must keep working: X A/B-tests these and rolls back.
+    assert matches_operation(base + "UserTweets", _OPERATIONS["own_tweet"])
+    assert matches_operation(base + "Bookmarks", _OPERATIONS["bookmark"])
+
+
+def test_matches_operation_rejects_other_operations_and_non_graphql_urls():
+    from xbrain.extract.extractor import _OPERATIONS, matches_operation
+
+    base = "https://x.com/i/api/graphql/abc123/"
+    # A background poll on the same page must not be mistaken for the timeline.
+    assert not matches_operation(base + "ProfileSpotlightsQuery", _OPERATIONS["own_tweet"])
+    assert not matches_operation(base + "Bookmarks", _OPERATIONS["own_tweet"])
+    # Scope stays on /graphql/: a REST endpoint whose path happens to contain the
+    # operation name is not a GraphQL body.
+    assert not matches_operation(
+        "https://x.com/i/api/1.1/UserTweets.json", _OPERATIONS["own_tweet"]
+    )
+
+
+def test_operations_table_maps_every_source_to_a_tuple_of_aliases():
+    from xbrain.extract.extractor import _OPERATIONS
+
+    assert set(_OPERATIONS) == {"bookmark", "own_tweet"}
+    for source, aliases in _OPERATIONS.items():
+        assert isinstance(aliases, tuple), source
+        assert aliases, source
+
+
+def test_operation_not_captured_is_not_a_rate_limit_error():
+    # The caller handles them the same way (never advance the cursor) but the
+    # cause differs, so an operator reading the log must be able to tell a rename
+    # from a block. Distinct types, both fatal for that source.
+    from xbrain.extract.extractor import OperationNotCaptured, RateLimitTruncated
+
+    assert issubclass(OperationNotCaptured, RuntimeError)
+    assert not issubclass(OperationNotCaptured, RateLimitTruncated)
+    assert not issubclass(RateLimitTruncated, OperationNotCaptured)


### PR DESCRIPTION
## What broke

`xbrain extract --source tweets` had been printing `own_tweet: 0 nuevos items` and exiting 0 **for 18 days** while posts piled up unread. X renamed the own-tweets timeline operation from `UserTweets` to `UserOriginalsTimeline`; every response fell through the capture filter and `captured` stayed empty.

Measured against the live profile on 30-ago-2026 — every `/graphql/` response on `x.com/vgonpa`, with status:

```
UserOriginalsTimeline: 2  (200)
UserTweets:            0
```

**Five posts were missing from the store**, four of them newer than the stored cursor. After the fix, the same command returns `own_tweet: 5 nuevos items`.

`Bookmarks` was checked the same way and is **not** renamed, so the blast radius is exactly one operation.

## Why it was silent

The parser survived the rename untouched — `parse_tweets` anchors on the `tweet_results` *key* rather than a path, deliberately, "so X restructuring the surrounding envelope" cannot break it. It parses the new envelope with no changes at all. The **capture filter** was a bare string literal. Resilient parser, rigid filter: that asymmetry is the entire bug.

And the existing guard could not catch it. The "0 items" warning only fires on a *first* run (`cursor.last_seen_id is None`). With a cursor stored, total capture failure and "nothing new" print the same line. `status` then refreshed *última extracción* on every failed run — a fresh timestamp over a run that read nothing.

## The change

- **`_OPERATIONS` maps each source to a tuple of aliases**, newest first, keeping the old names because X A/B-tests these and rolls back. Matching moves to `matches_operation`, still scoped to `/graphql/` so a REST path containing the same word is never mistaken for a GraphQL body.

- **`extract_source` fails closed on an empty capture.** A healthy timeline always answers its operation at least once — even a zero-post account gets a response with an empty instruction list — so capturing nothing is never a valid "no new items". `OperationNotCaptured` is deliberately **not** a `RateLimitTruncated`: reading the log, an operator has to be able to tell a rename from a block. The CLI handles them identically, though — never advance the cursor, save the healthy sources, exit non-zero — because advancing `last_run` would make the next run look fresh and bury the breakage under a second false negative.

## Tests

Six new tests: alias matching and its negative cases (other operations, non-GraphQL URLs), the `_OPERATIONS` shape, the exception hierarchy, plus two CLI integration tests — an empty capture must exit 1, must not print "0 nuevos items", and must leave the cursor untouched; and with `--source all`, one broken source must not cost the healthy one its items or its cursor.

Quality gate green locally (`uv sync --extra dev --locked`, ruff 0.15.13): 1729 tests, 94% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu14vRbJETETVbQb9Hszdg