### PR TITLE
fix(transcribe): the ASR wrappers died on every video, silently

### DIFF
--- a/scripts/xbrain-transcribe-auto
+++ b/scripts/xbrain-transcribe-auto
@@ -49,6 +49,8 @@ ENV
   XBRAIN_TRANSCRIBE_WHISPER  path to the whisper wrapper       (default: alongside this file)
 """
 
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/scripts/xbrain-transcribe-mlx
+++ b/scripts/xbrain-transcribe-mlx
@@ -27,6 +27,8 @@ ENV
   XBRAIN_UV         path to the `uv` binary (default: looked up on PATH)
 """
 
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/scripts/xbrain-transcribe-whisper
+++ b/scripts/xbrain-transcribe-whisper
@@ -20,6 +20,8 @@ Silencio: si whisper no produce texto y ffprobe confirma que no hay pista de
 audio → JSON de empty-speech (has_speech=false), igual que el wrapper parakeet.
 """
 
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/tests/test_transcribe_wrapper_runtime.py
+++ b/tests/test_transcribe_wrapper_runtime.py
@@ -1,0 +1,55 @@
+# tests/test_transcribe_wrapper_runtime.py — the wrappers must RUN, not just parse.
+"""`[transcribe].command` is executed by whatever `python3` the PATH resolves to.
+
+That is not this project's interpreter. On this machine `#!/usr/bin/env python3`
+resolved to 3.7.9, and every wrapper died at import with
+`TypeError: 'type' object is not subscriptable` — PEP 585 generics (`list[str]`)
+in a signature are EVALUATED when the function is defined, and 3.7 cannot. The
+scripts still compiled cleanly, so `py_compile` and ruff both stayed green while
+`digest-video` failed on every single video and reported it only as
+`fallidos: N` with exit code 0.
+
+`from __future__ import annotations` makes annotations strings, so they are never
+evaluated and the wrappers load on any Python the shebang may find.
+"""
+
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+_WRAPPERS = sorted(_SCRIPTS.glob("xbrain-transcribe-*"))
+
+
+def test_there_are_wrappers_to_check():
+    """A glob that silently matches nothing would make every test below vacuous."""
+    assert _WRAPPERS, f"no transcribe wrappers found under {_SCRIPTS}"
+
+
+@pytest.mark.parametrize("script", _WRAPPERS, ids=lambda p: p.name)
+def test_wrapper_postpones_annotation_evaluation(script: Path):
+    """Every wrapper declares `from __future__ import annotations`.
+
+    Asserted on ALL of them, not only the ones that currently use a generic: the
+    next `list[str]` someone adds must not reintroduce the failure, and the import
+    costs nothing.
+    """
+    source = script.read_text(encoding="utf-8")
+    assert "from __future__ import annotations" in source, (
+        f"{script.name} must postpone annotation evaluation — its shebang is "
+        "`/usr/bin/env python3`, which is not this project's interpreter."
+    )
+
+
+@pytest.mark.parametrize("script", _WRAPPERS, ids=lambda p: p.name)
+def test_wrapper_future_import_precedes_every_other_statement(script: Path):
+    """`from __future__` is only legal at the top; otherwise it is a SyntaxError."""
+    import ast
+
+    tree = ast.parse(script.read_text(encoding="utf-8"))
+    body = [n for n in tree.body if not isinstance(n, ast.Expr)]  # drop the docstring
+    assert body, f"{script.name} has no statements"
+    first = body[0]
+    assert isinstance(first, ast.ImportFrom) and first.module == "__future__", (
+        f"{script.name}: the __future__ import must come first, got {ast.dump(first)[:60]}"
+    )


### PR DESCRIPTION
## What broke

`digest-video` has been failing on **100% of videos**. Every run ended with `transcritos 0 ... fallidos N` and **exit code 0**, so nothing upstream noticed.

```
digest-video: transcription failed for item 2089928014935339318:
transcriber '/Users/vgonpa/.local/bin/xbrain-transcribe-auto' exited 1:
  File ".../xbrain-transcribe-auto", line 84, in <module>
    def _parse_args(args: list[str]) -> tuple[str, str]:
TypeError: 'type' object is not subscriptable
```

## Why

`[transcribe].command` is executed by whatever `python3` the PATH resolves to — **not** this project's interpreter. On this machine `#!/usr/bin/env python3` resolves to **Python 3.7.9**, and all three wrappers annotate with PEP 585 generics. Those annotations are *evaluated* when the function is defined, and 3.7 cannot subscript `list`, so the script dies at import before doing anything.

Reproduced against that exact interpreter:

```
$ /Library/.../3.7/bin/python3 -c "def f(a: list[str]) -> tuple[str,str]: pass"
TypeError: 'type' object is not subscriptable

$ /Library/.../3.7/bin/python3 -c "from __future__ import annotations
def f(a: list[str]) -> tuple[str,str]: pass"      # OK
```

## Why neither gate caught it

- `list[str]` is valid **syntax** on 3.7 — `py_compile` and ruff are both happy. The failure is at *runtime*, in an interpreter the test suite never runs.
- The failure surfaced only as a per-item warning folded into a summary line, never as a non-zero exit. Same shape as the other silent failures fixed this week: the run reports success by saying nothing.

## The change

`from __future__ import annotations` in all three wrappers — annotations become strings, so they are never evaluated and the scripts load on any Python the shebang may find. Verified by loading each of the three under 3.7.9 itself, before and after.

The new test asserts the import on **every** wrapper, not only the two that use a generic today, so the next `list[str]` someone adds cannot reintroduce this. It also asserts the import precedes every other statement (a `__future__` import anywhere else is a `SyntaxError`), and the glob that finds the wrappers is guarded by its own test so a path change cannot make the file vacuously pass.

Gate green locally: 1848 tests, 94% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wu14vRbJETETVbQb9Hszdg