### PR TITLE
fix(generate): the mirror must not open a cloud placeholder

### DIFF
--- a/src/xbrain/generate.py
+++ b/src/xbrain/generate.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import filecmp
 import logging
+import os
 import shutil
+import stat
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import assert_never, cast
@@ -477,6 +479,30 @@ def _mirror_file(item_id: str, source: Path, destination: Path) -> None:
     shutil.copy2(source, destination)
 
 
+# The BSD/macOS flag marking a cloud file whose bytes are not on disk. Read from
+# the stdlib rather than hardcoded, and behind a `getattr` because Linux does not
+# define it — there, `os.stat_result` carries no `st_flags` at all, `_is_dataless`
+# is always False, and the byte comparison stays the ONLY path, exactly as before
+# this guard existed.
+_SF_DATALESS = getattr(stat, "SF_DATALESS", 0x40000000)
+
+# Granularity for the metadata-only comparison below. One second is not a tuned
+# tolerance measured on one volume: it is the coarsest timestamp resolution POSIX
+# guarantees, and the granularity every archive format preserves. A copy onto a
+# filesystem with a different resolution comes back rounded, so comparing
+# `st_mtime_ns` for equality would call an already-correct mirror stale.
+_MTIME_GRANULARITY_NS = 1_000_000_000
+
+
+def _is_dataless(st: os.stat_result) -> bool:
+    """True when the platform reports `st` as a cloud file with no local bytes.
+
+    Duck-typed on purpose: anything exposing `st_flags` answers, and anything
+    without it (every Linux stat result) answers False.
+    """
+    return bool(getattr(st, "st_flags", 0) & _SF_DATALESS)
+
+
 def _already_mirrored(source: Path, destination: Path) -> bool:
     """True when `destination` already holds exactly `source`'s bytes.
 
@@ -486,15 +512,23 @@ def _already_mirrored(source: Path, destination: Path) -> bool:
     files in memory at once, and this walk mirrors `MediaVideoDownloaded` as
     well as photos — one `download-videos` mp4 would be loaded twice over.
 
-    Do NOT read the size check as "the cloud-only case settles from metadata".
-    It settles the DIVERGENT case, which is the rare one; the common case here
-    is a destination that is already identical, whose size therefore matches
-    and whose bytes do get read. On an evicted iCloud file that read faults the
-    bytes back in. That is inherent to answering "are these the same bytes" —
-    the alternative (trusting size+mtime, rsync-style) would silently leave a
-    corrupted same-size copy in place, which the sibling test forbids. Reading
-    is still far cheaper than the rewrite it replaces, and it happens once per
-    run instead of writing every run.
+    Reading is the DEFAULT, and it is what every platform that can read without
+    consequence does: a same-size destination whose bytes rotted is repaired,
+    which a metadata comparison could never notice.
+
+    The exception is a file the platform reports as `dataless` — a cloud
+    placeholder whose bytes are not on disk. Opening one blocks until the sync
+    daemon fetches them, and when it cannot, it blocks with no timeout: a
+    `generate` run sat there 22 minutes at 0.0% CPU. That is not an iCloud
+    quirk; OneDrive, Dropbox and any FUSE/NFS placeholder behave the same way.
+    So when either side is dataless the answer comes from size + mtime, the
+    metadata the placeholder already carries, and NOTHING is opened.
+
+    That is a real, named trade: on those files a same-size, same-second
+    corruption goes unrepaired. It buys the guarantee that mirroring cannot
+    hang the run, and it is confined to the case where the strong check is
+    impossible — everywhere else, including all of Linux and every
+    materialised file on macOS, the byte comparison is unchanged.
 
     `filecmp`'s result cache is keyed on both paths AND both stat signatures,
     so a file that changed gets a new key. It cannot go stale here anyway: a
@@ -504,6 +538,14 @@ def _already_mirrored(source: Path, destination: Path) -> bool:
     A stat/read failure answers False: mirroring anyway is the safe direction —
     it costs a redundant copy, never a stale or missing embed.
     """
+    try:
+        src, dst = source.stat(), destination.stat()
+    except OSError:
+        return False
+    if src.st_size != dst.st_size:
+        return False
+    if _is_dataless(src) or _is_dataless(dst):
+        return src.st_mtime_ns // _MTIME_GRANULARITY_NS == dst.st_mtime_ns // _MTIME_GRANULARITY_NS
     try:
         return filecmp.cmp(source, destination, shallow=False)
     except OSError:

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,10 +1,12 @@
 # tests/test_generate.py
 import os
+import shutil
+import stat as stat_module
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.generate import _mirror_file, generate
+from xbrain.generate import _is_dataless, _mirror_file, generate
 from xbrain.models import (
     Author,
     Content,
@@ -1820,3 +1822,173 @@ def test_mirror_file_rewrites_when_the_whole_stat_matches_but_bytes_differ(tmp_p
     _mirror_file("1", source, destination)
 
     assert destination.read_bytes() == b"AAAA"
+
+
+# --- The mirror must never force a cloud file to materialise -------------------
+#
+# `_already_mirrored` answers "are these the same bytes?" by READING both files.
+# On a cloud-synced vault the destination may be a placeholder whose bytes are
+# not on disk ("dataless"/evicted). `open()` on one blocks until the sync daemon
+# fetches them, and when it cannot, it blocks with no timeout: a `generate` run
+# sat there for 22 minutes at 0.0% CPU. That is not iCloud-specific — OneDrive,
+# Dropbox and any FUSE/NFS placeholder behave the same way.
+#
+# These tests inject the platform's dataless flag through `os.stat` and make the
+# destination genuinely unreadable, so a comparison that reads is caught by the
+# operating system rather than by a mock.
+
+
+class _StatWithFlags:
+    """A real `os.stat_result` with `st_flags` overridden.
+
+    `os.stat_result` is immutable and cannot be constructed with a chosen
+    `st_flags`, so this delegates every other attribute to the real one. The
+    production code therefore reads REAL sizes and REAL timestamps; only the
+    platform flag is injected.
+    """
+
+    def __init__(self, real: os.stat_result, flags: int) -> None:
+        self._real = real
+        self.st_flags = flags
+
+    def __getattr__(self, name: str):
+        return getattr(self._real, name)
+
+
+def _dataless_stat(monkeypatch, *targets: Path) -> None:
+    """Make `os.stat` report `targets` as evicted cloud placeholders."""
+    real_stat = os.stat
+    wanted = {str(t) for t in targets}
+
+    def fake_stat(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if str(path) in wanted:
+            return _StatWithFlags(result, stat_module.SF_DATALESS)
+        return result
+
+    monkeypatch.setattr(os, "stat", fake_stat)
+
+
+def test_mirror_file_does_not_read_a_dataless_destination(tmp_path: Path, monkeypatch):
+    """An evicted vault copy must be compared from metadata, never opened.
+
+    The destination is `chmod 000`: any attempt to read it raises
+    `PermissionError`, and any attempt to rewrite it raises too. So the test
+    needs no mock assertion — if the mirror reads or writes, the OS fails the
+    call and the test errors. Passing proves the bytes were never touched.
+
+    The flag is the trigger, the unreadable file is the detector. Both are
+    needed: without the flag the code has no reason to skip, without the
+    unreadable file a skip and a successful read look identical.
+    """
+    source = tmp_path / "store" / "0.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"pixels")
+    destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
+    destination.parent.mkdir(parents=True)
+    shutil.copy2(source, destination)
+    destination.chmod(0o000)
+    _dataless_stat(monkeypatch, destination)
+
+    try:
+        _mirror_file("1", source, destination)
+    finally:
+        destination.chmod(0o644)
+
+    assert destination.read_bytes() == b"pixels"
+
+
+def test_mirror_file_rewrites_a_dataless_destination_whose_size_differs(
+    tmp_path: Path, monkeypatch
+):
+    """Skipping the read must not strand a copy that is visibly wrong.
+
+    Size comes from the placeholder's metadata, so it is known without
+    materialising anything. A mismatch is decisive: repair it.
+    """
+    source = tmp_path / "store" / "0.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"fresh pixels")
+    destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"short")
+    _dataless_stat(monkeypatch, destination)
+
+    _mirror_file("1", source, destination)
+
+    assert destination.read_bytes() == b"fresh pixels"
+
+
+def test_mirror_file_tolerates_sub_second_mtime_drift_on_a_dataless_destination(
+    tmp_path: Path, monkeypatch
+):
+    """Timestamps are compared at 1-second granularity, not nanoseconds.
+
+    `copy2` restores mtime with nanosecond precision, but the two filesystems
+    need not agree on it: a copy onto a cloud-backed volume comes back rounded.
+    Comparing `st_mtime_ns` for equality would call an already-correct mirror
+    stale and re-copy — the rewrite this guard exists to prevent.
+
+    One second is not a tuned tolerance: it is the coarsest resolution POSIX
+    guarantees for a timestamp, and the granularity every archive format
+    preserves. It is pinned here at 100 ns, the drift a real APFS/iCloud pair
+    shows, and 2 s below, which must still repair.
+    """
+    source = tmp_path / "store" / "0.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"pixels")
+    # Pinned mid-second: +100 ns can then never straddle a second boundary,
+    # which would make this test flaky roughly once in ten million runs.
+    pinned = int(source.stat().st_mtime) * 1_000_000_000 + 500_000_000
+    os.utime(source, ns=(pinned, pinned))
+    destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
+    destination.parent.mkdir(parents=True)
+    shutil.copy2(source, destination)
+    src_stat = source.stat()
+    os.utime(destination, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns + 100))
+    destination.chmod(0o000)
+    _dataless_stat(monkeypatch, destination)
+
+    try:
+        _mirror_file("1", source, destination)
+    finally:
+        destination.chmod(0o644)
+
+    assert destination.read_bytes() == b"pixels"
+
+
+def test_mirror_file_rewrites_a_dataless_destination_a_second_out_of_date(
+    tmp_path: Path, monkeypatch
+):
+    """Drift beyond the 1-second granularity is a real difference: repair it."""
+    source = tmp_path / "store" / "0.jpg"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"fresher")
+    destination = tmp_path / "vault" / "_media" / "1" / "0.jpg"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"staler!")
+    src_stat = source.stat()
+    assert source.stat().st_size == destination.stat().st_size
+    os.utime(destination, ns=(src_stat.st_atime_ns, src_stat.st_mtime_ns - 2_000_000_000))
+    _dataless_stat(monkeypatch, destination)
+
+    _mirror_file("1", source, destination)
+
+    assert destination.read_bytes() == b"fresher"
+
+
+def test_dataless_detection_is_false_where_the_platform_has_no_flags():
+    """On Linux there is no `st_flags`, so the new branch is unreachable there.
+
+    This is the portability contract, asserted rather than assumed: every
+    platform that does not report the flag keeps the byte comparison as its
+    ONLY path, exactly as before this guard existed. CI runs on Linux, so
+    without this assertion the whole dataless branch would be untested there
+    in a way nothing would notice.
+    """
+
+    class _NoFlags:
+        st_size = 1
+        st_mtime_ns = 0
+
+    assert _is_dataless(_NoFlags()) is False

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,12 +1,11 @@
 # tests/test_generate.py
 import os
 import shutil
-import stat as stat_module
 import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-from xbrain.generate import _is_dataless, _mirror_file, generate
+from xbrain.generate import _SF_DATALESS, _is_dataless, _mirror_file, generate
 from xbrain.models import (
     Author,
     Content,
@@ -1856,14 +1855,20 @@ class _StatWithFlags:
 
 
 def _dataless_stat(monkeypatch, *targets: Path) -> None:
-    """Make `os.stat` report `targets` as evicted cloud placeholders."""
+    """Make `os.stat` report `targets` as evicted cloud placeholders.
+
+    Injects `_SF_DATALESS` imported from the production module, never a
+    re-derived `stat.SF_DATALESS`. The bare attribute does not exist on Linux —
+    an earlier version of this helper used it and these tests failed on CI while
+    passing on macOS. One definition, shared, so the two cannot diverge again.
+    """
     real_stat = os.stat
     wanted = {str(t) for t in targets}
 
     def fake_stat(path, *args, **kwargs):
         result = real_stat(path, *args, **kwargs)
         if str(path) in wanted:
-            return _StatWithFlags(result, stat_module.SF_DATALESS)
+            return _StatWithFlags(result, _SF_DATALESS)
         return result
 
     monkeypatch.setattr(os, "stat", fake_stat)


### PR DESCRIPTION
## The bug

`_already_mirrored` answers *"same bytes?"* by reading both files. When the vault copy is a **dataless** cloud placeholder — the file exists, carries its real size and mtime, but its bytes are not on disk — `open()` blocks while the sync daemon fetches them, and when it cannot, it blocks with **no timeout**. A `generate` run sat there **22 minutes at 0.0% CPU** (blocked in the kernel, not looping).

`_already_mirrored` is the only thing in `generate` that *reads* the vault. Everything else writes, and writing over a placeholder never needs its bytes — which is why the hang lives here and nowhere else.

## The fix, written against the platform rather than against one volume

This is not an iCloud quirk: OneDrive Files On-Demand, Dropbox Smart Sync and any FUSE/NFS placeholder behave identically.

- `_is_dataless` reads `st_flags & stat.SF_DATALESS` through `getattr`. Linux stat results carry **no** `st_flags`, so it is always `False` there and the byte comparison stays the **only** path.
- Only when a side is dataless does the answer come from size + mtime, at **1-second granularity** — the coarsest resolution POSIX guarantees, not a tolerance measured on one machine. A copy across filesystems comes back rounded, so comparing `st_mtime_ns` for equality would call an already-correct mirror stale and re-copy it: exactly the rewrite this guard exists to prevent.

## The trade, named rather than hidden

On a dataless file, a same-size **and** same-second corruption goes unrepaired. It buys the guarantee that mirroring cannot hang the run, and it is confined to the case where reading is impossible. Every materialised file, on every platform, behaves exactly as before — **the three pre-existing mirror tests pass untouched**.

## Tests

Five added; three went red first (one on the stub, two on behaviour). The two "still repairs" tests were already satisfied by the old path — they are regression guards, not drivers, and I could not make them fail honestly.

No mock assertions: the tests inject the flag through `os.stat` over a **real** `stat_result` and `chmod 000` the destination, so a comparison that reads is caught by the operating system. The flag is the trigger, the unreadable file is the detector.

`test_dataless_detection_is_false_where_the_platform_has_no_flags` is the portability contract asserted rather than assumed — CI runs on Linux, where the new branch is unreachable, so without it the whole branch would be untested there in a way nothing would notice.

## What I cannot claim

**Not validated against a real evicted file.** A scan of the 14,534 files in the live vault found **0** with `SF_DATALESS` set — every one already materialised by the very reads that caused the hang. The mechanism is implemented against the diagnosis in `8afe1bc`, not against a reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4Ek2wbCPC9Rh9HpAhn6cn