### PR TITLE
docs(claude): triage the truncation work list, don't count the bytes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,31 +309,45 @@ generates an Obsidian wiki.
   not quote as a census.** `looks_truncated` (`extract/graphql.py`) detects X's 280-char cut
   by LENGTH: ≥274 chars unconditionally, plus 265–273 when the text does not end on a real
   terminator (`:` and `;` are not terminators). `--apply` is a REAL browser re-fetch —
-  headful, human-paced, hours of it — checkpointing after every item (a session expiry on
-  item 90 of ~127 must not discard the first 89 repairs) and auto-snapshotting first;
-  without `--apply` it only reports and writes `data/truncated-items.json`. **Reach for
-  `reextract` first:** measured 2026-08-30 on the live store (2,404 items), of the **707**
-  items the detector flags only **5** have no stored payload — the other **702 re-parse
-  offline, for free, with no network at all**. Corpus-wide the payload layer covers 2,360 of
-  2,404, so the "payloads are NOT persisted" premise (still asserted in
-  `items_needing_refetch`'s own docstring — issue #142) survives only for what predates
-  persistence. **But 702 re-parses is a fact about where the BYTES live, not a count of
-  repairs.** Compare `note_tweet.note_tweet_results.result.text` in each payload against the
-  stored text and the work list splits four ways: **214 truncated** — the payload holds a
-  longer body, and these are the real repairs, offline and free; **358 complete** — the
-  long-form body is byte-identical to what is stored (358 of 358, median 721 chars, max
-  13,173), flagged on length alone, more than half the list; **122 undetermined** — no
-  long-form body in the payload, so the store cannot decide them either way; **13 other** —
-  8 rewritten without lengthening, 5 with no payload. The network job is therefore **at most
-  ~127 items**, and its real size is not determined by anything we hold. **Do not tidy the
-  122 away** by arguing they fitted inside 280 chars: tested against the 214 KNOWN
-  truncations on both signatures a reader reaches for, they are indistinguishable — median
-  stored prose 277 against 277, all 122 inside the 265–292 band against 212 of the 214, a
-  trailing self-link on 70% of them against 58%. A discriminating test that fails to
-  discriminate is a result, not a dead end. **And the re-parse log is not confirmation:** a
-  dry `reextract` warns `tweet ... arrives TRUNCATED` for 702 of the 707, and for the **480**
-  whose text it does not change that warning is guaranteed before it runs — same string in,
-  same `looks_truncated` out, 480 of 480. Rule 2, tripped inside the repo that wrote it. The
+  headful, human-paced, hours of it — auto-snapshotting first and checkpointing every **25**
+  items (`every: int = 25`) plus once more through a `finally` on the way out, so an expiry
+  that RAISES loses nothing and only a hard kill drops up to 24 repairs; without `--apply` it
+  only reports and writes `data/truncated-items.json`. **Reach for `reextract` first:**
+  measured 2026-08-30 on the live store (2,404 items), of the **707** items the detector
+  flags only **5** have no stored payload — the other **702 re-parse offline, for free, with
+  no network at all**. Corpus-wide the payload layer covers 2,360 of 2,404, so the "payloads
+  are NOT persisted" premise — asserted in `items_needing_refetch`'s docstring and AGAIN in
+  this command's own docstring (issue #142) — survives only for what predates persistence.
+  **But 702 re-parses is a fact about where the BYTES live, not a count of repairs.** Compare
+  `note_tweet.note_tweet_results.result.text` in each payload against the stored text and the
+  work list splits four ways: **214 truncated** — the payload holds a longer body, and these
+  are the real repairs, offline and free; **358 complete** — the long-form body is
+  byte-identical to what is stored (358 of 358, median 721 chars, max 13,173), flagged on
+  length alone; **122 undetermined** — no long-form body in the payload, so the store cannot
+  decide them either way; **13 other** — 8 rewritten without lengthening, 5 with no payload.
+  The undecided population is therefore **127**: the 122 plus those 5, which are undecided
+  for the stronger reason that no evidence exists in either direction. That puts the real
+  truncations at **214–341** and the false flags at **358–485** — two intervals of the same
+  width, 127, the same uncertainty counted from either end. The 8 rewritten-without-
+  lengthening sit OUTSIDE both and lean truncated (7 of the 8 carry a longer body once the
+  trailing t.co is stripped, which is the string `looks_truncated` actually judges), so
+  folding them in would raise the truncation ceiling to 349 and never the false-flag one.
+  **`--apply` knows none of this:** `targets = items_needing_refetch(store)` is the whole 707
+  and the loop re-fetches every one of them (only the WRITE is conditional), so as written it
+  is a 707-item browser run in which at most **127** items can gain a character — the same
+  127, because what the store cannot decide is exactly what the network would have to be
+  asked — while 358 of those fetches re-download posts this measurement proves were already
+  complete. That gap is the argument for triaging before you run it. **Do not tidy the 122
+  away** by arguing they fitted inside 280 chars: tested against the 214 KNOWN truncations on
+  both signatures a reader reaches for, they are indistinguishable — median stored prose 277
+  against 277, all 122 inside the 265–292 band against 212 of the 214, a trailing self-link
+  on 70% of them against 58%. Two readings survive and nothing in the store chooses between
+  them: a truncation whose payload never carried the body, or a complete ~277-character post
+  that ends in the author's own link. A discriminating test that fails to discriminate is a
+  result, not a dead end. **And the re-parse log is not confirmation:** a dry `reextract`
+  warns `tweet ... arrives TRUNCATED` for 702 of the 707, and for the **480** whose text it
+  does not change that warning is guaranteed before it runs — same string in, same
+  `looks_truncated` out, 480 of 480. Rule 2, tripped inside the repo that wrote it. The
   detector is deliberately biased towards flagging (a missed truncation is a fabrication kept
   forever; a false flag costs one re-fetch), so the number measures the flag, never the
   defect.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,18 +310,33 @@ generates an Obsidian wiki.
   by LENGTH: ≥274 chars unconditionally, plus 265–273 when the text does not end on a real
   terminator (`:` and `;` are not terminators). `--apply` is a REAL browser re-fetch —
   headful, human-paced, hours of it — checkpointing after every item (a session expiry on
-  item 400 of 707 must not discard the first 400 repairs) and auto-snapshotting first;
+  item 90 of ~127 must not discard the first 89 repairs) and auto-snapshotting first;
   without `--apply` it only reports and writes `data/truncated-items.json`. **Reach for
-  `reextract` first, and for nearly all of them it IS the answer:** measured 2026-08-30 on the
-  live store (2,404 items), of the **707** items the detector flags only **5** have no stored
-  payload — the other **702 re-parse offline, for free, with no network at all**. Corpus-wide
-  the payload layer covers 2,360 of 2,404, so the "payloads are NOT persisted" premise (still
-  asserted in `items_needing_refetch`'s own docstring — issue #142) survives only for what predates
-  persistence. **And 707 is a work list, not a census:** `looks_truncated` decides on LENGTH
-  ALONE (≥274 chars unconditionally), so **561 of the 707 are LONGER than 290 chars** — full
-  `note_tweet` bodies the length rule flags anyway. The detector is deliberately biased
-  towards flagging (a missed truncation is a fabrication kept forever; a false flag costs one
-  re-fetch), so the number measures the flag, never the defect.
+  `reextract` first:** measured 2026-08-30 on the live store (2,404 items), of the **707**
+  items the detector flags only **5** have no stored payload — the other **702 re-parse
+  offline, for free, with no network at all**. Corpus-wide the payload layer covers 2,360 of
+  2,404, so the "payloads are NOT persisted" premise (still asserted in
+  `items_needing_refetch`'s own docstring — issue #142) survives only for what predates
+  persistence. **But 702 re-parses is a fact about where the BYTES live, not a count of
+  repairs.** Compare `note_tweet.note_tweet_results.result.text` in each payload against the
+  stored text and the work list splits four ways: **214 truncated** — the payload holds a
+  longer body, and these are the real repairs, offline and free; **358 complete** — the
+  long-form body is byte-identical to what is stored (358 of 358, median 721 chars, max
+  13,173), flagged on length alone, more than half the list; **122 undetermined** — no
+  long-form body in the payload, so the store cannot decide them either way; **13 other** —
+  8 rewritten without lengthening, 5 with no payload. The network job is therefore **at most
+  ~127 items**, and its real size is not determined by anything we hold. **Do not tidy the
+  122 away** by arguing they fitted inside 280 chars: tested against the 214 KNOWN
+  truncations on both signatures a reader reaches for, they are indistinguishable — median
+  stored prose 277 against 277, all 122 inside the 265–292 band against 212 of the 214, a
+  trailing self-link on 70% of them against 58%. A discriminating test that fails to
+  discriminate is a result, not a dead end. **And the re-parse log is not confirmation:** a
+  dry `reextract` warns `tweet ... arrives TRUNCATED` for 702 of the 707, and for the **480**
+  whose text it does not change that warning is guaranteed before it runs — same string in,
+  same `looks_truncated` out, 480 of 480. Rule 2, tripped inside the repo that wrote it. The
+  detector is deliberately biased towards flagging (a missed truncation is a fabrication kept
+  forever; a false flag costs one re-fetch), so the number measures the flag, never the
+  defect.
 - **`verify-entities` / `entity_grounding.py` — the deterministic checker, and READ WHAT IT
   IS BLIND TO BEFORE QUOTING ANY NUMBER FROM IT.** Token-free, no model, so it cannot inherit
   the judge ensemble's blind spot (three judges sharing one model and one rubric are ONE


### PR DESCRIPTION
Corrects two overclaims in the `refetch-truncated` bullet (`## Architecture`). Both are
overclaim rather than falsehood, and both are the shape of **rule 2** — a number that
measures the instrument rather than the thing it is pointed at.

`## Rules paid for in blood` is byte-identical to develop. Verified, not asserted:

```
$ diff <(git show origin/develop:CLAUDE.md | sed -n '404,$p') <(sed -n '/Rules paid for in blood/,$p' CLAUDE.md)
$ echo $?
0
```

## Defect 1 — "for nearly all of them it IS the answer"

The re-parse claim itself is true and stays: 702 of the 707 flagged items have a stored
payload and re-parse offline. But that is a fact about **where the bytes live**. How many
of those re-parses actually *gain* text is a different number, and it is much smaller.

## Defect 2 — "561 of the 707 are LONGER than 290 chars"

The best argument available before the decisive test was run. Superseded and replaced.

## The measurement that supersedes it

Read `note_tweet.note_tweet_results.result.text` off each flagged item's payload and
compare against the stored text. Re-derived read-only against the live store today
(`items.json` never opened for write):

| bin | n | what it means |
|---|---|---|
| **truncated** | **214** | payload holds a longer body — the real repairs, offline and free |
| **complete** | **358** | long-form body byte-identical to stored, 358 of 358, median 721 chars, max 13,173 |
| **undetermined** | **122** | no long-form body in the payload — the store cannot decide |
| changed, not lengthened | 8 | re-parse rewrites without adding |
| no payload | 5 | nothing on disk to compare |
| | **707** | |

Network job ceiling: **~127**, and its real size is not determined by anything we hold.

## The residue that is not tidied away

The tempting move is to argue the 122 fitted inside 280 chars and are therefore complete.
Tested against the 214 **known** truncations on both signatures a reader would reach for,
they are indistinguishable:

| signature | 122 undetermined | 214 known truncated |
|---|---|---|
| median stored prose | 277 | 277 |
| inside the 265–292 band | 122 / 122 | 212 / 214 |
| trailing self-link | 70% | 58% |

A discriminating test that fails to discriminate is a result, not a dead end.

## The tautology trap

A dry `reextract` warns `tweet ... arrives TRUNCATED` for **702** of the 707, which reads
like confirmation and is not. For the **480** whose text the re-parse does not change, that
warning is guaranteed before it runs — `looks_truncated` is called on a string that did not
change, so it returns what it returned the first time. 480 of 480.

> Note: the handoff brief said the log fires for 480. It fires for 702; the 480 is the
> subset where it is *tautological*. The sharper claim, and the one in the diff.

## Kept unchanged

`looks_truncated` length mechanics (≥274 unconditional, 265–273 without a real terminator,
`:` and `;` not terminators) · the `--apply` browser/checkpoint/snapshot description ·
corpus-wide "payload layer covers 2,360 of 2,404" · the issue #142 docstring pointer · the
closing "the number measures the flag, never the defect" — now better supported, not worse.

## Also fixed

The checkpoint example read "a session expiry on item 400 of 707". A 707-item network run
is the very thing this correction exists to kill; rescoped to the real job (~127).

Docs only, one file. Follows #141 and #146.