### PR TITLE
docs: the transcriber is a language router now, and the manual never said so

### DIFF
--- a/docs/digest-video.md
+++ b/docs/digest-video.md
@@ -13,8 +13,9 @@ The heavy lifting is **external** — xbrain core carries no ML/ffmpeg dependenc
 Install once (see [Local models for `digest-video`](../README.md#local-models-for-digest-video-apple-silicon)):
 
 ```bash
-brew install ffmpeg                # frame extraction + audio probe
-uv tool install parakeet-mlx       # ASR (Apple Silicon)
+brew install ffmpeg                # frame extraction, audio probe, language detection
+brew install openai-whisper        # multilingual ASR + the router's language detector
+uv tool install parakeet-mlx       # fast English-only ASR (Apple Silicon)
 uv tool install mlx-vlm            # vision, only for --frames
 ```
 
@@ -22,12 +23,115 @@ and point `config.toml` at the wrappers:
 
 ```toml
 [transcribe]
-command = "/abs/path/to/xbrain/scripts/xbrain-transcribe"   # wraps parakeet-mlx
+# Detects the language, then picks the ASR. See "Picking the transcriber" below.
+command = "/abs/path/to/xbrain/scripts/xbrain-transcribe-auto"
 
 [vision]
 command = "/abs/path/to/xbrain/scripts/xbrain-vision"       # local + cloud selector
 model   = "qwen-7b"
 ```
+
+Leave `[transcribe].model` unset unless you know which backend will run: the
+router picks the backend, and each one resolves its own default model.
+
+If your corpus is **English only**, you can skip `openai-whisper` and point
+`[transcribe].command` straight at `scripts/xbrain-transcribe` (the parakeet
+wrapper). It is the faster path. On anything else, read the next section before
+you run: the wrong choice here does not fail, it fabricates.
+
+## Picking the transcriber
+
+xbrain never transcribes anything itself: it shells out to whatever
+`[transcribe].command` names. The repo ships three backends and a router to
+choose between them, and the choice matters more than it looks.
+
+### Why `parakeet-mlx` on its own is a data-loss path
+
+`parakeet-tdt` (v2 and v3) is **English-only, and it does not fail on other
+languages.** Handed Spanish audio it exits 0 and emits fluent, broken English
+that never reproduces what was said — verified 17-jul-2026 against an es-ES TV
+clip, and the reason `scripts/xbrain-transcribe-auto` exists.
+
+This is the worst failure mode available here. A crash shows up in a log; this
+one passes the entire pipeline. The invented transcript attaches as an `x_video`
+source, `enrich` summarises it, `topics` files it, `video-digest` writes a
+readable digest *of* it, and it lands in your vault rendered as a quotation of
+the speaker. By the time you read it, nothing on the page distinguishes "the
+video said that" from "the ASR made it up".
+
+So the backend has to be chosen **before** transcription, not audited after.
+
+### The router — `scripts/xbrain-transcribe-auto`
+
+Point `[transcribe].command` at it and it decides per video:
+
+1. `ffprobe` short-circuits a genuinely **silent** clip (no audio stream) into
+   the empty-speech JSON — `has_speech=false`, not a failure — before anything
+   else runs.
+2. `ffmpeg` slices the first **30 s** of audio; `whisper` transcribes that slice
+   with **no** `--language`, so it reports the language it detected.
+3. **English** (`en`) goes to `xbrain-transcribe` → parakeet-mlx, the fast path.
+   **Anything else, and anything it could not identify**, goes to whisper: it
+   tries `xbrain-transcribe-mlx` (mlx-whisper on the Apple GPU, pulled on demand
+   through `uv run --with`) and falls back to `xbrain-transcribe-whisper` (the
+   brew `whisper` CLI, CPU, portable) when the GPU backend cannot run.
+
+| Backend | Wrapper | Languages | Notes |
+|---------|---------|-----------|-------|
+| parakeet-mlx | `xbrain-transcribe` | **English only** | fastest; fabricates on anything else |
+| mlx-whisper | `xbrain-transcribe-mlx` | multilingual | Apple GPU; needs `uv` |
+| whisper (brew) | `xbrain-transcribe-whisper` | multilingual | CPU; works anywhere, slow |
+
+The two whisper backends were verified to produce a **character-identical**
+transcript on a real clip, so the GPU→CPU fallback costs accuracy nothing and
+only costs time. The wrapper records the measurement behind that ordering: on
+one 68-second Spanish clip (M-series Mac, 12-ago-2026) the CPU CLI took
+**7 min 25 s** and mlx-whisper **17.7 s**.
+
+**It fails towards whisper, always.** Missing `ffmpeg`, a `whisper` that errors,
+an unreadable result — every one of those returns "undetected", and undetected
+routes to whisper. The costs are asymmetric in exactly one direction: whisper on
+English is slower than it needed to be, while parakeet on non-English is a
+fabricated transcript.
+
+One consequence worth knowing: **detection needs the `whisper` CLI on `PATH`.**
+Without it nothing can ever be detected, so every video takes the multilingual
+path — you lose the parakeet fast path silently rather than noisily. That still
+transcribes correctly *provided the mlx backend can run*, because the CPU
+fallback is that same missing `whisper` binary: with neither `uv`/mlx-whisper nor
+`whisper` available the run fails outright. Which is the right direction to fail
+in, but it is a failure, not a slow success.
+
+Both whisper wrappers also discard whisper's canned **no-speech artefacts** —
+when the *whole* transcript is one of the subtitle-boilerplate lines the model
+emits on silence (`Subtítulos realizados por la comunidad de Amara.org`,
+`Thanks for watching!`, `[Música]`), it is recorded as no speech instead of as
+something a person said. Matching is on the entire transcript, so a video that
+merely *mentions* Amara or thanks its viewers mid-sentence is untouched.
+
+### Tuning
+
+All optional environment variables, all read by the router:
+
+| Variable | Default | What it does |
+|----------|---------|--------------|
+| `XBRAIN_ASR_DETECT_MODEL` | `base` | whisper model used for the detection pass |
+| `XBRAIN_ASR_DETECT_SECONDS` | `30` | seconds of audio sampled to detect |
+| `XBRAIN_ASR_FORCE` | *(unset)* | `parakeet` or `whisper` — skip detection entirely |
+| `XBRAIN_TRANSCRIBE_PARAKEET` | sibling script | path to the parakeet wrapper |
+| `XBRAIN_TRANSCRIBE_MLX` | sibling script | path to the mlx-whisper wrapper |
+| `XBRAIN_TRANSCRIBE_WHISPER` | sibling script | path to the CPU whisper wrapper |
+
+Detection costs one small-model pass over 30 seconds per video. The wrapper's
+own timing (M-series, 12-ago-2026, one es-ES and one en-US clip) puts `base` at
+~19 s per clip and `tiny` at ~10 s, with both models identifying both clips
+correctly. `base` stays the default: two clips are not enough evidence to trade
+accuracy for nine seconds on the one axis where being wrong means a fabricated
+transcript. Reach for `XBRAIN_ASR_DETECT_MODEL=tiny` on a large backlog, where
+the halving actually adds up.
+
+`XBRAIN_ASR_FORCE=parakeet` skips detection for a run you *know* is English —
+and re-introduces the fabrication risk for every clip in it that isn't.
 
 ## Run it
 
@@ -129,3 +233,5 @@ uv run xbrain digest-video --topic ai-coding      --frames --vision-model qwen-7
 Re-running skips videos already carrying an `x_video` source unless `--force`.
 
 Slow? See [Troubleshooting → digest-video](troubleshooting.md#digest-video-is-slow-or-times-out).
+Digest reads fluently but doesn't match the video? →
+[Troubleshooting](troubleshooting.md#a-digest-reads-perfectly-but-says-nothing-that-was-said).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -31,6 +31,50 @@ always means an **expired session** or an X GraphQL change, not that your
 bookmarks vanished. It aborts rather than overwrite good data. Re-authenticate
 (above) and re-run. If you're sure the store is stale, `--force` overrides it.
 
+## `extract` captured nothing — "0 respuestas de … en toda la timeline"
+
+Symptom: `extract --source tweets` (or `sync`) aborts with
+
+```
+own_tweet: 0 respuestas de UserOriginalsTimeline/UserTweets en toda la timeline —
+no es que no haya items nuevos, es que no se capturó NADA. Lo normal es que X haya
+renombrado la operación: mira las operaciones GraphQL reales de la página y añade
+el nombre nuevo a `_OPERATIONS`.
+```
+
+Cause: X renames its internal GraphQL timeline operations without notice. The
+own-tweets timeline answered to `UserTweets` until X moved it to
+`UserOriginalsTimeline` (measured 30-ago-2026). The *parser* survives a rename —
+it anchors on the `tweet_results` key, not on a path — but the **capture filter**
+matches by operation name, so a name it doesn't know means every response is
+filtered out and nothing is ever collected.
+
+**This is not "no new posts", and the difference is not a judgement call.** A
+healthy timeline always answers its operation at least once; even an account with
+zero posts gets one response carrying an empty instruction list. Zero responses
+therefore has exactly one meaning: the filter matched nothing. That is why the run
+now fails closed instead of reporting a total.
+
+Fix — find the name X is using and add it:
+
+1. Open `x.com` in a browser, DevTools → Network, filter on `graphql`.
+2. Scroll the timeline that's failing (your profile for `tweets`, `/i/bookmarks`
+   for `bookmarks`) and read the operation name out of the request path.
+3. Add it to `_OPERATIONS` in `src/xbrain/extract/extractor.py`, **newest first**,
+   keeping the old names — X A/B-tests these and rolls them back:
+
+   ```python
+   _OPERATIONS: dict[str, tuple[str, ...]] = {
+       "bookmark": ("Bookmarks",),
+       "own_tweet": ("UserOriginalsTimeline", "UserTweets"),
+   }
+   ```
+
+If instead the run reports **"0 nuevos items" and exits 0**, you are on a build
+from before this was fixed, where the filter held a single literal per source and
+a rename was silent — indistinguishable from an empty timeline, with the cursor
+advancing over the gap. Update, then re-run.
+
 ## Getting rate-limited / the browser stalls
 
 `extract` runs **headful** (visible Chromium) by default to look human, paces
@@ -45,7 +89,7 @@ transcriber '.../xbrain-transcribe' exited 1: FileNotFoundError: 'parakeet-mlx'
 
 The external tools aren't on `PATH`. Two cases:
 
-- **Interactive shell:** install them (`brew install ffmpeg`,
+- **Interactive shell:** install them (`brew install ffmpeg openai-whisper`,
   `uv tool install parakeet-mlx mlx-vlm`) and make sure `~/.local/bin` +
   `/opt/homebrew/bin` are on your `PATH`.
 - **cron / launchd / a scheduled job:** these run with a **minimal PATH** that
@@ -61,6 +105,13 @@ The external tools aren't on `PATH`. Two cases:
 
   When testing a job, reproduce its env (`env -i HOME=$HOME PATH=... your-cmd`),
   not your shell — your shell's full PATH hides the bug.
+
+If you use `scripts/xbrain-transcribe-auto`, it needs `ffmpeg` **and** `whisper`
+on `PATH` to detect the language at all, plus `uv` for the GPU backend. A minimal
+job environment that hides them makes the run fail outright rather than fall
+through to parakeet — which is the safe direction, but it does mean a cron job
+that used to "work" on an English corpus starts erroring once you switch to the
+router.
 
 ## `digest-video` is slow or times out
 
@@ -84,6 +135,44 @@ Local vision (`--frames`) is the bottleneck: a slide-heavy talk can have up to
   (errors = no audio exists).
 - `fallidos` (real failures): usually `parakeet-mlx` not found (see the PATH
   section above) — the fix is almost always the environment, not the video.
+
+## A digest reads perfectly but says nothing that was said
+
+Symptom: a video note's transcript and digest are fluent, confident English —
+and bear no relation to the video. Nothing failed: `digest-video` reported the
+video under **transcritos**, `enrich` summarised it, `video-digest` wrote a
+readable digest of it, and every stage exited 0.
+
+Cause: `parakeet-mlx` transcribed non-English audio. `parakeet-tdt` (v2 and v3)
+is English-only and **does not fail** on other languages — handed Spanish audio
+it invents fluent English and exits 0. There is no error anywhere in the run,
+and by the time the text reaches your vault it is rendered as a quotation of the
+speaker.
+
+Fix: switch `[transcribe].command` to the router, then re-transcribe the affected
+videos with `--force`:
+
+```toml
+[transcribe]
+command = "/abs/path/to/xbrain/scripts/xbrain-transcribe-auto"
+```
+
+```bash
+brew install openai-whisper       # the router's detector + its multilingual backend
+uv run xbrain digest-video --ids <affected-ids> --force
+uv run xbrain video-digest --executor claude-code    # re-digest against the real transcript
+uv run xbrain enrich                                 # re-summarise it
+```
+
+The router detects the language on the first 30 s and sends English to parakeet,
+everything else — and anything it cannot identify — to whisper. See
+[Picking the transcriber](digest-video.md#picking-the-transcriber) for the
+backends, the tuning env vars, and why it fails towards whisper.
+
+There is no way to detect this after the fact from the transcript alone: a
+fabricated transcript is well-formed. If you have run `digest-video` over a
+multilingual corpus with plain `parakeet-mlx`, treat every non-English video's
+text as unverified rather than trying to spot the bad ones.
 
 ## `generate` hangs or takes very long
 
@@ -122,6 +211,42 @@ you fill it, and a second `--apply` run consumes it. Common cases:
 
 Both default to `[enrich].executor` and support only `--executor claude-code|manual`
 (no `api` track).
+
+## A note shows no verification badge, but I know it was judged
+
+Symptom: you ran `verify … --write-verdicts`, the verdict is in `items.json`, and
+`generate` renders the note with no ❌ / ⚠️ line under it.
+
+Two causes, both deliberate:
+
+- **The verdict was PASS.** A PASS is never badged — it would put a green line
+  under most of the corpus and train you to ignore all of them. Only FAIL and
+  REVIEW paint.
+- **The verdict went stale.** A badge paints only while the stored
+  `contract_fingerprint` still matches what would be computed today, and that
+  fingerprint hashes **three arms**: the *output* under judgment, the *source the
+  judge actually read* for that target (the evidence surfaces plus the
+  not-fetched markers), and the *rubrics* it was judged by. Change any one and
+  the verdict is retired silently.
+
+The staleness rule is the point, not a bug: a verdict is not a property of the
+output alone, it is the result of judging *that* output against *that* source
+under *those* rules. So **an output fixed after a FAIL never shows a ❌** — which
+is exactly what you want — but so does a FAIL whose article body arrived later,
+or whose frame descriptions landed, or that was judged before the rubrics were
+rewritten. A verdict stored before contract fingerprinting existed carries no
+fingerprint at all and is stale by construction: it is retired, not
+grandfathered.
+
+Fix: nothing is broken, so there is nothing to repair — re-run `verify` to judge
+the output under the contract in force now. When it exports a worksheet it tells
+you how much of the layer has been retired, which is the number to watch after a
+rubric change:
+
+```
+⚠️  N de M verdicts almacenados quedaron OBSOLETOS: se juzgaron bajo otro contrato
+(otro output, otra fuente u otra rúbrica). No pintan badge; hay que re-verificarlos.
+```
 
 ## Where's the source of truth? Can I delete the vault notes?
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -156,6 +156,20 @@ uv run xbrain verify-entities --target digest
 # → Report: data/entity-report.md
 ```
 
+Counts come from one corpus (205 digests across 2,404 items, read 30-ago-2026);
+yours will differ.
+
+**That trailing zero is not a finding**, and it is the easiest number in this
+tool to misread. The clause counts flagged outputs the judges had already passed
+*unanimously* — the ensemble's false-negative floor. It can only be non-zero when
+you pass `--verdicts`; without that flag there is no ensemble to join against and
+the count is structurally `0`. Even *with* it this corpus still reports `0`, for
+a second reason: only 39 digest verdicts exist across 205 digests, and none of
+them lands on a flagged output. So the zero here measures **coverage, not
+agreement** — it says the judges never looked at these, not that they cleared
+them. Read it as a finding only when your verdict coverage is high enough for
+the join to mean something.
+
 Read the caveat before you read the report, because it is narrower than it
 sounds. **It checks only that proper nouns appear somewhere on the evidence. It
 never checks what is asserted about them, and it never looks at a number.** A
@@ -168,9 +182,10 @@ confident false claim about a correctly-named real entity, is exactly the shape
 it cannot see.
 
 That is why the two passes are both here: the judges can read a claim but share
-one blind spot, and this one cannot share it but cannot read a claim. Pass
-`--verdicts data/verify-report.json` to cross-reference them — it reports how
-many flagged outputs the judges passed *unanimously*.
+one blind spot, and this one cannot share it but cannot read a claim.
+`--verdicts data/verify-report.json` is what actually joins them, and it is worth
+running only once enough of the corpus carries verdicts — otherwise, as above,
+you are measuring your own coverage.
 
 ## 7. See the whole corpus at a glance
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -85,8 +85,14 @@ Obsidian's search finds "that chart about pricing".
 
 This turns a saved talk into a readable, topic-linked note. It needs the local
 tooling from [Local models for `digest-video`](../README.md#local-models-for-digest-video-apple-silicon)
-(ffmpeg + parakeet-mlx, plus mlx-vlm for `--frames`). See the worked example in
+(ffmpeg + an ASR backend, plus mlx-vlm for `--frames`). See the worked example in
 [digest-video.md](digest-video.md).
+
+> **If any of your videos are not in English, set the transcriber first.**
+> `parakeet-mlx` is English-only and does *not* fail on other languages — it
+> invents fluent English and exits 0. Point `[transcribe].command` at
+> `scripts/xbrain-transcribe-auto`, which detects the language and routes
+> accordingly. See [Picking the transcriber](digest-video.md#picking-the-transcriber).
 
 ```bash
 # Transcript only (fast): every bookmarked video → an x_video transcript source
@@ -108,16 +114,65 @@ uv run xbrain generate
 Skip the `video-digest` step and the note still renders — it just falls back to the
 raw transcript inline, without the readable digest.
 
-Optionally, sanity-check the LLM outputs with `verify` — an LLM-as-judge pass over
-the summaries, digests and topics. It writes `data/verify-report.md` and **never
-touches your store**:
+## 6. Check what the LLM wrote (optional)
+
+Two QA passes. Both are **report-only** — neither touches your store — and they
+are deliberately different instruments: one is a panel of LLM judges, the other
+has no model in it at all.
+
+**`verify`** scores each `summary` / `digest` / `topics` output for faithfulness
+(did it invent facts the source doesn't support?) and rubric-adherence, and
+writes `data/verify-report.md` worst-first. It is a worksheet flow, like
+`enrich`:
 
 ```bash
 uv run xbrain verify --target all --executor claude-code
-uv run xbrain verify --apply data/verify-worksheet.json   # one worksheet per judge
+# → <N> outputs exportados a data/verify-worksheet.json
+# →   Copia N veces (una por juez), rellena `judgments` en cada una, y ejecuta:
+# →     xbrain verify --apply ws1.json --apply ws2.json ...
 ```
 
-## 6. See the whole corpus at a glance
+Copy the exported worksheet **once per judge**, fill each one in its own Claude
+Code session, then aggregate them in a single call:
+
+```bash
+uv run xbrain verify --apply ws1.json --apply ws2.json --apply ws3.json
+```
+
+How much this is worth depends on how many judges you actually run. One filled
+worksheet is one opinion; the aggregation is what surfaces divergence between
+judges, and divergence is the signal. Verdicts, `--audit`, `--write-verdicts`
+and the badge-writing path have a large flag surface — see the `verify` row in
+the README's [Commands](../README.md#commands) table before you use them.
+
+**`verify-entities`** is the deterministic sweep: no LLM, no tokens, and the
+whole corpus rather than a sample. It flags generated outputs containing proper
+nouns that appear on none of the evidence surfaces:
+
+```bash
+uv run xbrain verify-entities --target digest
+# → 51 outputs con entidades sin soporte (64 entidades); 0 de ellas con PASS UNÁNIME de los jueces.
+# → + 116 outputs cuyo ÚNICO indicio es del tier incierto (mayúscula ambigua, …)
+# → Report: data/entity-report.md
+```
+
+Read the caveat before you read the report, because it is narrower than it
+sounds. **It checks only that proper nouns appear somewhere on the evidence. It
+never checks what is asserted about them, and it never looks at a number.** A
+digest claiming Sam Altman said he'd fire half the company, against evidence
+where he discusses hiring, finds `Sam Altman` on the transcript and passes
+clean. So does an invented benchmark score, a wrong date, a fabricated funding
+round. A clean verdict means "no unknown proper nouns" — never "not
+hallucinated", and the most damaging hallucination for a knowledge base, a
+confident false claim about a correctly-named real entity, is exactly the shape
+it cannot see.
+
+That is why the two passes are both here: the judges can read a claim but share
+one blind spot, and this one cannot share it but cannot read a claim. Pass
+`--verdicts data/verify-report.json` to cross-reference them — it reports how
+many flagged outputs the judges passed *unanimously*.
+
+## 7. See the whole corpus at a glance
 
 `generate` also writes `dashboard.html` — a self-contained interactive dashboard
 (counts, topics, authors, growth over time, photo thumbnails), with drill-down and
@@ -143,5 +198,40 @@ uv run xbrain generate
 The markdown is **derived and disposable** — delete and regenerate any time. The
 source of truth is `data/items.json` (snapshotted before every destructive op;
 see [Snapshots & safety](../README.md#snapshots--safety)).
+
+## When something went wrong
+
+Not part of the happy path. These repair a corpus you already have. Most report
+before they write — run the dry form, read it, then re-run to apply.
+
+```bash
+# A parse bug was fixed: re-run the parser over the STORED payloads. Offline,
+# no network, no re-scrape. Prints exactly what would change; --apply writes it.
+uv run xbrain reextract
+# → Dry run. Pass --apply to write.
+uv run xbrain reextract --apply
+
+# Posts whose text was cut at 280 chars on ingest (the generator then "finished"
+# the sentence for them). The raw payloads aren't on disk for these, so applying
+# re-fetches each one from X — slow, human-paced browser work.
+uv run xbrain refetch-truncated
+# → Dry run. Re-fetching requires the network: pass --apply.
+
+# Quote-tweets stored without the post they quote. --from-store joins against
+# items you already hold: no browser, instant, re-runnable. It has NO dry run —
+# it writes on the spot (after snapshotting). Start here; run the full
+# `xbrain refresh-quoted` afterwards for the ones it couldn't reach.
+uv run xbrain refresh-quoted --from-store
+
+# Links that failed to fetch, retried only where a retry could actually help.
+uv run xbrain fetch --retry-failed --dry-run
+uv run xbrain fetch --retry-failed
+```
+
+The applying form of each rewrites `items.json`, and auto-snapshots `data/`
+before it does, so a bad run is undoable with `xbrain snapshot restore`.
+`refetch-truncated` and `refresh-quoted` invalidate the summaries of the items
+they repair — re-run `xbrain enrich` afterwards so those get written against the
+evidence they were missing.
 
 Stuck? → [Troubleshooting](troubleshooting.md).

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -227,8 +227,9 @@ uv run xbrain reextract
 uv run xbrain reextract --apply
 
 # Posts whose text was cut at 280 chars on ingest (the generator then "finished"
-# the sentence for them). The raw payloads aren't on disk for these, so applying
-# re-fetches each one from X — slow, human-paced browser work.
+# the sentence for them). Run `reextract` FIRST: payloads are persisted now, and
+# roughly a third of these re-parse offline for free. Only what that leaves needs
+# this, and applying it re-fetches each from X — slow, human-paced browser work.
 uv run xbrain refetch-truncated
 # → Dry run. Re-fetching requires the network: pass --apply.
 
@@ -242,6 +243,17 @@ uv run xbrain refresh-quoted --from-store
 uv run xbrain fetch --retry-failed --dry-run
 uv run xbrain fetch --retry-failed
 ```
+
+Two things about `refetch-truncated`'s count before you plan a session around
+it. Its detector decides on **length alone** — 274 characters or more is
+truncated unconditionally — so the total is a work list biased towards flagging,
+not a census: on one corpus (2,404 items, read 30-ago-2026) it flags 707, of
+which only 146 are 290 characters or shorter. And a stored payload is not
+automatically a free repair: 702 of those 707 have one, but a payload only helps
+when X included the long-form body at capture time, so on that same corpus
+`reextract` recovers the text of 222 of them and the remaining ~480 still need
+the network. Run the `reextract` dry pass and read its count — that is the number
+you actually get for free.
 
 The applying form of each rewrites `items.json`, and auto-snapshots `data/`
 before it does, so a bad run is undoable with `xbrain snapshot restore`.


### PR DESCRIPTION
Refreshes the three files under `docs/` against what actually shipped since the
manual was written in July. **Docs only** — no code, tests or config touched.
The sibling PRs own `ARCHITECTURE.md`, `README.md` and `CLAUDE.md`.

## Why

A reader following the manual today gets a worse result than the tool can give,
and on a multilingual corpus a **silently wrong** one. `parakeet-tdt` is
English-only and does *not* fail on other languages — handed Spanish audio it
exits 0 and emits fluent, broken English that never reproduces what was said.
The docs pointed `[transcribe].command` straight at it. The invented transcript
attaches as an `x_video` source, `enrich` summarises it, `video-digest` writes a
readable digest *of* it, and it lands in the vault as a quotation of the speaker
with nothing in the run to distinguish it from a real one. The router that fixes
this shipped in #133 with no documentation.

## `docs/digest-video.md`

- **Prerequisites + config snippet** now land a new user on
  `scripts/xbrain-transcribe-auto`; straight-to-parakeet kept as the explicit
  English-only option. Adds `brew install openai-whisper` (verified: the local
  `whisper` resolves to `Cellar/openai-whisper/20250625_3`).
- **New §Picking the transcriber** — the fabrication path, the three backends,
  the dispatch order, and the tuning env vars.

| Claim | Verified against |
|---|---|
| parakeet English-only, fabricates, exits 0 | `scripts/xbrain-transcribe-auto` module docstring ("WHY THIS EXISTS"); `scripts/xbrain-transcribe-whisper` docstring |
| ffprobe silent short-circuit before detection | `xbrain-transcribe-auto:main` → `_confirmed_no_audio` / `_write_silent` |
| 30 s slice, whisper with no `--language` | `xbrain-transcribe-auto:detect_language` |
| English → parakeet; everything else *and* undetected → whisper | `PARAKEET_LANGUAGES`, `pick_backend` |
| mlx GPU tried before brew CPU | `main`'s `(XBRAIN_TRANSCRIBE_MLX, XBRAIN_TRANSCRIBE_WHISPER)` fallback loop |
| mlx exits non-zero *without writing* when unusable | `xbrain-transcribe-mlx:run_mlx` → `main` returns 1 |
| `XBRAIN_ASR_DETECT_MODEL` (`base`), `XBRAIN_ASR_DETECT_SECONDS` (30), `XBRAIN_ASR_FORCE`, `XBRAIN_TRANSCRIBE_{PARAKEET,MLX,WHISPER}` | `xbrain-transcribe-auto` `DEFAULT_*` + `_wrapper()` + `main`; cross-checked against `config.toml.example` `[transcribe]` |
| no-speech artefact discard is whole-transcript only | `NO_SPEECH_ARTEFACTS` / `is_hallucinated_silence` in both whisper wrappers |

Behaviour covered by `tests/test_xbrain_transcribe_auto.py`
(`test_pick_backend_routes_non_english_and_unknown_to_whisper`,
`test_gpu_backend_failure_falls_back_to_the_cpu_one`, `test_force_env_skips_detection`,
`test_silent_video_short_circuits_before_any_detection`).

## `docs/tutorial.md`

- **§5** gains a non-English warning before the first `digest-video` command.
- **New §6 "Check what the LLM wrote"** — `verify` (worksheet + ensemble; its
  worth scales with how many judges you run, so it links to the README
  `Commands` row rather than restating the flag surface) and `verify-entities`
  with its caveat stated in the tutorial, not buried: it checks that proper
  nouns *appear* on the evidence, never what is asserted about them, never a
  number (`src/xbrain/entity_grounding.py` module docstring, "WHAT IT IS BLIND
  TO"). Dashboard section renumbered 6 → 7.
- **New §"When something went wrong"** — `reextract`, `refetch-truncated`,
  `refresh-quoted --from-store`, `fetch --retry-failed --dry-run`, kept off the
  happy path. Verified against `cli.py:reextract_command`,
  `refetch_truncated_command`, `_run_refresh_quoted_from_store`, and the
  `--retry-failed` / `--dry-run` options; dry-run echo strings quoted verbatim.
  Noted that `refresh-quoted --from-store` has **no** dry run and writes on the
  spot (after its auto-snapshot).

## `docs/troubleshooting.md`

Three entries in the file's existing symptom / cause / fix shape:

1. **`extract` captured nothing.** `grep -n "_OPERATIONS" src/xbrain/extract/extractor.py`
   → `"own_tweet": ("UserOriginalsTimeline", "UserTweets")`. **The fix IS in this
   tree**, so it is documented as fixed: the alias tuple plus the fail-closed
   `OperationNotCaptured` raise. Documents the *new loud* symptom (with the error
   quoted verbatim in Spanish), the rename-vs-empty-timeline diagnostic (a healthy
   timeline always answers at least once, even at zero posts), and how to add a new
   operation name. The old silent `"0 nuevos items"` + exit 0 form is described as
   the tell that you are on a pre-#136 build.
2. **A digest reads perfectly but says nothing that was said** — the parakeet
   fabrication, cross-linked to `digest-video.md#picking-the-transcriber`.
3. **A missing verdict badge** — `src/xbrain/generate.py:_verdict_badge` (PASS is
   never badged; stale is skipped) and `src/xbrain/verification.py:contract_fingerprint`
   / `verdict_is_current` (three arms: output, target-scoped source, rubrics; a
   verdict with no fingerprint is retired, not grandfathered).

Also extends the existing PATH entry: the router needs `ffmpeg` **and** `whisper`
to detect at all, plus `uv` for the GPU backend — traced through to confirm a
minimal cron env makes the run fail outright rather than fall through to parakeet.

## Numbers

Re-derived against the live store (2,325 items) with `/opt/homebrew/bin/python3.13`,
read-only, via `scan_store` / `summarise_scan` / `outputs_present` in-process — the
CLI was not run, since `verify-entities` writes `entity-report.*` into the live
`data/`. `--target digest`: 205 outputs present, **51 flagged, 64 entities, 116
uncertain-tier-only**. Those are the figures in the tutorial's `# →` lines.

The wrapper benchmarks (7 min 25 s CPU vs 17.7 s mlx; `base` ~19 s vs `tiny` ~10 s)
are attributed in-text as the scripts' own recorded measurements **with their
dates**, because they cannot be re-derived in this session.

All internal links and anchors were checked programmatically (GitHub slug rules,
including the `&`-induced double hyphen); every one resolves, and all code fences
balance.

## Base

Branched from `origin/develop` @ `439ec08`, **not** the `d0c86fd` in the brief —
develop had moved 7 commits, including #136 (the extract rename fix) and #137.
Documenting `d0c86fd` would have described the extract bug as unfixed in a PR
that merges into a tree where it is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
