### PR TITLE
feat(#90): frame captions transcribe on-screen text verbatim

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,14 @@ reads `XBRAIN_VISION_MLX_PYTHON` only if mlx-vlm is not at the uv-tool default
 a `--frames` run — a cold `qwen-32b` (~18 GB) download can exceed the 300 s
 per-frame vision timeout and fail the first run (a re-run uses the cache).
 
+xbrain also sets `XBRAIN_VISION_PROMPT` in the command's environment, carrying
+the frame-caption rubric it renders (transcribe on-screen text verbatim, never
+translated). The argv contract `<command> [--model M] <image-path>` is
+deliberately unchanged, so a command that ignores the variable still works — it
+just gets no caption discipline, and its captions will not ground what the
+digest says about the screen. A custom command SHOULD read it and use it as the
+prompt.
+
 ---
 
 ## The pipeline

--- a/config.toml.example
+++ b/config.toml.example
@@ -82,14 +82,15 @@ command = "parakeet-mlx"
 # this command as a subprocess. There is NO bundled default: leave it unset and
 # `--frames` errors clearly until you configure a local VLM. xbrain invokes:
 #   <command> [--model M] <image-path>
+# and reads the frame's text description from stdout. May be a multi-token wrapper
+# (split with shlex, run without a shell). `--frames` is fully opt-in: a normal
+# `digest-video` run never touches ffmpeg or this command.
+#
 # xbrain also sets XBRAIN_VISION_PROMPT in the command's environment, carrying the
 # frame-caption rubric (transcribe on-screen text verbatim, never translated). The
 # argv is unchanged, so a command that ignores the variable still works — it just
 # gets no caption discipline, and its captions will not ground what the digest
 # says about the screen. A custom command SHOULD read it and use it as the prompt.
-# and reads the frame's text description from stdout. May be a multi-token wrapper
-# (split with shlex, run without a shell). `--frames` is fully opt-in: a normal
-# `digest-video` run never touches ffmpeg or this command.
 #
 # The bundled `scripts/xbrain-vision` wrapper is a MULTI-BACKEND SELECTOR: the
 # `--model` name routes to a local mlx-vlm model OR a cloud Claude model, so one

--- a/config.toml.example
+++ b/config.toml.example
@@ -82,6 +82,11 @@ command = "parakeet-mlx"
 # this command as a subprocess. There is NO bundled default: leave it unset and
 # `--frames` errors clearly until you configure a local VLM. xbrain invokes:
 #   <command> [--model M] <image-path>
+# xbrain also sets XBRAIN_VISION_PROMPT in the command's environment, carrying the
+# frame-caption rubric (transcribe on-screen text verbatim, never translated). The
+# argv is unchanged, so a command that ignores the variable still works — it just
+# gets no caption discipline, and its captions will not ground what the digest
+# says about the screen. A custom command SHOULD read it and use it as the prompt.
 # and reads the frame's text description from stdout. May be a multi-token wrapper
 # (split with shlex, run without a shell). `--frames` is fully opt-in: a normal
 # `digest-video` run never touches ffmpeg or this command.

--- a/scripts/xbrain-vision
+++ b/scripts/xbrain-vision
@@ -40,11 +40,11 @@ import urllib.request
 from pathlib import Path
 
 # xbrain injects the frame-caption rubric here (`xbrain.vision.PROMPT_ENV_VAR`).
-# The variable is the delivery channel precisely so the argv contract stays
-# frozen. This constant is the fallback for a BARE run outside xbrain — it must
-# never be empty, because an empty prompt would silently produce a useless
-# caption rather than an error.
+# The variable is the delivery channel precisely so the argv contract stays frozen.
 _PROMPT_ENV_VAR = "XBRAIN_VISION_PROMPT"
+# This constant is the fallback for a BARE run outside xbrain — it must never be
+# empty, because an empty prompt would silently produce a useless caption rather
+# than an error.
 _FALLBACK_PROMPT = (
     "Describe this video key-frame for a personal knowledge wiki in one or two "
     "dense, factual sentences. Transcribe any on-screen text VERBATIM, in its "

--- a/scripts/xbrain-vision
+++ b/scripts/xbrain-vision
@@ -46,11 +46,13 @@ _PROMPT_ENV_VAR = "XBRAIN_VISION_PROMPT"
 # empty, because an empty prompt would silently produce a useless caption rather
 # than an error.
 _FALLBACK_PROMPT = (
-    "Describe this video key-frame for a personal knowledge wiki in one or two "
-    "dense, factual sentences. Transcribe any on-screen text VERBATIM, in its "
-    "original language and exact spelling — slide titles, code identifiers, UI "
-    "labels, chart axes. Never invent text or numbers; if something is unreadable, "
-    "say so. No preamble, no markdown — reply with only the description."
+    "Describe this video key-frame for a personal knowledge wiki. Prefer coverage "
+    "over depth: transcribe every legible on-screen string VERBATIM, in its "
+    "original language and exact spelling, each in double quotes — slide titles, "
+    "code identifiers, UI labels, chart axes, error messages. A few sentences of "
+    "your own prose is fine, but never at the cost of a dropped label. Never "
+    "invent text or numbers; if something is unreadable, say so plainly instead of "
+    "guessing. No preamble, no markdown — reply with only the description."
 )
 
 
@@ -110,7 +112,9 @@ def _describe_cloud(model: str, image: Path) -> str:
     body = json.dumps(
         {
             "model": model,
-            "max_tokens": 512,
+            # 1024, not the original 512 — see `_describe_local`'s `max_tokens`
+            # comment below for why (same rubric, same ceiling, one explanation).
+            "max_tokens": 1024,
             "messages": [
                 {
                     "role": "user",
@@ -143,6 +147,18 @@ def _describe_cloud(model: str, image: Path) -> str:
         )
     except urllib.error.URLError as exc:  # DNS / connection / TLS / timeout — also clean, no stack
         raise SystemExit(f"xbrain-vision: network error reaching Anthropic API: {exc.reason}")
+    # A truncated caption is still better than none — xbrain.vision treats a
+    # non-zero exit as a per-video failure, so we do NOT fail the run here. But a
+    # cut-off label is indistinguishable downstream from an invented one, which is
+    # exactly what the rubric's "do NOT guess" paragraph exists to prevent, so make
+    # the truncation visible on stderr instead of letting it pass silently.
+    if payload.get("stop_reason") == "max_tokens":
+        print(
+            f"xbrain-vision: WARNING: caption for {image.name} hit the token ceiling "
+            "and is truncated — a cut-off label is indistinguishable from an "
+            "invented one downstream",
+            file=sys.stderr,
+        )
     blocks = [b.get("text", "") for b in payload.get("content", []) if b.get("type") == "text"]
     return "".join(blocks).strip()
 
@@ -165,7 +181,12 @@ def _describe_local(model: str, image: Path) -> str:
         "from mlx_vlm.prompt_utils import apply_chat_template\n"
         "model, processor = load(sys.argv[1])\n"
         "prompt = apply_chat_template(processor, getattr(model, 'config', None), sys.argv[3], num_images=1)\n"
-        "res = generate(model, processor, prompt, image=[sys.argv[2]], verbose=False, max_tokens=256)\n"
+        # 1024, not the original 256: the frame rubric now permits ~600 chars of prose
+        # PLUS unbounded verbatim transcription of on-screen text, and 256 tokens (~1000
+        # chars) is consumed by the prose budget alone on a dense slide. A ceiling hit
+        # here truncates a label mid-string, and nothing downstream can tell a truncated
+        # label from an invented one — the exact confusion the rubric forbids.
+        "res = generate(model, processor, prompt, image=[sys.argv[2]], verbose=False, max_tokens=1024)\n"
         "res = res[0] if isinstance(res, (tuple, list)) and res else res\n"
         "text = getattr(res, 'text', res if isinstance(res, str) else str(res))\n"
         f"sys.stdout.write({_LOCAL_MARKER!r} + text.strip())\n"

--- a/scripts/xbrain-vision
+++ b/scripts/xbrain-vision
@@ -21,6 +21,10 @@ pick per run with `digest-video --vision-model NAME` or set `[vision].model`:
 Cloud uses the Anthropic REST API via stdlib urllib (no SDK dependency). Local
 shells out to the mlx-vlm tool's python (env `XBRAIN_VISION_MLX_PYTHON`, else the
 uv-tool default `~/.local/share/uv/tools/mlx-vlm/bin/python`).
+
+xbrain passes the frame-caption rubric in the XBRAIN_VISION_PROMPT environment
+variable; run bare (outside xbrain) the script falls back to a built-in prompt.
+The argv contract is unchanged either way.
 """
 
 from __future__ import annotations
@@ -35,12 +39,25 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
-PROMPT = (
+# xbrain injects the frame-caption rubric here (`xbrain.vision.PROMPT_ENV_VAR`).
+# The variable is the delivery channel precisely so the argv contract stays
+# frozen. This constant is the fallback for a BARE run outside xbrain — it must
+# never be empty, because an empty prompt would silently produce a useless
+# caption rather than an error.
+_PROMPT_ENV_VAR = "XBRAIN_VISION_PROMPT"
+_FALLBACK_PROMPT = (
     "Describe this video key-frame for a personal knowledge wiki in one or two "
-    "dense, factual Spanish sentences. If it is a slide, chart, code, diagram or "
-    "screenshot, state its content faithfully; never invent text or numbers. "
-    "No preamble, no markdown — reply with only the description."
+    "dense, factual sentences. Transcribe any on-screen text VERBATIM, in its "
+    "original language and exact spelling — slide titles, code identifiers, UI "
+    "labels, chart axes. Never invent text or numbers; if something is unreadable, "
+    "say so. No preamble, no markdown — reply with only the description."
 )
+
+
+def _prompt() -> str:
+    """The injected rubric, or the bare-run fallback."""
+    return os.environ.get(_PROMPT_ENV_VAR, "").strip() or _FALLBACK_PROMPT
+
 
 LOCAL_ALIASES = {
     "qwen-3b": "mlx-community/Qwen2.5-VL-3B-Instruct-4bit",
@@ -102,7 +119,7 @@ def _describe_cloud(model: str, image: Path) -> str:
                             "type": "image",
                             "source": {"type": "base64", "media_type": media_type, "data": data},
                         },
-                        {"type": "text", "text": PROMPT},
+                        {"type": "text", "text": _prompt()},
                     ],
                 }
             ],
@@ -155,7 +172,7 @@ def _describe_local(model: str, image: Path) -> str:
     )
     try:
         out = subprocess.run(
-            [mlx_python, "-c", script, model, str(image), PROMPT],
+            [mlx_python, "-c", script, model, str(image), _prompt()],
             capture_output=True,
             text=True,
             timeout=_LOCAL_TIMEOUT,

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -1489,8 +1489,9 @@ def _build_visual_config(cfg: Config, vision_model: str | None = None) -> Visual
         # AUDIO language passed to the transcriber. `language` became required on
         # `describe_image` in #90 (a default would silently ship an unresolved
         # `{language}`); wiring it here is the minimal fix this call site needs to
-        # keep working — the dedicated pinning test for it lives in a later PR3
-        # step (`test_frames_render_the_rubric_in_the_output_language`).
+        # keep working — the dedicated pinning test for it is
+        # `test_frames_render_the_rubric_in_the_output_language` in
+        # `tests/test_cli.py`, shipped in this same branch.
         return describe_image(
             path, command=cfg.vision_command, model=model, language=cfg.output_language
         )

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -1481,7 +1481,16 @@ def _build_visual_config(cfg: Config, vision_model: str | None = None) -> Visual
         )
 
     def _describe(path: Path) -> str:
-        return describe_image(path, command=cfg.vision_command, model=model)
+        # `cfg.output_language` — the WIKI's language, which is what the frame
+        # rubric's `{language}` means. NOT `digest-video --language`, which is the
+        # AUDIO language passed to the transcriber. `language` became required on
+        # `describe_image` in #90 (a default would silently ship an unresolved
+        # `{language}`); wiring it here is the minimal fix this call site needs to
+        # keep working — the dedicated pinning test for it lives in a later PR3
+        # step (`test_frames_render_the_rubric_in_the_output_language`).
+        return describe_image(
+            path, command=cfg.vision_command, model=model, language=cfg.output_language
+        )
 
     return VisualConfig(
         media_root=cfg.media_dir, extract_fn=_extract, describe_fn=_describe, reduce_fn=_reduce

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -1454,6 +1454,9 @@ def _build_visual_config(cfg: Config, vision_model: str | None = None) -> Visual
     `vision_model` overrides `[vision].model` for this run (the `--vision-model`
     flag): the model name is passed to `[vision].command` as `--model`, so a
     multi-backend wrapper can route it (e.g. `opus` → cloud, `qwen-7b` → local).
+
+    The frame rubric is rendered in `cfg.output_language` (the wiki's language),
+    deliberately not in `digest-video --language` (the audio language).
     """
     if not cfg.vision_command.strip():
         raise ValueError(

--- a/src/xbrain/describe.py
+++ b/src/xbrain/describe.py
@@ -45,11 +45,27 @@ logger = logging.getLogger(__name__)
 # saving vs per-image, modest added complexity).
 _DEFAULT_BATCH_SIZE = 5
 
-# Token ceiling for the JSON list response. Per-image average is ~3
-# sentences ≈ 80 tokens of prose + 20 of JSON scaffolding = ~100 tokens.
-# A batch of 5 fits comfortably under 600; the cap is set high enough to
-# survive an over-eager model that emits long descriptions.
-_MAX_TOKENS = 1200
+# Token ceiling for the JSON list response.
+#
+# #90's rubric raised the per-image budget to up to 5 sentences (~600 chars,
+# ~150 tokens) of prose PLUS every visible on-screen label transcribed verbatim
+# and quoted — explicitly unbounded, because a dense screenshot (a terminal, a
+# slide, a table) can carry dozens of short quoted strings that do not count
+# against the sentence budget. Call it ~150 tokens of prose + ~300 tokens of
+# labels + ~20 of JSON scaffolding on a genuinely dense image — ~470 tokens —
+# and a batch of 5 images can land comfortably over 2000. The old "~100 tokens
+# per image" arithmetic (1200 total) was sized for the pre-#90 "one or two
+# dense sentences" prompt and is stale.
+#
+# The ceiling matters more here than it does for a single-image call: a
+# `max_tokens` cutoff lands mid-JSON, `_parse_batch_response` raises
+# `json.JSONDecodeError`, and the WHOLE BATCH of 5 is marked failed — not just
+# the one dense image that pushed the response long. Batching is deterministic
+# (`itertools.batched` over the same ordered candidate list), so an
+# under-sized ceiling does not recover on retry: the same 5 photos re-form the
+# same batch and fail again on the next run, forever, until the ceiling is
+# raised.
+_MAX_TOKENS = 3000
 
 # Map file extensions to the Anthropic vision media-type strings. The
 # downloader writes one of these four (`.jpg` is mapped twice — once for

--- a/src/xbrain/digest.py
+++ b/src/xbrain/digest.py
@@ -38,7 +38,14 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-from xbrain.models import Content, ContentSource, ContentSourceSuccess, Item, VideoFrame
+from xbrain.models import (
+    Content,
+    ContentSource,
+    ContentSourceSuccess,
+    FRAME_CAPTION_CONTRACT,
+    Item,
+    VideoFrame,
+)
 from xbrain.transcribe import Transcript, TranscriberFailed, transcribe_media
 from xbrain.video_fetch import FetchReport, _select_entry, fetch_videos
 from xbrain.video_frames import (
@@ -293,6 +300,7 @@ def attach_transcript(
         item = store.get(item_id)
         if item is None:
             continue
+        item_frames = frames_map.get(item_id, [])
         source = ContentSourceSuccess(
             kind="x_video",
             url=_source_url_for(item),
@@ -300,7 +308,10 @@ def attach_transcript(
             text=transcript.text,
             has_speech=transcript.has_speech,
             language=transcript.language,
-            frames=frames_map.get(item_id, []),
+            frames=item_frames,
+            # Claim the contract only when this run actually described frames; an
+            # audio-only digest has no captions to vouch for.
+            caption_contract=FRAME_CAPTION_CONTRACT if item_frames else "",
         )
         if item.content is None:
             item.content = Content(fetched_at=now, sources=[source])

--- a/src/xbrain/digest.py
+++ b/src/xbrain/digest.py
@@ -292,6 +292,12 @@ def attach_transcript(
     video enriched from its tweet BEFORE the transcript landed must re-enrich, and
     that hinges on `fetched_at` moving past the earlier `enriched_at`. Without the
     bump the new transcript would look already-processed and the video keeps "—".
+
+    When this run actually described frames, the source is also stamped with
+    `FRAME_CAPTION_CONTRACT` (`caption_contract`, #90) — which rubric produced
+    those captions, so `redescribe-frames` can tell a current caption from a
+    stale pre-#90 one and skip it. An audio-only digest attaches `""`: it made
+    no captions, so it has nothing to vouch for.
     """
     now = datetime.now(timezone.utc)
     frames_map = frames_by_item or {}

--- a/src/xbrain/fetch.py
+++ b/src/xbrain/fetch.py
@@ -447,7 +447,12 @@ def _utcnow() -> datetime:
 # fingerprinted automatically instead of being silently dropped by a stale
 # allow-list. It fails safe: forgetting to exclude a bookkeeping field costs at
 # most one redundant re-enrichment, never a lost (stale-content) one.
-_BOOKKEEPING_FIELDS = {"attempts", "error"}
+#
+# `caption_contract` (#90) is bookkeeping too: it records WHICH rubric produced a
+# source's frame captions, not what those captions say. Re-stamping unchanged
+# captions must not read as a content change — see the field's own comment in
+# `models.py` for why it sits at source level rather than on `VideoFrame`.
+_BOOKKEEPING_FIELDS = {"attempts", "error", "caption_contract"}
 
 
 def _source_signature(source: ContentSource) -> str:

--- a/src/xbrain/fetch.py
+++ b/src/xbrain/fetch.py
@@ -508,7 +508,7 @@ _BOOKKEEPING_FIELDS = {"attempts", "error", "caption_contract"}
 
 def _source_signature(source: ContentSource) -> str:
     """A *material-content* fingerprint of one source: the whole model minus
-    fetch bookkeeping (`attempts`/`error`).
+    fetch bookkeeping (`attempts`/`error`/`caption_contract`).
 
     Two sources with equal signatures carry the same material content even if a
     re-fetch churned their bookkeeping. Deriving the fingerprint from the model
@@ -575,7 +575,7 @@ def fetch_item(
     re-flag the item forever — one wasted, identical LLM call per stuck item per
     cycle. So when the re-fetched source set is *materially equivalent* to the
     existing one — the whole source model minus fetch bookkeeping
-    (`attempts`/`error`); see `_source_signature` — we keep the prior
+    (`attempts`/`error`/`caption_contract`); see `_source_signature` — we keep the prior
     `fetched_at`; it advances only when the content actually changed (a failure
     that becomes a success, new/edited text, a changed title, a changed failure
     reason/status). `now` is injectable for deterministic tests.

--- a/src/xbrain/models.py
+++ b/src/xbrain/models.py
@@ -634,6 +634,14 @@ ArticleBlockAdapter: TypeAdapter[Union[ArticleTextBlock, ArticleImageBlock]] = T
 )
 
 
+# The frame-caption contract the descriptions on a source were produced under
+# (#90). Mirrors `verification._CONTRACT_VERSION`: when the rubric changes in a
+# way that invalidates existing captions, bump this and `redescribe-frames`
+# treats every older caption as stale. `""` means "produced before #90" — which
+# is also stale, and is what every record in the current corpus carries.
+FRAME_CAPTION_CONTRACT = "xbrain-frame-caption/v1"
+
+
 class ContentSourceSuccess(BaseModel):
     """A fetched article whose body was successfully extracted.
 
@@ -684,6 +692,19 @@ class ContentSourceSuccess(BaseModel):
     # every article source) simply carries an empty digest, and `generate` falls
     # back to rendering the raw transcript + frames. `""` = "no digest yet".
     digest: str = ""
+    # Which frame-caption contract the `frames` descriptions were produced under
+    # (#90). Optional + additive (defaults to `""`), so every EXISTING record
+    # LOADS unchanged — the same pattern as `frames`/`has_speech`/`digest`.
+    #
+    # It lives HERE and not on `VideoFrame` on purpose. `fetch._source_signature`
+    # fingerprints material content with `model_dump_json(exclude=...)` over a
+    # FLAT set of top-level field names; a stamp nested inside `frames` would land
+    # INSIDE that fingerprint, so re-stamping unchanged captions would read as a
+    # material change and bump `content.fetched_at` — re-enriching the whole video
+    # corpus for nothing. At source level it is excluded cleanly, as bookkeeping.
+    # Source-level granularity is also the right unit: captions are re-described
+    # per video, never per frame.
+    caption_contract: str = ""
     # Ordered body blocks (text + inline images) for `kind="x_article"` sources
     # captured as a structured Article (#39). Optional + additive (defaults to
     # `[]`), so every EXISTING record LOADS unchanged — a pre-#39 `x_article`

--- a/src/xbrain/rubrics.py
+++ b/src/xbrain/rubrics.py
@@ -18,6 +18,22 @@ from xbrain.models import Topic
 # str.replace("{language}", ...) would silently miss.
 _LEFTOVER_PLACEHOLDER = re.compile(r"\{[^}]*language[^}]*\}", re.IGNORECASE)
 
+# The shared on-screen-text rule (#90). It lives in ONE fragment file spliced
+# into every rubric that describes an image, because the frame rubric and the
+# photo rubric must state the SAME rule — two copies drift, and a drifted rule
+# is worse than no rule (one surface silently keeps translating).
+#
+# The fragment is named `fragment-*.md`, NOT `rubric-*.md`, so `load_rubric`
+# cannot load it as a rubric and `tests/test_rubrics.py`'s `rubric-*.md` glob
+# does not parametrize over it.
+_ONSCREEN_FRAGMENT = "fragment-onscreen-text.md"
+_ONSCREEN_PLACEHOLDER = "{onscreen_text_rule}"
+# Same defensive idea as `_LEFTOVER_PLACEHOLDER`: a near-miss spelling
+# (`{onscreen_text_rules}`) survives str.replace and would ship the literal
+# placeholder to the vision model. Deliberately NOT a generic `\{[^}]*\}` scan —
+# `rubric-describe-image.md` embeds a JSON example that such a pattern would flag.
+_LEFTOVER_ONSCREEN = re.compile(r"\{[^}]*onscreen[^}]*\}", re.IGNORECASE)
+
 _PKG = Path(__file__).resolve().parent
 _RUBRICS_DIR = _PKG / "rubrics"
 _GUARDRAILS = _PKG / "guardrails.yaml"
@@ -66,6 +82,18 @@ def truncate_transcript(text: str, limit: int) -> str:
     return text[:limit].rstrip() + "\n[… transcript truncated …]"
 
 
+def _load_fragment(filename: str) -> str:
+    """Return the text of a shared rubric fragment (`rubrics/<filename>`).
+
+    Fragments are composed INTO rubrics by `load_rubric`; they are never a
+    prompt on their own, which is why they carry no `rubric-` prefix.
+    """
+    path = _RUBRICS_DIR / filename
+    if not path.exists():
+        raise FileNotFoundError(f"Rubric fragment not found: {path}")
+    return path.read_text(encoding="utf-8").strip()
+
+
 def load_rubric(name: str, *, language: str | None = None) -> str:
     """Return the text of `rubrics/rubric-<name>.md`.
 
@@ -79,11 +107,26 @@ def load_rubric(name: str, *, language: str | None = None) -> str:
     Defensive check: when `language` is provided, the returned text must not
     contain a literal `{language}` (catches typos like `{Language}` that
     would silently survive substitution and ship the placeholder to the LLM).
+
+    A `{onscreen_text_rule}` placeholder is replaced with the shared
+    `fragment-onscreen-text.md` before the language pass, so the rule is stated
+    once and both image rubrics inherit it verbatim.
     """
     path = _RUBRICS_DIR / f"rubric-{name}.md"
     if not path.exists():
         raise FileNotFoundError(f"Rubric not found: {path}")
     text = path.read_text(encoding="utf-8")
+    # Splice shared fragments FIRST, so a fragment's own `{language}` is
+    # substituted by the language pass below rather than shipped literally.
+    if _ONSCREEN_PLACEHOLDER in text:
+        text = text.replace(_ONSCREEN_PLACEHOLDER, _load_fragment(_ONSCREEN_FRAGMENT))
+    leftover_rule = _LEFTOVER_ONSCREEN.search(text)
+    if leftover_rule is not None:
+        raise ValueError(
+            f"Rubric {name!r} contains an unresolved placeholder "
+            f"{leftover_rule.group()!r}. The supported form is "
+            f"`{{onscreen_text_rule}}` (lowercase, singular)."
+        )
     if language is not None:
         text = text.replace("{language}", language)
         leftover = _LEFTOVER_PLACEHOLDER.search(text)

--- a/src/xbrain/rubrics/fragment-onscreen-text.md
+++ b/src/xbrain/rubrics/fragment-onscreen-text.md
@@ -13,9 +13,10 @@ boundary between your words and the screen's words is unambiguous.
 
 - **Right:** your sentence is in {language}, and the labels stay exactly as
   printed — "Embedding", "Layer Norm", "Self-Attention", "Projection".
-- **Wrong:** translating the labels at all — writing "Norma de Capa" where the
-  screen says "Layer Norm". Whoever later cites the label can no longer match it
-  against this description, and a correct citation gets reported as unfounded.
+- **Wrong:** translating the labels at all — writing "Auto-Atención" where the
+  screen says "Self-Attention". Whoever later cites the label can no longer
+  match it against this description, and a correct citation gets reported as
+  unfounded.
 
 If a string is too small, blurred or cut off to read WITH CERTAINTY, say so
 plainly — call it an unreadable label — and do NOT guess. A wrong

--- a/src/xbrain/rubrics/fragment-onscreen-text.md
+++ b/src/xbrain/rubrics/fragment-onscreen-text.md
@@ -1,0 +1,27 @@
+**On-screen text is DATA, not prose.**
+
+Transcribe every legible string you can see VERBATIM — in its ORIGINAL
+language and its exact spelling. Never translate it, never normalise it,
+never paraphrase it. This covers slide titles and section headings, code
+identifiers, function and variable names, file paths, CLI commands and their
+output, UI labels and menu items, chart axis labels and legends, table
+headers, error messages, URLs and product names.
+
+The **Language: {language}** rule governs YOUR PROSE. It does NOT govern the
+text you are transcribing. Put each transcribed string in double quotes so the
+boundary between your words and the screen's words is unambiguous.
+
+- **Right:** your sentence is in {language}, and the labels stay exactly as
+  printed — "Embedding", "Layer Norm", "Self-Attention", "Projection".
+- **Wrong:** the labels rendered into {language} — "Norma de Capa" for "Layer
+  Norm". Whoever later cites the label can no longer match it against this
+  description, and a correct citation gets reported as unfounded.
+
+If a string is too small, blurred or cut off to read WITH CERTAINTY, say so
+plainly — call it an unreadable label — and do NOT guess. A wrong
+transcription is worse than an admitted gap: downstream, an invented string is
+indistinguishable from a real one, and it becomes evidence for a claim nobody
+can check.
+
+Prefer COVERAGE over depth: every visible label matters more than the full
+prose of any single one.

--- a/src/xbrain/rubrics/fragment-onscreen-text.md
+++ b/src/xbrain/rubrics/fragment-onscreen-text.md
@@ -7,15 +7,15 @@ identifiers, function and variable names, file paths, CLI commands and their
 output, UI labels and menu items, chart axis labels and legends, table
 headers, error messages, URLs and product names.
 
-The **Language: {language}** rule governs YOUR PROSE. It does NOT govern the
+The **Language:** {language} rule governs YOUR PROSE. It does NOT govern the
 text you are transcribing. Put each transcribed string in double quotes so the
 boundary between your words and the screen's words is unambiguous.
 
 - **Right:** your sentence is in {language}, and the labels stay exactly as
   printed — "Embedding", "Layer Norm", "Self-Attention", "Projection".
-- **Wrong:** the labels rendered into {language} — "Norma de Capa" for "Layer
-  Norm". Whoever later cites the label can no longer match it against this
-  description, and a correct citation gets reported as unfounded.
+- **Wrong:** translating the labels at all — writing "Norma de Capa" where the
+  screen says "Layer Norm". Whoever later cites the label can no longer match it
+  against this description, and a correct citation gets reported as unfounded.
 
 If a string is too small, blurred or cut off to read WITH CERTAINTY, say so
 plainly — call it an unreadable label — and do NOT guess. A wrong

--- a/src/xbrain/rubrics/rubric-describe-frame.md
+++ b/src/xbrain/rubrics/rubric-describe-frame.md
@@ -1,0 +1,38 @@
+# Rubric — Describe a video key frame
+
+You describe ONE key frame extracted from a video, for a personal knowledge
+wiki. Your description is read by downstream LLMs that assign topics, write the
+video digest and synthesise topic pages — it is NOT shown to a human, and it is
+the ONLY channel through which anything visible in the video reaches them.
+Nothing downstream ever sees the pixels. What you leave out is lost.
+
+- **Language:** {language}, for your own prose. The rule below overrides this
+  for text you transcribe.
+- **Length:** at most 5 sentences / 600 characters. No preamble ("This frame
+  shows..."). No markdown, no bullet characters.
+
+{onscreen_text_rule}
+
+## What to describe
+
+- **A slide:** its title, every heading and bullet label, and any visible
+  figure caption.
+- **A terminal or a code editor:** the commands, identifiers, paths and error
+  strings visible. This content is essentially never spoken aloud, so if you do
+  not transcribe it, it exists nowhere else.
+- **A diagram:** the component labels and the relationships between them, in
+  the labels' own words.
+- **A chart:** the chart type, the axis labels, the legend entries and any
+  headline number printed on it.
+- **A face, a stage, a webcam or a title card with no text:** say so in one
+  short sentence. There is nothing to transcribe, and saying so is a complete
+  and correct answer.
+
+## Output format
+
+Reply with the description text and NOTHING else — no JSON, no key, no
+preamble, no surrounding prose, no quotes around the whole reply. Exactly one
+description for the one image you were given.
+
+Never reply with an empty string: an empty reply is treated as a failure, and a
+frame with nothing to transcribe still deserves its one sentence.

--- a/src/xbrain/rubrics/rubric-describe-frame.md
+++ b/src/xbrain/rubrics/rubric-describe-frame.md
@@ -8,8 +8,14 @@ Nothing downstream ever sees the pixels. What you leave out is lost.
 
 - **Language:** {language}, for your own prose. The rule below overrides this
   for text you transcribe.
-- **Length:** at most 5 sentences / 600 characters. No preamble ("This frame
-  shows..."). No markdown, no bullet characters.
+- **Length:** at most 5 sentences / 600 characters **of your own prose**.
+  Transcribed on-screen text does not count against that budget, and is never
+  dropped to fit it: a long caption is cheap, a dropped label is the failure this
+  rubric exists to prevent. If a frame carries more text than you can transcribe,
+  keep it in this order — title and headings, then axis and legend labels, then
+  code identifiers and commands, then body prose — and say plainly that you
+  stopped. No preamble ("This frame shows..."). No markdown, no bullet
+  characters.
 
 {onscreen_text_rule}
 

--- a/src/xbrain/rubrics/rubric-describe-image.md
+++ b/src/xbrain/rubrics/rubric-describe-image.md
@@ -5,12 +5,16 @@ read by a downstream LLM that assigns topics and writes topic-page
 overviews — they are NOT shown to the user. Write for that LLM: be
 factual, dense, and short.
 
-- **Language:** {language}, regardless of any text visible in the image.
-- **Length per description:** 1 to 3 sentences. No preamble ("This image
-  shows..."). No markdown, no wikilinks, no bullet characters, no quotes.
+- **Language:** {language} for your own prose. The on-screen-text rule below
+  overrides this for text you transcribe.
+- **Length per description:** 1 to 3 sentences, or up to 5 when the image is
+  dense with text. No preamble ("This image shows..."). No markdown, no
+  wikilinks, no bullet characters.
 - **Faithful:** describe only what is visible. Never invent text, numbers
   or names. If a chart's labels are unreadable, say so plainly rather
   than guessing.
+
+{onscreen_text_rule}
 
 ## Classify each image
 
@@ -33,12 +37,11 @@ cheap, missing topic signal is not.
 
 ## Write each description
 
-- For a chart: name the chart type, the axes (if labelled), the
-  comparison being made, and any headline number visible. Two sentences
-  is usually enough.
-- For a screenshot of text: paraphrase the substance in your own words.
-  Quote a short distinctive phrase only if the verbatim wording matters
-  (a product name, a thesis statement).
+- For a chart: name the chart type, quote the axis labels and legend entries
+  exactly as printed, state the comparison being made and any headline number
+  visible.
+- For a screenshot of text: transcribe the headings, labels and identifiers
+  verbatim per the rule above, then summarise the surrounding body prose.
 - For a diagram: name the components and the relationships between them
   in one sentence; the second sentence may add what the diagram is
   arguing.

--- a/src/xbrain/rubrics/rubric-describe-image.md
+++ b/src/xbrain/rubrics/rubric-describe-image.md
@@ -8,8 +8,11 @@ factual, dense, and short.
 - **Language:** {language} for your own prose. The on-screen-text rule below
   overrides this for text you transcribe.
 - **Length per description:** 1 to 3 sentences, or up to 5 when the image is
-  dense with text. No preamble ("This image shows..."). No markdown, no
-  wikilinks, no bullet characters.
+  dense with text — **of your own prose.** Transcribed on-screen text does not
+  count against that budget, and is never dropped to fit it: a long caption is
+  cheap, a dropped label is the failure the on-screen-text rule exists to
+  prevent. No preamble ("This image shows..."). No markdown, no wikilinks, no
+  bullet characters.
 - **Faithful:** describe only what is visible. Never invent text, numbers
   or names. If a chart's labels are unreadable, say so plainly rather
   than guessing.

--- a/src/xbrain/vision.py
+++ b/src/xbrain/vision.py
@@ -27,20 +27,36 @@ transcriber — aborts the run), a **non-zero exit / timeout / empty output**
 (`VisionFailed`, which the digest treats as a per-video visual-layer failure and
 records). The `runner` (a `subprocess.run` stand-in) is injectable so tests run
 offline against a fake — no real vision model, ever.
+
+- The frame-caption rubric is delivered in the environment as
+  ``XBRAIN_VISION_PROMPT``. The argv contract is unchanged, so a command that
+  ignores the variable still works — it just receives no caption discipline.
 """
 
 from __future__ import annotations
 
+import os
 import shlex
 import subprocess  # nosec B404 - the vision model is an external subprocess by design (#44)
 from collections.abc import Callable
 from pathlib import Path
+
+from xbrain.rubrics import load_rubric
 
 # A generous wall-clock cap: describing a single downscaled frame is quick, but a
 # wedged VLM process must not hang the run forever.
 _DEFAULT_TIMEOUT_SECONDS = 300
 
 Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+# The environment variable carrying the frame-caption rubric to the vision
+# subprocess (#90). It is delivered OUT OF BAND, in the environment, precisely so
+# the documented argv contract `<command> [--model M] <image-path>` stays frozen:
+# a third-party or older command simply never reads the variable and keeps
+# working. The trade-off is accepted and documented — such a command receives no
+# caption discipline, which is why the bundled `scripts/xbrain-vision` is the
+# reference implementation.
+PROMPT_ENV_VAR = "XBRAIN_VISION_PROMPT"
 
 
 class VisionError(RuntimeError):
@@ -64,10 +80,10 @@ def _build_argv(command: str, model: str | None, path: Path) -> list[str]:
     return argv
 
 
-def _run_vision(argv: list[str], runner: Runner, timeout_seconds: int) -> str:
+def _run_vision(argv: list[str], runner: Runner, timeout_seconds: int, env: dict[str, str]) -> str:
     """Run the vision command; return its stdout, or raise a clear operator error."""
     try:
-        completed = runner(argv, capture_output=True, text=True, timeout=timeout_seconds)
+        completed = runner(argv, capture_output=True, text=True, timeout=timeout_seconds, env=env)
     except FileNotFoundError as exc:
         raise VisionNotFound(
             f"vision command {argv[0]!r} not found — install it or set a valid "
@@ -96,6 +112,7 @@ def describe_image(
     path: Path | str,
     *,
     command: str,
+    language: str,
     model: str | None = None,
     runner: Runner | None = None,
     timeout_seconds: int = _DEFAULT_TIMEOUT_SECONDS,
@@ -109,6 +126,11 @@ def describe_image(
     abort the run. A non-zero exit, timeout, or **empty output** raises
     `VisionFailed` (never a silent empty description). `runner` defaults to
     `subprocess.run`, resolved at call time so it stays monkeypatchable.
+
+    `language` is the wiki's OUTPUT language (`[output].language`), used to render
+    the frame rubric's `{language}`. It is NOT `digest-video --language`, which is
+    the AUDIO language handed to the transcriber. It is required, with no default,
+    because a default would ship an unresolved `{language}` to the model.
     """
     if not command.strip():
         raise VisionNotFound(
@@ -117,7 +139,10 @@ def describe_image(
         )
     active_runner: Runner = runner if runner is not None else subprocess.run
     argv = _build_argv(command, model, Path(path))
-    stdout = _run_vision(argv, active_runner, timeout_seconds)
+    # The rubric is loaded HERE, not passed in, so every caller (digest-video and
+    # redescribe-frames) inherits the same discipline from the same file.
+    env = {**os.environ, PROMPT_ENV_VAR: load_rubric("describe-frame", language=language)}
+    stdout = _run_vision(argv, active_runner, timeout_seconds, env)
     description = stdout.strip()
     if not description:
         raise VisionFailed(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2740,6 +2740,34 @@ def test_digest_video_frames_talking_head_skips_and_embeds_nothing(tmp_path: Pat
     assert not (vault / "x-knowledge" / "_media" / "42" / "frames").exists()
 
 
+def test_frames_render_the_rubric_in_the_output_language(tmp_path: Path, monkeypatch):
+    """The frame rubric renders in the WIKI's language (`[output].language`).
+    `digest-video --language` is the AUDIO language handed to the transcriber;
+    wiring that one here would render the rubric in the language of the SPEECH,
+    which is a different thing that happens to look right in the common case."""
+    _setup_repo_with_vision(tmp_path, monkeypatch)
+    cfg = tmp_path / "config.toml"
+    cfg.write_text(
+        cfg.read_text(encoding="utf-8") + '[output]\nlanguage = "Spanish"\n', encoding="utf-8"
+    )
+    save_store({"42": _video_item("42", url=_AMPLIFY_URL_1)}, tmp_path / "data" / "items.json")
+    _wire_digest(monkeypatch, _speech_transcript("the talk"))
+    _wire_frames(monkeypatch)
+    seen: list = []
+
+    def _capture(path, *, command, model, language):
+        seen.append(language)
+        return "slide"
+
+    monkeypatch.setattr("xbrain.cli.describe_image", _capture)
+    # --language English is the AUDIO language and must NOT reach the rubric.
+    result = runner.invoke(
+        app, ["digest-video", "--ids", "42", "--frames", "--language", "English"]
+    )
+    assert result.exit_code == 0, result.output
+    assert seen and set(seen) == {"Spanish"}
+
+
 def _verify_video_item(item_id: str = "7") -> Item:
     """An enriched item with an x_video source — the shape `verify` audits."""
     return Item(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2630,7 +2630,7 @@ def test_digest_video_vision_model_override(tmp_path: Path, monkeypatch):
     _wire_frames(monkeypatch)  # extract → slide frames; real classify_visual runs
     seen: list = []
 
-    def _capture(path, *, command, model):
+    def _capture(path, *, command, model, language=None):
         seen.append(model)
         return "slide"
 
@@ -2665,7 +2665,7 @@ def test_digest_video_vision_model_defaults_to_config(tmp_path: Path, monkeypatc
     _wire_frames(monkeypatch)
     seen: list = []
 
-    def _capture(path, *, command, model):
+    def _capture(path, *, command, model, language=None):
         seen.append(model)
         return "slide"
 

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -1006,7 +1006,7 @@ def test_describe_all_sends_payload_with_expected_kwarg_shape(tmp_path: Path):
     )
     kwargs = client.messages.calls[0]
     assert kwargs["model"] == "claude-sonnet-4-6"
-    assert kwargs["max_tokens"] == 1200
+    assert kwargs["max_tokens"] == 3000
     assert isinstance(kwargs["system"], str) and kwargs["system"]
     messages = kwargs["messages"]
     assert isinstance(messages, list) and len(messages) == 1

--- a/tests/test_digest.py
+++ b/tests/test_digest.py
@@ -941,3 +941,23 @@ def test_format_digest_summary_omits_visual_on_non_frames_run():
     Visual segment — the summary is byte-unchanged from the PR2/PR3 shape."""
     report = DigestReport(transcribed=1, groups={"amplify_video/1": ["a"]})
     assert "Visual:" not in format_digest_summary(report)
+
+
+def test_digest_stamps_the_caption_contract_when_frames_were_described():
+    """A `--frames` run produces captions under the CURRENT contract, so it must
+    say so — otherwise `redescribe-frames` re-captions frames that are already
+    fresh, at full cost."""
+    from xbrain.models import FRAME_CAPTION_CONTRACT, VideoFrame
+
+    store = {"1": _item("1", _VIDEO_A_URL_1)}
+    frames = {"1": [VideoFrame(timestamp=0.0, local_path="1/frames/0.png", description="d")]}
+    attach_transcript(store, ["1"], _speech(), frames_by_item=frames)
+    source = store["1"].content.sources[-1]
+    assert source.caption_contract == FRAME_CAPTION_CONTRACT
+
+
+def test_digest_leaves_the_contract_empty_when_no_frames_were_described():
+    """An audio-only digest describes nothing, so it must claim no contract."""
+    store = {"1": _item("1", _VIDEO_A_URL_1)}
+    attach_transcript(store, ["1"], _speech())
+    assert store["1"].content.sources[-1].caption_contract == ""

--- a/tests/test_entity_grounding.py
+++ b/tests/test_entity_grounding.py
@@ -155,15 +155,24 @@ def test_quotes_are_delimiters_not_letters():
     assert "O'Brien" in extract_entities("el ensayo de O'Brien sobre agentes")
 
 
-def test_quoted_transcription_still_grounds_the_entity():
-    """#90 has the caption QUOTE on-screen text ("Layer Norm"), and the digest cite
-    it unquoted. `_entities_in_sentence` strips quotes and `_norm_tokens` reduces to
-    [a-z0-9]+, so the two forms match — but nothing pinned it, and the whole point of
-    the change is that a correctly-cited label stops being reported as unfounded.
+def test_verbatim_caption_grounds_but_translated_caption_does_not():
+    """#90's caption-contract rubric bans translating on-screen labels, and the reason
+    is measurable right here: `is_grounded`'s fuzzy match is generous enough that a
+    translated COGNATE ("Proyección" for "Projection") still grounds — but
+    "Auto-Atención" / "Incrustación" do NOT match "Self-Attention" / "Embedding". A
+    caption that transcribes the labels verbatim (quoted, per the rubric) keeps a
+    downstream citation grounded; one that translates them makes a correct citation
+    get reported as unfounded — the exact failure the rubric exists to prevent. This
+    only pins the rule if it exercises BOTH halves: a checker loosened to let the
+    translated form ground too would still pass a test that asserted the positive
+    half alone.
     """
-    caption = 'Diapositiva con un diagrama que conecta "Embedding" y "Layer Norm".'
-    assert is_grounded("Layer Norm", caption)
-    assert is_grounded("Embedding", caption)
+    verbatim = 'Diapositiva con un diagrama que conecta "Embedding" y "Self-Attention".'
+    translated = 'Diapositiva con un diagrama que conecta "Incrustación" y "Auto-Atención".'
+    assert is_grounded("Self-Attention", verbatim)
+    assert is_grounded("Embedding", verbatim)
+    assert not is_grounded("Self-Attention", translated)
+    assert not is_grounded("Embedding", translated)
 
 
 def test_line_initial_common_word_is_demoted_but_never_dropped():

--- a/tests/test_entity_grounding.py
+++ b/tests/test_entity_grounding.py
@@ -155,6 +155,17 @@ def test_quotes_are_delimiters_not_letters():
     assert "O'Brien" in extract_entities("el ensayo de O'Brien sobre agentes")
 
 
+def test_quoted_transcription_still_grounds_the_entity():
+    """#90 has the caption QUOTE on-screen text ("Layer Norm"), and the digest cite
+    it unquoted. `_entities_in_sentence` strips quotes and `_norm_tokens` reduces to
+    [a-z0-9]+, so the two forms match — but nothing pinned it, and the whole point of
+    the change is that a correctly-cited label stops being reported as unfounded.
+    """
+    caption = 'Diapositiva con un diagrama que conecta "Embedding" y "Layer Norm".'
+    assert is_grounded("Layer Norm", caption)
+    assert is_grounded("Embedding", caption)
+
+
 def test_line_initial_common_word_is_demoted_but_never_dropped():
     """Every Spanish bullet opens with a capitalised verb ("Muestra…", "Aparece…"). Their
     capital proves nothing, so they must not reach the headline — but they are NOT

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1355,12 +1355,32 @@ def test_caption_contract_is_bookkeeping_not_material_content():
     Stamping the contract on a source whose captions are byte-identical must NOT
     read as a material change. If it does, every `redescribe-frames` run bumps
     `content.fetched_at` on every source it touches and re-enriches the whole
-    video corpus for nothing. A `caption_contract` nested on `VideoFrame` would
-    have failed this, because `_source_signature`'s `exclude` is a FLAT set of
-    top-level fields and does not descend into `frames`.
+    video corpus for nothing.
+
+    The equality assertion at the end, BY ITSELF, is VACUOUS: pydantic v2
+    defaults to `extra="ignore"` at runtime, so if `caption_contract` were
+    nested on `VideoFrame` instead of on `ContentSourceSuccess`, the
+    `caption_contract=...` kwarg below would be silently DROPPED by the
+    constructor, `before` and `after` would come out byte-identical for
+    entirely the WRONG reason, and the equality would pass regardless of
+    whether the design is actually correct. The three structural assertions
+    below are what actually pin the design (field on the right model, absent
+    from the wrong one, deny-listed); do not "simplify" them away as redundant
+    with the equality — they are the only thing that makes the equality mean
+    anything.
     """
-    from xbrain.fetch import _sources_materially_equal
+    from xbrain.fetch import _BOOKKEEPING_FIELDS, _sources_materially_equal
     from xbrain.models import FRAME_CAPTION_CONTRACT, ContentSourceSuccess, VideoFrame
+
+    # PLACEMENT IS THE POINT, and the behavioural assertion below cannot see it:
+    # pydantic v2 ignores unknown kwargs at runtime, so with `caption_contract`
+    # nested on `VideoFrame` the constructor call below would silently DROP it,
+    # both sources would come out identical, and the equality would pass for
+    # entirely the wrong reason. These three assertions are what actually pin the
+    # design; the equality then pins the behaviour that design buys.
+    assert "caption_contract" in ContentSourceSuccess.model_fields
+    assert "caption_contract" not in VideoFrame.model_fields
+    assert "caption_contract" in _BOOKKEEPING_FIELDS
 
     frames = [VideoFrame(timestamp=0.0, local_path="1/frames/0.png", description="same")]
     before = ContentSourceSuccess(

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1347,3 +1347,48 @@ def test_revalidate_keeps_a_real_article_that_merely_carries_one_cookie_line():
         ],
     )
     assert revalidate_stored_bodies({"7": item}).items == []
+
+
+def test_caption_contract_is_bookkeeping_not_material_content():
+    """THE REGRESSION THIS DESIGN NEARLY SHIPPED.
+
+    Stamping the contract on a source whose captions are byte-identical must NOT
+    read as a material change. If it does, every `redescribe-frames` run bumps
+    `content.fetched_at` on every source it touches and re-enriches the whole
+    video corpus for nothing. A `caption_contract` nested on `VideoFrame` would
+    have failed this, because `_source_signature`'s `exclude` is a FLAT set of
+    top-level fields and does not descend into `frames`.
+    """
+    from xbrain.fetch import _sources_materially_equal
+    from xbrain.models import FRAME_CAPTION_CONTRACT, ContentSourceSuccess, VideoFrame
+
+    frames = [VideoFrame(timestamp=0.0, local_path="1/frames/0.png", description="same")]
+    before = ContentSourceSuccess(
+        kind="x_video", url="https://x.com/a/status/1", text="t", frames=frames
+    )
+    after = ContentSourceSuccess(
+        kind="x_video",
+        url="https://x.com/a/status/1",
+        text="t",
+        frames=frames,
+        caption_contract=FRAME_CAPTION_CONTRACT,
+    )
+    assert _sources_materially_equal([before], [after])
+
+
+def test_a_changed_caption_IS_material_content():
+    """The other half: the stamp is excluded, the caption text is not."""
+    from xbrain.fetch import _sources_materially_equal
+    from xbrain.models import ContentSourceSuccess, VideoFrame
+
+    def _source(description: str) -> ContentSourceSuccess:
+        return ContentSourceSuccess(
+            kind="x_video",
+            url="https://x.com/a/status/1",
+            text="t",
+            frames=[
+                VideoFrame(timestamp=0.0, local_path="1/frames/0.png", description=description)
+            ],
+        )
+
+    assert not _sources_materially_equal([_source("old")], [_source("new")])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1429,3 +1429,11 @@ def test_verification_verdict_rejects_unknown_verdict():
             output_fingerprint="a" * 64,
             verified_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
         )
+
+
+def test_caption_contract_defaults_to_empty_so_legacy_records_load():
+    """Additive default — an `items.json` written before #90 must load unchanged."""
+    from xbrain.models import ContentSourceSuccess
+
+    source = ContentSourceSuccess(kind="x_video", url="https://x.com/a/status/1", text="hi")
+    assert source.caption_contract == ""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1437,3 +1437,22 @@ def test_caption_contract_defaults_to_empty_so_legacy_records_load():
 
     source = ContentSourceSuccess(kind="x_video", url="https://x.com/a/status/1", text="hi")
     assert source.caption_contract == ""
+
+
+def test_caption_contract_round_trips_through_json():
+    """The design's testing section asks for round-trip coverage of the stamp, and
+    only the default-empty case (above) was covered — a stamped value must survive
+    a dump → re-parse too, or `redescribe-frames`' skip-if-current-contract check
+    (#90 PR2) would silently forget which rubric produced a video's captions.
+    """
+    from xbrain.models import FRAME_CAPTION_CONTRACT, ContentSourceAdapter, ContentSourceSuccess
+
+    src = ContentSourceSuccess(
+        kind="x_video",
+        url="https://video.twimg.com/amplify_video/123/vid/720/A.mp4?tag=16",
+        text="hello, this is the transcript",
+        caption_contract=FRAME_CAPTION_CONTRACT,
+    )
+    restored = ContentSourceAdapter.validate_python(src.model_dump(mode="json"))
+    assert isinstance(restored, ContentSourceSuccess)
+    assert restored.caption_contract == FRAME_CAPTION_CONTRACT

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -478,3 +478,18 @@ def test_describe_image_rubric_keeps_its_json_contract():
     text = load_rubric("describe-image", language="English")
     assert "is_decorative" in text
     assert "index" in text
+
+
+def test_both_image_rubrics_defer_language_to_the_onscreen_rule():
+    """The negative assertions above only catch the two exact strings #90 deleted;
+    they pass forever once those are gone. This is the positive half: BOTH image
+    rubrics must keep saying that `{language}` governs the model's own prose and
+    that the on-screen-text rule overrides it. Restoring an unconditional
+    "write in {language} regardless of any text visible" — the wording that
+    caused #90 — deletes these phrases, so this test fails where the negative
+    ones would not.
+    """
+    for name in ("describe-image", "describe-frame"):
+        text = load_rubric(name, language="English")
+        assert "for your own prose" in text, f"{name} no longer scopes {{language}} to prose"
+        assert "overrides this" in text, f"{name} no longer defers to the on-screen rule"

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -422,6 +422,7 @@ def test_describe_frame_rubric_states_the_verbatim_rule():
     assert "{language}" not in text
     assert "{onscreen_text_rule}" not in text
     assert "Spanish" in text
+    # The rule must enforce exact transcription without translation or normalization.
     assert "VERBATIM" in text
     # The rule must forbid translation explicitly — this is the #90 defect.
     assert "Never translate" in text

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -414,3 +414,36 @@ def test_load_rubric_missing_fragment_is_a_loud_error(tmp_path, monkeypatch):
 
     with pytest.raises(FileNotFoundError, match="fragment-onscreen-text.md"):
         load_rubric("orphan", language="English")
+
+
+def test_describe_frame_rubric_states_the_verbatim_rule():
+    """The frame rubric must carry the shared rule and resolve both placeholders."""
+    text = load_rubric("describe-frame", language="Spanish")
+    assert "{language}" not in text
+    assert "{onscreen_text_rule}" not in text
+    assert "Spanish" in text
+    assert "VERBATIM" in text
+    # The rule must forbid translation explicitly — this is the #90 defect.
+    assert "Never translate" in text
+    # And must license an honest gap rather than a guess.
+    assert "do NOT guess" in text
+
+
+def test_describe_frame_rubric_asks_for_plain_text_not_json():
+    """`vision.describe_image` reads raw stdout, so the frame contract is prose.
+    Asking for JSON here would make every caption unparseable."""
+    text = load_rubric("describe-frame", language="English")
+    assert "is_decorative" not in text
+    assert "JSON" in text  # ...only to forbid it
+    assert "no JSON" in text
+
+
+def test_describe_frame_rubric_carries_the_shared_fragment():
+    """The frame half of the anti-drift assertion: the rule reaches the rubric from
+    the fragment file, not from a paragraph pasted into it. (The photo half lands
+    in Task 3, once that rubric opts in.)"""
+    frame = load_rubric("describe-frame", language="English")
+    fragment = rubrics_module._load_fragment(rubrics_module._ONSCREEN_FRAGMENT).replace(
+        "{language}", "English"
+    )
+    assert fragment in frame

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -348,3 +348,69 @@ def test_verify_rubric_declares_the_evidence_surfaces_per_target():
     assert "digest" in text and "summary" in text
     assert "video transcript" in text.lower()
     assert "fetched article body" in text.lower()
+
+
+def test_load_rubric_splices_the_shared_onscreen_fragment(tmp_path, monkeypatch):
+    """`{onscreen_text_rule}` is replaced by the shared fragment file, and the
+    fragment's OWN `{language}` is substituted in the same call — the fragment
+    must be spliced BEFORE the language pass, not after."""
+    from xbrain import rubrics as rubrics_mod
+
+    rubric_dir = tmp_path / "rubrics"
+    rubric_dir.mkdir()
+    (rubric_dir / "fragment-onscreen-text.md").write_text(
+        "Transcribe VERBATIM; your prose is in {language}.\n", encoding="utf-8"
+    )
+    (rubric_dir / "rubric-probe.md").write_text(
+        "**Language:** {language}\n\n{onscreen_text_rule}\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", rubric_dir)
+
+    text = load_rubric("probe", language="Spanish")
+    assert "{onscreen_text_rule}" not in text
+    assert "Transcribe VERBATIM" in text
+    # The fragment's own placeholder resolved too — proves the splice ran first.
+    assert "your prose is in Spanish" in text
+    assert "{language}" not in text
+
+
+def test_load_rubric_without_the_placeholder_is_unchanged(tmp_path, monkeypatch):
+    """A rubric that does not opt in is returned byte-for-byte — the splice is
+    opt-in, so the six rubrics that carry no on-screen text are untouched."""
+    from xbrain import rubrics as rubrics_mod
+
+    rubric_dir = tmp_path / "rubrics"
+    rubric_dir.mkdir()
+    (rubric_dir / "rubric-plain.md").write_text("No placeholders here.\n", encoding="utf-8")
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", rubric_dir)
+
+    assert load_rubric("plain", language="English") == "No placeholders here.\n"
+
+
+def test_load_rubric_catches_a_misspelt_onscreen_placeholder(tmp_path, monkeypatch):
+    """`{onscreen_text_rules}` (plural) survives str.replace and would ship the
+    literal placeholder to the vision model. Same defence as `{Language}`."""
+    from xbrain import rubrics as rubrics_mod
+
+    rubric_dir = tmp_path / "rubrics"
+    rubric_dir.mkdir()
+    (rubric_dir / "fragment-onscreen-text.md").write_text("rule\n", encoding="utf-8")
+    (rubric_dir / "rubric-typo.md").write_text("{onscreen_text_rules}\n", encoding="utf-8")
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", rubric_dir)
+
+    with pytest.raises(ValueError, match=r"onscreen_text_rules"):
+        load_rubric("typo", language="English")
+
+
+def test_load_rubric_missing_fragment_is_a_loud_error(tmp_path, monkeypatch):
+    """A rubric asking for a fragment that is not packaged must fail loudly, not
+    ship a half-rendered prompt."""
+    from xbrain import rubrics as rubrics_mod
+
+    rubric_dir = tmp_path / "rubrics"
+    rubric_dir.mkdir()
+    (rubric_dir / "rubric-orphan.md").write_text("{onscreen_text_rule}\n", encoding="utf-8")
+    monkeypatch.setattr(rubrics_mod, "_RUBRICS_DIR", rubric_dir)
+
+    with pytest.raises(FileNotFoundError, match="fragment-onscreen-text.md"):
+        load_rubric("orphan", language="English")

--- a/tests/test_rubrics.py
+++ b/tests/test_rubrics.py
@@ -448,3 +448,33 @@ def test_describe_frame_rubric_carries_the_shared_fragment():
         "{language}", "English"
     )
     assert fragment in frame
+
+
+def test_describe_image_and_describe_frame_share_one_rule():
+    """The anti-drift assertion, now that BOTH rubrics opt in: they must carry the
+    SAME rule text, because both are spliced from the same fragment. If someone
+    re-inlines the paragraph into either one, this fails."""
+    frame = load_rubric("describe-frame", language="English")
+    photo = load_rubric("describe-image", language="English")
+    fragment = rubrics_module._load_fragment(rubrics_module._ONSCREEN_FRAGMENT).replace(
+        "{language}", "English"
+    )
+    assert fragment in frame
+    assert fragment in photo
+
+
+def test_describe_image_rubric_no_longer_orders_paraphrase_or_bans_quotes():
+    """Two clauses actively caused #90 on the photo surface:
+    'paraphrase the substance in your own words' discarded on-screen text, and
+    'no quotes' removed the only device for marking a verbatim string."""
+    text = load_rubric("describe-image", language="English")
+    assert "paraphrase the substance in your own words" not in text
+    assert "no quotes" not in text
+
+
+def test_describe_image_rubric_keeps_its_json_contract():
+    """The photo path is a BATCH JSON contract and must stay one — the new rule
+    changes what goes in `description`, never the response shape."""
+    text = load_rubric("describe-image", language="English")
+    assert "is_decorative" in text
+    assert "index" in text

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -46,7 +46,10 @@ def _runner(stdout: str, *, returncode: int = 0, stderr: str = ""):
 
 def test_parses_stdout_into_description(tmp_path: Path):
     result = describe_image(
-        tmp_path / "f.png", command="vlm-describe", runner=_runner("A slide titled 'Loops'.\n")
+        tmp_path / "f.png",
+        command="vlm-describe",
+        language="English",
+        runner=_runner("A slide titled 'Loops'.\n"),
     )
     assert result == "A slide titled 'Loops'."
 
@@ -54,7 +57,9 @@ def test_parses_stdout_into_description(tmp_path: Path):
 def test_argv_carries_model_and_image_path(tmp_path: Path):
     runner = _runner("desc")
     image = tmp_path / "f.png"
-    describe_image(image, command="vlm-describe", model="qwen2-vl", runner=runner)
+    describe_image(
+        image, command="vlm-describe", model="qwen2-vl", language="English", runner=runner
+    )
     argv = runner.calls[0]  # type: ignore[attr-defined]
     assert argv[0] == "vlm-describe"
     assert "--model" in argv and "qwen2-vl" in argv
@@ -63,7 +68,9 @@ def test_argv_carries_model_and_image_path(tmp_path: Path):
 
 def test_multi_token_command_is_split(tmp_path: Path):
     runner = _runner("desc")
-    describe_image(tmp_path / "f.png", command="python -m my_vlm", runner=runner)
+    describe_image(
+        tmp_path / "f.png", command="python -m my_vlm", language="English", runner=runner
+    )
     argv = runner.calls[0]  # type: ignore[attr-defined]
     assert argv[:3] == ["python", "-m", "my_vlm"]
 
@@ -72,7 +79,7 @@ def test_unconfigured_command_raises_vision_not_found(tmp_path: Path):
     """An empty `[vision].command` is a clear operator error (abort), not a crash —
     there is NO bundled default vision model."""
     with pytest.raises(VisionNotFound):
-        describe_image(tmp_path / "f.png", command="   ", runner=_runner("x"))
+        describe_image(tmp_path / "f.png", command="   ", language="English", runner=_runner("x"))
 
 
 def test_missing_binary_raises_vision_not_found(tmp_path: Path):
@@ -80,7 +87,7 @@ def test_missing_binary_raises_vision_not_found(tmp_path: Path):
         raise FileNotFoundError(2, "No such file or directory", "vlm-describe")
 
     with pytest.raises(VisionNotFound) as excinfo:
-        describe_image(tmp_path / "f.png", command="vlm-describe", runner=_run)
+        describe_image(tmp_path / "f.png", command="vlm-describe", language="English", runner=_run)
     assert "vlm-describe" in str(excinfo.value)
 
 
@@ -89,21 +96,25 @@ def test_permission_denied_raises_vision_not_found(tmp_path: Path):
         raise PermissionError(13, "Permission denied", "vlm-describe")
 
     with pytest.raises(VisionNotFound):
-        describe_image(tmp_path / "f.png", command="vlm-describe", runner=_run)
+        describe_image(tmp_path / "f.png", command="vlm-describe", language="English", runner=_run)
 
 
 def test_empty_output_is_failure_not_silent_empty(tmp_path: Path):
     """Exit 0 with NO output is a `VisionFailed` — never a silent empty
     description (that would drop the slide's content invisibly)."""
     with pytest.raises(VisionFailed) as excinfo:
-        describe_image(tmp_path / "f.png", command="vlm-describe", runner=_runner("   \n"))
+        describe_image(
+            tmp_path / "f.png", command="vlm-describe", language="English", runner=_runner("   \n")
+        )
     assert "no" in str(excinfo.value).lower()
 
 
 def test_nonzero_exit_raises_with_stderr(tmp_path: Path):
     runner = _runner("", returncode=2, stderr="model weights not found")
     with pytest.raises(VisionFailed) as excinfo:
-        describe_image(tmp_path / "f.png", command="vlm-describe", runner=runner)
+        describe_image(
+            tmp_path / "f.png", command="vlm-describe", language="English", runner=runner
+        )
     assert "model weights not found" in str(excinfo.value)
 
 
@@ -112,7 +123,7 @@ def test_timeout_raises_vision_failed(tmp_path: Path):
         raise subprocess.TimeoutExpired(cmd="vlm-describe", timeout=1)
 
     with pytest.raises(VisionFailed):
-        describe_image(tmp_path / "f.png", command="vlm-describe", runner=_run)
+        describe_image(tmp_path / "f.png", command="vlm-describe", language="English", runner=_run)
 
 
 def test_non_utf8_stdout_raises_vision_failed(tmp_path: Path):
@@ -123,7 +134,7 @@ def test_non_utf8_stdout_raises_vision_failed(tmp_path: Path):
         raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
 
     with pytest.raises(VisionFailed) as excinfo:
-        describe_image(tmp_path / "f.png", command="vlm-describe", runner=_run)
+        describe_image(tmp_path / "f.png", command="vlm-describe", language="English", runner=_run)
     assert "non-UTF-8" in str(excinfo.value)
 
 
@@ -141,3 +152,61 @@ def test_vision_imports_no_ml_or_vision_library():
         "coremltools",
     ):
         assert forbidden not in source
+
+
+def _env_runner(stdout: str = "desc"):
+    """A fake runner that records the `env=` kwarg as well as the argv."""
+    calls: list[dict] = []
+
+    def _run(argv, **kwargs):
+        calls.append({"argv": list(argv), "env": kwargs.get("env")})
+        return _completed(stdout)
+
+    _run.calls = calls  # type: ignore[attr-defined]
+    return _run
+
+
+def test_rubric_reaches_the_subprocess_through_the_env_var(tmp_path: Path):
+    """The caption discipline travels by environment variable, so the argv
+    contract stays frozen and a third-party command keeps working."""
+    from xbrain.vision import PROMPT_ENV_VAR
+
+    runner = _env_runner()
+    describe_image(tmp_path / "f.png", command="vlm", language="English", runner=runner)
+    env = runner.calls[0]["env"]  # type: ignore[attr-defined]
+    assert env is not None
+    prompt = env[PROMPT_ENV_VAR]
+    assert "VERBATIM" in prompt
+    assert "{language}" not in prompt
+    assert "English" in prompt
+
+
+def test_env_var_is_added_to_the_inherited_environment_not_replacing_it(tmp_path: Path):
+    """PATH and ANTHROPIC_API_KEY must survive — the cloud backend of the bundled
+    wrapper needs the key, and every backend needs PATH."""
+    import os
+
+    runner = _env_runner()
+    describe_image(tmp_path / "f.png", command="vlm", language="English", runner=runner)
+    env = runner.calls[0]["env"]  # type: ignore[attr-defined]
+    for key in os.environ:
+        assert key in env
+
+
+def test_argv_contract_is_unchanged_by_the_prompt_injection(tmp_path: Path):
+    """The backward-compatibility guarantee, pinned: adding the rule must NOT add
+    an argument, or every third-party `[vision].command` breaks at once."""
+    runner = _env_runner()
+    image = tmp_path / "f.png"
+    describe_image(image, command="vlm", model="qwen-3b", language="English", runner=runner)
+    argv = runner.calls[0]["argv"]  # type: ignore[attr-defined]
+    assert argv == ["vlm", "--model", "qwen-3b", str(image)]
+
+
+def test_a_runner_that_ignores_env_still_works(tmp_path: Path):
+    """Simulates a third-party command that never reads the variable: it must
+    still produce a description, not an error."""
+    result = describe_image(
+        tmp_path / "f.png", command="vlm", language="English", runner=_runner("plain caption")
+    )
+    assert result == "plain caption"

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -212,24 +212,14 @@ def test_a_runner_that_ignores_env_still_works(tmp_path: Path):
     assert result == "plain caption"
 
 
-def test_bundled_wrapper_reads_the_prompt_from_the_environment():
-    """`scripts/xbrain-vision` is the reference implementation of the contract, so
-    it must prefer the injected rubric over its own fallback constant. It is
-    stdlib-only by design (it runs under the system python, which has no xbrain),
-    so this is asserted on the source text rather than by importing it."""
-    from pathlib import Path
-
-    from xbrain.vision import PROMPT_ENV_VAR
-
-    source = Path(__file__).resolve().parents[1].joinpath("scripts/xbrain-vision").read_text()
-    assert PROMPT_ENV_VAR in source
-    assert "import xbrain" not in source
-
-
-def test_bundled_wrapper_keeps_a_fallback_prompt():
-    """Run outside xbrain (a bare `xbrain-vision photo.png`), the wrapper must
-    still have a prompt rather than sending the model an empty string."""
+def test_bundled_wrapper_imports_no_xbrain_module():
+    """`scripts/xbrain-vision` runs under the SYSTEM python, which has no xbrain
+    installed, so it must stay stdlib-only. The tempting regression is
+    `from xbrain.vision import PROMPT_ENV_VAR` to stop repeating the env-var name
+    — which a plain `"import xbrain" not in source` check would NOT catch, because
+    the word order is reversed. Match both forms."""
+    import re
     from pathlib import Path
 
     source = Path(__file__).resolve().parents[1].joinpath("scripts/xbrain-vision").read_text()
-    assert "_FALLBACK_PROMPT" in source
+    assert not re.search(r"^\s*(?:import|from)\s+xbrain\b", source, re.MULTILINE)

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -210,3 +210,26 @@ def test_a_runner_that_ignores_env_still_works(tmp_path: Path):
         tmp_path / "f.png", command="vlm", language="English", runner=_runner("plain caption")
     )
     assert result == "plain caption"
+
+
+def test_bundled_wrapper_reads_the_prompt_from_the_environment():
+    """`scripts/xbrain-vision` is the reference implementation of the contract, so
+    it must prefer the injected rubric over its own fallback constant. It is
+    stdlib-only by design (it runs under the system python, which has no xbrain),
+    so this is asserted on the source text rather than by importing it."""
+    from pathlib import Path
+
+    from xbrain.vision import PROMPT_ENV_VAR
+
+    source = Path(__file__).resolve().parents[1].joinpath("scripts/xbrain-vision").read_text()
+    assert PROMPT_ENV_VAR in source
+    assert "import xbrain" not in source
+
+
+def test_bundled_wrapper_keeps_a_fallback_prompt():
+    """Run outside xbrain (a bare `xbrain-vision photo.png`), the wrapper must
+    still have a prompt rather than sending the model an empty string."""
+    from pathlib import Path
+
+    source = Path(__file__).resolve().parents[1].joinpath("scripts/xbrain-vision").read_text()
+    assert "_FALLBACK_PROMPT" in source

--- a/tests/test_xbrain_vision.py
+++ b/tests/test_xbrain_vision.py
@@ -89,3 +89,15 @@ def test_fallback_prompt_still_demands_verbatim_transcription():
     discipline #90 exists to enforce, or the caption silently paraphrases again."""
     assert "VERBATIM" in xv._FALLBACK_PROMPT
     assert xv._FALLBACK_PROMPT.strip()
+
+
+def test_wrapper_and_xbrain_agree_on_the_env_var_name():
+    """The two halves of the injection contract spell this string INDEPENDENTLY —
+    the wrapper cannot import xbrain (it runs under the system python), so the
+    duplication is deliberate. Nothing else pins them equal: rename either side and
+    every test still passes while production silently falls back to the weaker
+    built-in prompt, reverting this whole change with no failure anywhere.
+    """
+    from xbrain.vision import PROMPT_ENV_VAR
+
+    assert xv._PROMPT_ENV_VAR == PROMPT_ENV_VAR

--- a/tests/test_xbrain_vision.py
+++ b/tests/test_xbrain_vision.py
@@ -60,3 +60,32 @@ def test_main_prints_description_and_returns_0(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(sys, "argv", ["xbrain-vision", "--model", "opus", str(img)])
     assert xv.main() == 0
     assert "Un gráfico de barras." in capsys.readouterr().out
+
+
+def test_prompt_prefers_the_injected_rubric(monkeypatch):
+    """xbrain injects the frame rubric as XBRAIN_VISION_PROMPT; the wrapper is the
+    reference implementation of that contract, so it must USE it rather than its
+    own constant. Read at CALL time, so a value set after import still applies."""
+    monkeypatch.setenv("XBRAIN_VISION_PROMPT", "transcribe verbatim, injected")
+    assert xv._prompt() == "transcribe verbatim, injected"
+
+
+def test_prompt_falls_back_when_the_env_var_is_absent(monkeypatch):
+    """Run bare, outside xbrain, the script still needs a working prompt — an empty
+    one would produce a useless caption instead of an error."""
+    monkeypatch.delenv("XBRAIN_VISION_PROMPT", raising=False)
+    assert xv._prompt() == xv._FALLBACK_PROMPT
+
+
+def test_prompt_treats_a_blank_env_var_as_absent(monkeypatch):
+    """A variable set to whitespace is a misconfiguration, not an instruction to
+    send the model nothing."""
+    monkeypatch.setenv("XBRAIN_VISION_PROMPT", "   \n  ")
+    assert xv._prompt() == xv._FALLBACK_PROMPT
+
+
+def test_fallback_prompt_still_demands_verbatim_transcription():
+    """The fallback is a real prompt, not a stub: a bare run must still get the
+    discipline #90 exists to enforce, or the caption silently paraphrases again."""
+    assert "VERBATIM" in xv._FALLBACK_PROMPT
+    assert xv._FALLBACK_PROMPT.strip()


### PR DESCRIPTION
Primera de dos PRs para #90. Esta establece **el contrato de caption**; la siguiente (`redescribe-frames`) lo aplica al corpus ya descrito.

## El problema, corregido respecto al issue

El issue #90 dice que los captions *omiten* el texto en pantalla. Leyendo los captions reales del store, lo que hacen es **traducirlo**: el rubric pedía `paraphrase the substance in your own words` y `{language}` (español), así que un frame que muestra `Layer Norm` produce «Normalización de Capa». El digest, escrito en inglés, cita `Layer Norm` — y el checker determinista de #89 lo marca como no fundamentado, **con razón**: esa cadena no aparece en ninguna superficie de evidencia.

Y la constante en cuestión ordenaba «one or two dense, factual **Spanish** sentences» — el mandato de español sin excepción para el texto en pantalla es lo que producía la traducción, y el tope de una o dos frases es lo que forzaba tirar etiquetas.

Los captions son el ÚNICO canal por el que el contenido en pantalla llega al pipeline, así que la traducción no pierde estilo: pierde el dato.

No se toca `entity_grounding.py`. Aflojar el instrumento sería bajar el listón hasta la medición — lo que el propio issue prohíbe. Verificado sobre toda la rama:
`git diff --stat <base>..HEAD -- src/xbrain/entity_grounding.py` → vacío.

## Tres causas raíz, tres arreglos

| # | Causa | Arreglo |
|---|---|---|
| 1 | El rubric ordenaba parafrasear y prohibía comillas | Regla compartida `fragment-onscreen-text.md`: **el texto en pantalla es DATO, no prosa** — verbatim, en su idioma original |
| 2 | Los frames no recibían **ningún** prompt de xbrain: el único en juego era la constante `PROMPT` hardcodeada dentro de `scripts/xbrain-vision` — no versionada con los rubrics, no cargable, no comprobable desde los tests. Un `[vision].command` de terceros no recibía **nada** | Nuevo `rubric-describe-frame.md`, un artefacto de xbrain como los demás |
| 3 | El rubric nunca llegaba al subproceso de visión | `XBRAIN_VISION_PROMPT`, **fuera de banda** |

La regla vive en **un** fichero spliceado en ambos rubrics. Dos copias derivan, y una regla derivada es peor que ninguna: una superficie sigue traduciendo en silencio (regla 5 del CLAUDE.md).

## Por qué variable de entorno y no argv

El contrato documentado `<command> [--model M] <image-path>` queda **congelado**. Un comando de terceros o antiguo simplemente no lee la variable y sigue funcionando; el trade-off (no recibe disciplina de caption) está documentado en `config.toml.example` para quien escriba su propio comando.

## `caption_contract` va a nivel de FUENTE, no de frame

`ContentSourceSuccess.caption_contract` registra bajo qué rubric se produjeron los captions. Puesto en `VideoFrame` habría caído dentro de `fetch._source_signature` — cuya deny-list es **plana, no desciende a modelos anidados** — y re-estampar captions idénticos habría contado como cambio de contenido: **142 items re-enriquecidos** a coste completo de LLM sin que nada cambiara. Va en `_BOOKKEEPING_FIELDS`.

## Techos de tokens (hallazgo del review de rama)

El rubric ahora pide transcripción sin límite mientras los techos seguían dimensionados para el prompt viejo: qwen-3b local en `max_tokens=256`, cloud en 512, foto en 1200. En los slides densos —los que esta feature existe para arreglar— se cortaba a media cadena **en silencio**. Una etiqueta truncada es indistinguible aguas abajo de una alucinada, que es justo lo que el párrafo «do NOT guess» existe para prevenir. Local y cloud a 1024, foto a 3000, y el path cloud avisa por stderr al tocar techo.

## Paso operativo requerido tras mergear

`describe._is_stale` sólo re-describe si se sube `[describe].version` a mano: **el contenido del rubric no se fingerprintea**. Sin ese paso, esta PR edita el rubric de fotos y ninguna foto ya descrita se regenera. El default NO se cambia aquí a propósito — eso re-describiría el corpus de todo el mundo al actualizar, a coste completo de API y sin avisar.

## Verificación

- Gate verde **sobre el resultado del merge con `develop`**, no sobre la rama sola: 1871 tests, 94.23% cobertura, 11/11 checks. (La rama sola corría 1663; la diferencia es lo que prueba que se ejecutó la combinación — regla 4.)
- 7 tareas, cada una con review propia; 5 rondas de fix; 1 review de rama completa (Opus) con 2 hallazgos Important, ambos cerrados.
- El reviewer descargó empíricamente el riesgo §8 del diseño: el caption nuevo fundamenta `Layer Norm` / `Self-Attention` / `Projection` / `SORTTAB` / `KSYM`; el traducido deja `Self-Attention` sin fundamentar — **#90 reproducido**.

Refs #90

