### PR TITLE
feat(knowledge) 02.1: version each response envelope on its own, and name the strategy that runs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1146,7 +1146,7 @@ xbrain/
 │   │   ├── surfaces.py      ← the emitter + the three totality maps
 │   │   ├── chunking.py      ← structural chunker (atomic beats MAX_CHARS)
 │   │   ├── profile.py       ← the item's retrieval profile (never a citation)
-│   │   ├── contracts.py     ← Search*/Evidence*/Graph*, frozen per envelope (SearchResponse "2", EvidenceBundle "2", Graph "1")
+│   │   ├── contracts.py     ← Search*/Evidence*/Graph*, frozen per envelope (SearchResponse "2", EvidenceBundle "1", Graph "1")
 │   │   ├── goldenset.py     ← two-stage loader: structure, then resolution
 │   │   ├── lexical_fts.py   ← the FTS5 DDL + scorer Plan 02 reuses
 │   │   ├── lexical_memory.py← that same FTS5 on sqlite3(":memory:")

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1146,7 +1146,7 @@ xbrain/
 │   │   ├── surfaces.py      ← the emitter + the three totality maps
 │   │   ├── chunking.py      ← structural chunker (atomic beats MAX_CHARS)
 │   │   ├── profile.py       ← the item's retrieval profile (never a citation)
-│   │   ├── contracts.py     ← Search*/Evidence*/Graph*, frozen at schema_version "1"
+│   │   ├── contracts.py     ← Search*/Evidence*/Graph*, frozen per envelope (SearchResponse "2", EvidenceBundle "2", Graph "1")
 │   │   ├── goldenset.py     ← two-stage loader: structure, then resolution
 │   │   ├── lexical_fts.py   ← the FTS5 DDL + scorer Plan 02 reuses
 │   │   ├── lexical_memory.py← that same FTS5 on sqlite3(":memory:")

--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -2832,8 +2832,12 @@ def _inspect_item(corpus, item_id: str, *, want_surfaces: bool, want_chunks: boo
         transcribe_command=cfg.transcribe_command,
         vision_command=cfg.vision_command,
     )
+    from xbrain.knowledge.contracts import EVIDENCE_SCHEMA_VERSION
+
     payload: dict = {
-        "schema_version": "1",
+        # The version of the shapes this payload dumps, read off the contract (U-1): the
+        # surfaces and chunks here are the `EvidenceBundle`'s, so they carry its number.
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
         "item": knowledge_item(item, vault_dir=cfg.output_dir).model_dump(mode="json"),
         # Hydrated from the LIVE store, never persisted on a surface (M5): a stored copy
         # could not be invalidated when the verdict changed, so a revoked FAIL would keep
@@ -2892,8 +2896,10 @@ def _inspect_topic(corpus, slug: str, *, want_surfaces: bool) -> dict:
         raise ValueError(f"No existe el topic {slug!r} en data/vocab.yaml.")
     page = corpus.topic_pages.get(slug)
     primary, secondary = _topic_membership(corpus, slug)
+    from xbrain.knowledge.contracts import EVIDENCE_SCHEMA_VERSION
+
     payload: dict = {
-        "schema_version": "1",
+        "schema_version": EVIDENCE_SCHEMA_VERSION,
         "topic": topic_record(topic, page, primary, secondary).model_dump(mode="json"),
     }
     if want_surfaces:

--- a/src/xbrain/knowledge/contracts.py
+++ b/src/xbrain/knowledge/contracts.py
@@ -1,5 +1,5 @@
 """The external response schemas, frozen per envelope — `SearchResponse` at `"2"`,
-`EvidenceBundle` at `"2"`, the graph envelope at `"1"` (spec §7; the policy below).
+`EvidenceBundle` at `"1"`, the graph envelope at `"1"` (spec §7; the policy below).
 
 FROZEN NOW, ON PURPOSE, before the services that fill them exist. Spec §7.1 says CLI JSON
 and MCP are two adapters over ONE service and must not implement two formats — and the way
@@ -17,20 +17,31 @@ and this contract does NOT: a required key added under the same number is a docu
 version-1 consumer refuses (`Extra inputs are not permitted`) and a version-1 document the
 new consumer refuses (`Field required`), two producers announcing one version that do not
 interoperate. So a key added to a frozen shape BUMPS the version of every envelope that
-transports it, and the refusal then names the version rather than a field. Round 06 made
-`KnowledgeChunk.locator` required — spec §3.7 invariant 2 demanded it from the start — and
-`EvidenceBundle`, the one envelope carrying chunks, is at "2" for it; `SearchResponse` stayed
-at "1" then, because `SearchMatch` always carried its locator, and moved to "2" when
-`SearchMatch` gained the `title` spec §4 makes accompany a chunk (B2, gate Codex on
-`b61e04b`). OPTIONAL-WITH-A-DEFAULT IS NOT AN EXEMPTION, and this is the half of U-1 that is
-easy to miss: a defaulted key is additive for the NEW consumer, which fills it in, and
-incompatible for the OLD one, which forbids it — the version-1 reader refuses the document
-outright, so the number has to move for the refusal to name the version rather than a field
-nobody told it about. No document at either number is persisted
-anywhere (the index stores `locator_json` per surface, never a bundle), so there is no
-migration, only the honest number. `EVIDENCE_SCHEMA_VERSION` is READ off the model, never
-written a second time, so an adapter that stamps an envelope by hand (`cli.py`'s inspect
-payloads) cannot drift from it.
+transports it, and the refusal then names the version rather than a field.
+OPTIONAL-WITH-A-DEFAULT IS NOT AN EXEMPTION, and this is the half of U-1 that is easy to
+miss: a defaulted key is additive for the NEW consumer, which fills it in, and incompatible
+for the OLD one, which forbids it — the version-1 reader refuses the document outright, so
+the number has to move for the refusal to name the version rather than a field nobody told
+it about. That is why `SearchResponse` is at "2" here: `SearchMatch` gained the `title`
+spec §4 makes accompany a chunk (B2, gate Codex on `b61e04b`), and `SearchResponse` is the
+one envelope that transports a `SearchMatch`.
+
+AND THE RULE CUTS BOTH WAYS — A NUMBER IS A CLAIM ABOUT A SHAPE, SO IT SHIPS WITH THE SHAPE.
+`EvidenceBundle` is at "1" in this child PR, and the reason is the whole of the policy read
+backwards. The bump queued for it means one specific thing — `KnowledgeChunk.locator` became
+required (spec §3.7 invariant 2 demanded it from the start) — and that field, together with
+the `chunking.fragment_locator` that computes it and the producers that fill it, lands in
+child PR 02.5. Announcing "2" over chunks that carry no locator would publish a version whose
+only meaning is a field this build does not have: a consumer told to expect the locator would
+find none, and the refusal-by-version this policy exists to buy would name a version that
+describes nothing. So the number moves in 02.5, in the same PR as the field, and the test
+that pins a version-1 document as refused-by-its-version moves with it. Today the honest
+triple is `SearchResponse` "2", `EvidenceBundle` "1", the graph envelope "1".
+
+No document at any of those numbers is persisted anywhere (the index stores `locator_json`
+per surface, never a bundle), so there is no migration, only the honest number.
+`EVIDENCE_SCHEMA_VERSION` is READ off the model, never written a second time, so an adapter
+that stamps an envelope by hand (`cli.py`'s inspect payloads) cannot drift from it.
 
 THE NAMING RULE, AND WHY IT IS ENFORCED BY TOTALITY (m12). Invariant 2 of spec §3.7: nothing
 is called `text` without `origin` beside it. A walker that scans a JSON payload and fails on
@@ -206,9 +217,9 @@ class IndexStatusRef(BaseModel):
 
     TWO SIGNALS WITH TWO NAMES (B3). `corrupt_chunks_excluded` counts rows whose fingerprint
     does not recompute — corruption, or a row written by a different chunker version — and,
-    since round 06 (B-k), rows whose surface cannot be resolved to a locator (spec §3.7
-    invariant 1), which are the same operator situation. That is
-    an INTERNAL consistency check and it does not detect the failure that actually happens:
+    once the writer that fills it lands (child PR 02.5, with `KnowledgeChunk.locator`), rows
+    whose surface cannot be resolved to a locator (spec §3.7 invariant 1), which are the same
+    operator situation. That is an INTERNAL consistency check and it does not detect the failure that actually happens:
     *you ran `enrich` and did not reindex*. That one is a `degraded` flag
     (`"index_behind_store"`), raised by comparing the manifest's cheap store signal against
     the current file.
@@ -256,10 +267,12 @@ class EvidenceBundle(BaseModel):
 
     model_config = _FROZEN
 
-    # "2" since round 07 (U-1): `KnowledgeChunk.locator` became required in round 06, and
-    # under `extra="forbid"` that is an incompatible change of THIS envelope — see the
-    # module docstring for the policy. A document announcing "1" is refused by its version.
-    schema_version: Literal["2"] = "2"
+    # STILL "1", and deliberately: the bump queued for this envelope means
+    # `KnowledgeChunk.locator` is required, and that field arrives in child PR 02.5 with the
+    # `chunking.fragment_locator` that computes it. A number is a claim about a shape, so it
+    # ships with the shape — see the module docstring. `SearchResponse` moved to "2" here
+    # because the key that moved it, `SearchMatch.title`, is in this PR.
+    schema_version: Literal["1"] = "1"
     item: KnowledgeItem
     topics: tuple[TopicRecord, ...] = ()
     surfaces: tuple[KnowledgeSurface, ...] = ()
@@ -324,8 +337,12 @@ class GraphExpansionResponse(BaseModel):
 
 # The evidence envelope's version, read off the model so there is ONE definition (U-1). The
 # CLI's `knowledge inspect` payloads dump the same `KnowledgeSurface`/`KnowledgeChunk`/
-# `TopicRecord` shapes the bundle transports, and used to stamp "1" by hand — which is how a
-# bump here would have left them announcing the old number over the new shape.
+# `TopicRecord` shapes the bundle transports, and used to stamp "1" by HAND — a literal that
+# happens to agree with the model today and would go on agreeing with nothing the day the
+# model moves. Reading it off the model is what makes 02.5's bump reach the CLI without
+# anyone having to remember; `tests/test_knowledge_cli.py` proves the derivation by injecting
+# a version the source does not contain, because equality against the current literal cannot
+# tell a derived value from a hardcoded one.
 EVIDENCE_SCHEMA_VERSION: str = EvidenceBundle.model_fields["schema_version"].default
 SEARCH_SCHEMA_VERSION: str = SearchResponse.model_fields["schema_version"].default
 

--- a/src/xbrain/knowledge/contracts.py
+++ b/src/xbrain/knowledge/contracts.py
@@ -1,4 +1,5 @@
-"""The external response schemas, frozen at `schema_version: "1"` (spec §7).
+"""The external response schemas, frozen per envelope — `SearchResponse` at `"2"`,
+`EvidenceBundle` at `"2"`, the graph envelope at `"1"` (spec §7; the policy below).
 
 FROZEN NOW, ON PURPOSE, before the services that fill them exist. Spec §7.1 says CLI JSON
 and MCP are two adapters over ONE service and must not implement two formats — and the way
@@ -8,6 +9,28 @@ consumer rather than an author.
 
 It is also why `producer`, `produced_at` and the eight filters are all here in version 1.
 Adding a field afterwards is exactly the incompatible change the freeze is meant to prevent.
+
+THE VERSION POLICY, STATED ONCE (U-1, round 07). Every model here is `extra="forbid"`, so
+the only consumer that exists — these Pydantic models, which the Plan 04 MCP adapter will
+inherit — refuses a key it was not frozen with. That makes "additive" a property JSON has
+and this contract does NOT: a required key added under the same number is a document the
+version-1 consumer refuses (`Extra inputs are not permitted`) and a version-1 document the
+new consumer refuses (`Field required`), two producers announcing one version that do not
+interoperate. So a key added to a frozen shape BUMPS the version of every envelope that
+transports it, and the refusal then names the version rather than a field. Round 06 made
+`KnowledgeChunk.locator` required — spec §3.7 invariant 2 demanded it from the start — and
+`EvidenceBundle`, the one envelope carrying chunks, is at "2" for it; `SearchResponse` stayed
+at "1" then, because `SearchMatch` always carried its locator, and moved to "2" when
+`SearchMatch` gained the `title` spec §4 makes accompany a chunk (B2, gate Codex on
+`b61e04b`). OPTIONAL-WITH-A-DEFAULT IS NOT AN EXEMPTION, and this is the half of U-1 that is
+easy to miss: a defaulted key is additive for the NEW consumer, which fills it in, and
+incompatible for the OLD one, which forbids it — the version-1 reader refuses the document
+outright, so the number has to move for the refusal to name the version rather than a field
+nobody told it about. No document at either number is persisted
+anywhere (the index stores `locator_json` per surface, never a bundle), so there is no
+migration, only the honest number. `EVIDENCE_SCHEMA_VERSION` is READ off the model, never
+written a second time, so an adapter that stamps an envelope by hand (`cli.py`'s inspect
+payloads) cannot drift from it.
 
 THE NAMING RULE, AND WHY IT IS ENFORCED BY TOTALITY (m12). Invariant 2 of spec §3.7: nothing
 is called `text` without `origin` beside it. A walker that scans a JSON payload and fails on
@@ -21,7 +44,7 @@ total: adding a text field without deciding which side it is on goes red.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, get_args, get_origin
+from typing import Literal, cast, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.fields import FieldInfo
@@ -47,6 +70,53 @@ _FROZEN = ConfigDict(frozen=True, extra="forbid")
 # adding a member later would change the response schema.
 Strategy = Literal["lexical", "vector", "hybrid", "hybrid_graph"]
 
+# WHICH OF THEM THIS BUILD CAN ACTUALLY RUN (F-2). The comment above already stated this fact
+# — *this PR ships only `lexical`* — but it stated it in PROSE, and prose is not readable by
+# the two surfaces that label their output with a strategy name. `search` echoed the strategy
+# it was ASKED for into `SearchResponse.strategy`, so `strategy="hybrid"` came back labelled
+# `hybrid` over results produced entirely by bm25; and `xbrain eval --strategy vector`
+# published a report headed `vector` with 21 cases scored by the lexical retriever. Turning
+# the prose into a constant is rule 5 applied to a fact the file already asserted.
+#
+# Plan 03 adds its member here when the vector backend lands, and both surfaces stop
+# degrading with no other change.
+IMPLEMENTED_STRATEGIES: frozenset[str] = frozenset({"lexical"})
+
+# What answers when the requested strategy has no backend. Spec §9.3's first bullet is
+# explicit that this is a DEGRADATION and not a refusal: *lexical sigue operativo y el
+# response declara estrategia degradada; no finge resultados vectoriales.*
+FALLBACK_STRATEGY: Strategy = "lexical"
+
+NOT_IMPLEMENTED_SUFFIX = "_not_implemented"
+
+
+def resolve_strategy(requested: str) -> tuple[Strategy, tuple[str, ...]]:
+    """The strategy that will actually run, and what to call the gap. Spec §9.3.
+
+    THREE OUTCOMES, and the difference between the last two is the whole point:
+
+    - implemented -> it runs, nothing is degraded;
+    - declared in `Strategy` but with no backend -> `lexical` runs and the response says
+      `<requested>_not_implemented`, which is the spec's *lexical sigue operativo* and its
+      *el response declara estrategia degradada* in one return value;
+    - not in `Strategy` at all -> `ValueError` naming what would have been valid. A typo is
+      not a degradation, and answering it with lexical results would turn it into a
+      measurement; spec §9.3 asks for a *error de validación estable* for invalid arguments.
+
+    Read from the module global at call time rather than closed over, so a test can inject a
+    hypothetical backend without depending on `vector` staying unimplemented.
+    """
+    if requested in IMPLEMENTED_STRATEGIES:
+        return cast(Strategy, requested), ()
+    if requested in get_args(Strategy):
+        return FALLBACK_STRATEGY, (f"{requested}{NOT_IMPLEMENTED_SUFFIX}",)
+    raise ValueError(
+        f"Estrategia desconocida: {requested!r}. "
+        f"Las declaradas son: {', '.join(get_args(Strategy))}; "
+        f"implementadas hoy: {', '.join(sorted(IMPLEMENTED_STRATEGIES))}."
+    )
+
+
 # Which generator produced a match. `graph` is declared for Plan 04 for the same reason.
 Channel = Literal["lexical", "vector", "graph"]
 
@@ -58,6 +128,16 @@ class SearchMatch(BaseModel):
     fusion to preserve the EXPLANATION of a result. `score` is a ranking signal and is
     documented as such — it is deliberately not presented as a probability, because a fused
     rank has no calibrated scale.
+
+    `title` IS THE SURFACE'S, and it is here because spec §4 says *títulos de artículos
+    acompañan a sus chunks* (B2, gate Codex on `b61e04b`). The chunker already copies it onto
+    every `KnowledgeChunk` for this exact reason — *with the title only on the surface, a
+    `SearchMatch` on chunk 7 of a long article would reach the consumer as an orphan
+    paragraph* — the writer stores it and `LexicalHit` hydrates it; the loss was here, in the
+    public projection, and only here. Optional because most surfaces name no work: a tweet
+    body, a summary and an image description have no title, and `None` is the honest value
+    for them rather than the item's URL or a neighbour's title. Metadata, so it needs no
+    origin — a title names a work rather than asserting anything about it.
     """
 
     model_config = _FROZEN
@@ -68,6 +148,7 @@ class SearchMatch(BaseModel):
     trust_class: TrustClass
     derived: bool
     excerpt: str
+    title: str | None = None
     attribution: Author | None = None
     matched_by: tuple[Channel, ...] = ()
     lexical_rank: int | None = None
@@ -124,7 +205,9 @@ class IndexStatusRef(BaseModel):
     """What the response says about the index that answered it (spec §5.6, §9.3).
 
     TWO SIGNALS WITH TWO NAMES (B3). `corrupt_chunks_excluded` counts rows whose fingerprint
-    does not recompute — corruption, or a row written by a different chunker version. That is
+    does not recompute — corruption, or a row written by a different chunker version — and,
+    since round 06 (B-k), rows whose surface cannot be resolved to a locator (spec §3.7
+    invariant 1), which are the same operator situation. That is
     an INTERNAL consistency check and it does not detect the failure that actually happens:
     *you ran `enrich` and did not reindex*. That one is a `degraded` flag
     (`"index_behind_store"`), raised by comparing the manifest's cheap store signal against
@@ -145,11 +228,11 @@ class IndexStatusRef(BaseModel):
 
 
 class SearchResponse(BaseModel):
-    """The `search` envelope (spec §7.2)."""
+    """The `search` envelope (spec §7.2). At `"2"` since `SearchMatch` gained its title."""
 
     model_config = _FROZEN
 
-    schema_version: Literal["1"] = "1"
+    schema_version: Literal["2"] = "2"
     query: str
     strategy: Strategy
     filters: SearchFilters
@@ -173,7 +256,10 @@ class EvidenceBundle(BaseModel):
 
     model_config = _FROZEN
 
-    schema_version: Literal["1"] = "1"
+    # "2" since round 07 (U-1): `KnowledgeChunk.locator` became required in round 06, and
+    # under `extra="forbid"` that is an incompatible change of THIS envelope — see the
+    # module docstring for the policy. A document announcing "1" is refused by its version.
+    schema_version: Literal["2"] = "2"
     item: KnowledgeItem
     topics: tuple[TopicRecord, ...] = ()
     surfaces: tuple[KnowledgeSurface, ...] = ()
@@ -234,6 +320,14 @@ class GraphExpansionResponse(BaseModel):
     nodes: tuple[GraphNode, ...] = ()
     edges: tuple[GraphEdge, ...] = ()
     paths: tuple[GraphPath, ...] = ()
+
+
+# The evidence envelope's version, read off the model so there is ONE definition (U-1). The
+# CLI's `knowledge inspect` payloads dump the same `KnowledgeSurface`/`KnowledgeChunk`/
+# `TopicRecord` shapes the bundle transports, and used to stamp "1" by hand — which is how a
+# bump here would have left them announcing the old number over the new shape.
+EVIDENCE_SCHEMA_VERSION: str = EvidenceBundle.model_fields["schema_version"].default
+SEARCH_SCHEMA_VERSION: str = SearchResponse.model_fields["schema_version"].default
 
 
 # Every model whose declared text fields the partition below must cover.
@@ -310,6 +404,7 @@ TEXT_FIELDS_WITHOUT_ORIGIN: frozenset[tuple[str, str]] = frozenset(
         ("SearchResult", "item_id"),
         ("SearchResult", "url"),
         ("SearchMatch", "chunk_id"),
+        ("SearchMatch", "title"),
         ("SearchFilters", "author"),
         ("IndexStatusRef", "manifest_version"),
         ("EvidenceBundle", "cursor"),

--- a/src/xbrain/knowledge/models.py
+++ b/src/xbrain/knowledge/models.py
@@ -11,7 +11,8 @@ THREE CONSTRAINTS CARRY THE WEIGHT, and each is asserted by the suite:
 * `frozen=True` — a surface whose text can be mutated after emission has a fingerprint that
   no longer means anything, and "the retrieved text is verbatim with respect to that
   surface" (spec §3.8) stops being checkable;
-* `extra="forbid"` — spec §7.1 freezes these shapes at `schema_version: "1"` so the CLI and
+* `extra="forbid"` — spec §7.1 freezes these shapes per envelope (`SearchResponse` "2",
+  `EvidenceBundle` "2") so the CLI and
   MCP adapters cannot drift; a model that swallows unknown keys lets a producer add a field
   no consumer ever sees;
 * fingerprints are pattern-constrained to lowercase sha256 hex, the same defence

--- a/src/xbrain/knowledge/models.py
+++ b/src/xbrain/knowledge/models.py
@@ -11,10 +11,9 @@ THREE CONSTRAINTS CARRY THE WEIGHT, and each is asserted by the suite:
 * `frozen=True` — a surface whose text can be mutated after emission has a fingerprint that
   no longer means anything, and "the retrieved text is verbatim with respect to that
   surface" (spec §3.8) stops being checkable;
-* `extra="forbid"` — spec §7.1 freezes these shapes per envelope (`SearchResponse` "2",
-  `EvidenceBundle` "2") so the CLI and
-  MCP adapters cannot drift; a model that swallows unknown keys lets a producer add a field
-  no consumer ever sees;
+* `extra="forbid"` — spec §7.1 freezes these shapes per envelope (today `SearchResponse` "2",
+  `EvidenceBundle` "1", the graph envelope "1") so the CLI and MCP adapters cannot drift; a
+  model that swallows unknown keys lets a producer add a field no consumer ever sees;
 * fingerprints are pattern-constrained to lowercase sha256 hex, the same defence
   `VerificationVerdict.output_fingerprint` already carries.
 

--- a/tests/test_knowledge_cli.py
+++ b/tests/test_knowledge_cli.py
@@ -76,8 +76,12 @@ def test_inspect_emits_pure_json_on_stdout(workspace: Path) -> None:
     payload = _json_stdout(runner.invoke(app, ["knowledge", "inspect", "k08", "--json"]))
     assert payload["item"]["item_id"] == "k08"
     # The version of the shapes it dumps, read off the contract and never stamped by hand
-    # (U-1): the surfaces and chunks in this payload are the `EvidenceBundle`'s.
-    assert payload["schema_version"] == EVIDENCE_SCHEMA_VERSION == "2"
+    # (U-1): the surfaces and chunks in this payload are the `EvidenceBundle`'s, which is at
+    # "1" until `KnowledgeChunk.locator` lands with it in child PR 02.5. That the value is
+    # DERIVED rather than a literal that happens to agree is a separate question, and
+    # equality against the current number cannot answer it — see
+    # `test_both_inspect_payloads_read_their_version_off_the_contract`.
+    assert payload["schema_version"] == EVIDENCE_SCHEMA_VERSION == "1"
 
 
 def test_inspect_returns_surfaces_with_provenance_and_locator(workspace: Path) -> None:
@@ -138,6 +142,41 @@ def test_inspect_a_topic(workspace: Path) -> None:
     assert payload["topic"]["slug"] == "agent-evaluation"
     assert payload["topic"]["overview"]["origin"] == "llm"
     assert {s["surface_type"] for s in payload["surfaces"]} >= {"topic_overview", "topic_note"}
+
+
+@pytest.mark.parametrize(
+    ("argv", "surface"),
+    [
+        (["knowledge", "inspect", "k08", "--json"], "_inspect_item"),
+        (["knowledge", "inspect", "--topic", "agent-evaluation", "--json"], "_inspect_topic"),
+    ],
+)
+def test_both_inspect_payloads_read_their_version_off_the_contract(
+    workspace: Path, monkeypatch, argv: list[str], surface: str
+) -> None:
+    """The stamp is DERIVED from `contracts.EVIDENCE_SCHEMA_VERSION`, not a literal that
+    currently agrees with it (U-1).
+
+    WHY EQUALITY IS NOT ENOUGH, and this test exists because the equality version was
+    measured NOT catching it: reverting `_inspect_topic` alone to a hardcoded `"1"` left the
+    whole suite green, because `"1"` is exactly what the contract says today. An assertion
+    that a payload equals the current number is satisfied by a payload that will never move
+    again — CLAUDE.md rule 1, satisfied for the wrong reason.
+
+    So the version is INJECTED instead. Both inspect helpers import the constant inside the
+    function body, at call time, which is what makes it reachable here; a hardcoded literal
+    cannot follow an injected value, so this goes red on the exact mutation the equality
+    assertion survived. The sentinel is deliberately a string no contract will ever declare,
+    so it cannot pass by coincidence at any future version.
+
+    Both payloads are covered because `_inspect_topic` had no assertion on its
+    `schema_version` at all: the item path was pinned and the topic path was free to drift.
+    """
+    import xbrain.knowledge.contracts as contracts
+
+    monkeypatch.setattr(contracts, "EVIDENCE_SCHEMA_VERSION", "sentinel-not-a-version")
+    payload = _json_stdout(runner.invoke(app, argv))
+    assert payload["schema_version"] == "sentinel-not-a-version", surface
 
 
 def test_inspect_an_unknown_item_is_an_actionable_error(workspace: Path) -> None:

--- a/tests/test_knowledge_cli.py
+++ b/tests/test_knowledge_cli.py
@@ -71,9 +71,13 @@ def test_inspect_emits_pure_json_on_stdout(workspace: Path) -> None:
     Parsed as a whole document, so one stray `print` fails this test instead of failing a
     consumer's parser weeks later, far from the cause.
     """
+    from xbrain.knowledge.contracts import EVIDENCE_SCHEMA_VERSION
+
     payload = _json_stdout(runner.invoke(app, ["knowledge", "inspect", "k08", "--json"]))
     assert payload["item"]["item_id"] == "k08"
-    assert payload["schema_version"] == "1"
+    # The version of the shapes it dumps, read off the contract and never stamped by hand
+    # (U-1): the surfaces and chunks in this payload are the `EvidenceBundle`'s.
+    assert payload["schema_version"] == EVIDENCE_SCHEMA_VERSION == "2"
 
 
 def test_inspect_returns_surfaces_with_provenance_and_locator(workspace: Path) -> None:

--- a/tests/test_knowledge_contracts.py
+++ b/tests/test_knowledge_contracts.py
@@ -1,9 +1,9 @@
 # tests/test_knowledge_contracts.py
 """The frozen external schemas (Plan 01 §3.5, spec §7, steps 19-20).
 
-These shapes are frozen per envelope NOW (`SearchResponse` "1", `EvidenceBundle` "2" since
-U-1, the graph envelope "1"), while the services that fill them do
-not exist yet. That is the point: spec §7.1 says CLI JSON and MCP are adapters over the same
+These shapes are frozen per envelope NOW (`SearchResponse` "2" since `SearchMatch` gained
+its title, `EvidenceBundle` "1", the graph envelope "1"), while the services that fill them
+do not exist yet. That is the point: spec §7.1 says CLI JSON and MCP are adapters over the same
 service and must not implement two formats, and the way two formats appear is that the
 second adapter is written months after the first, against whatever the first happened to
 emit. Freezing the model first makes the second adapter a consumer rather than an author.
@@ -151,23 +151,26 @@ def test_a_search_match_serializes_its_excerpt_next_to_its_origin() -> None:
 # ---------------------------------------------------------------------------
 
 
-# The version each envelope carries TODAY, and why (U-1, round 07). `SearchResponse` and
-# `GraphExpansionResponse` is still the Plan 01 freeze: nothing in its shape moved.
-# `EvidenceBundle` is at "2" because round 06
-# made `KnowledgeChunk.locator` REQUIRED, and under `extra="forbid"` that is the incompatible
-# change the freeze exists to name: the Pydantic consumer of version 1 refuses a bundle with
-# the key (`chunks.0.locator: Extra inputs are not permitted`, measured against the exact
-# `origin/develop` model) and the new consumer refuses a version-1 document (`Field
-# required`). Two producers announcing one version that do not interoperate is the silent
-# mutation spec §7.1 forbids; the number is what makes the refusal honest.
-# `SearchResponse` is at "2" for the same rule read forwards (B2): `SearchMatch` gained the
-# `title` spec §4 makes accompany a chunk, and a DEFAULTED key is additive only for the new
-# consumer — the version-1 one forbids it, so the number moves for its refusal to name the
-# version. A bump nobody needs makes two adapters disagree; a bump nobody made makes them
-# disagree silently, which is worse.
+# The version each envelope carries TODAY, and why (U-1). `EvidenceBundle` and
+# `GraphExpansionResponse` are still the Plan 01 freeze: nothing in the shapes they transport
+# has moved in this PR.
+#
+# `SearchResponse` is at "2" (B2, gate Codex on `b61e04b`): `SearchMatch` gained the `title`
+# spec §4 makes accompany a chunk, and under `extra="forbid"` a DEFAULTED key is additive only
+# for the NEW consumer — the version-1 one forbids it outright, so the number moves for its
+# refusal to name the version rather than a field nobody told it about.
+#
+# `EvidenceBundle` STAYS at "1", and that is the same rule read backwards. Its queued bump
+# means one specific thing — `KnowledgeChunk.locator` required (spec §3.7 invariant 2) — and
+# that field lands in child PR 02.5 with the `chunking.fragment_locator` that computes it.
+# A number is a claim about a shape, so it ships with the shape: announcing "2" here would
+# publish a version whose only meaning is a field this build does not have, and the
+# refusal-by-version the policy exists to buy would name a version that describes nothing.
+# A bump nobody needs makes two adapters disagree; a bump nobody made makes them disagree
+# silently. Both are failures, and the first is the one this table now records.
 ENVELOPE_VERSIONS: dict[type, str] = {
     SearchResponse: "2",
-    EvidenceBundle: "2",
+    EvidenceBundle: "1",
     GraphExpansionResponse: "1",
 }
 
@@ -175,45 +178,41 @@ ENVELOPE_VERSIONS: dict[type, str] = {
 @pytest.mark.parametrize("model", [SearchResponse, EvidenceBundle, GraphExpansionResponse])
 def test_every_response_declares_its_schema_version(model) -> None:
     """Spec §7.1: every contract carries `schema_version`, and an incompatible change needs
-    a new version rather than a silent mutation. Seen red on `9dfa34e`: `EvidenceBundle`
-    still said "1" over a shape its own version-1 model refuses."""
+    a new version rather than a silent mutation — so the numbers are no longer one shared
+    literal but one per envelope, and this table is where they are stated once.
+
+    `EVIDENCE_SCHEMA_VERSION` is checked here against the same table because it is what the
+    CLI stamps its payloads with: the module constant and the model must not be two numbers.
+    """
     assert model.model_fields["schema_version"].default == ENVELOPE_VERSIONS[model]
-    assert (
-        getattr(__import__("xbrain.knowledge.contracts", fromlist=["x"]), "EVIDENCE_SCHEMA_VERSION")
-        == ENVELOPE_VERSIONS[EvidenceBundle]
-    )
+    assert contracts_module.EVIDENCE_SCHEMA_VERSION == ENVELOPE_VERSIONS[EvidenceBundle]
+    assert contracts_module.SEARCH_SCHEMA_VERSION == ENVELOPE_VERSIONS[SearchResponse]
 
 
-def _bundle_document() -> dict:
-    """A bundle as `get --query` emits it: one chunk — serialised.
+def test_the_evidence_envelope_stays_at_one_until_the_shape_it_names_arrives() -> None:
+    """The PRESENT boundary of the evidence envelope, bound to the shape it describes (U-1).
 
-    FRONTIER ADAPTATION, declared (child PR 02.1). The snapshot builds this chunk with
-    `locator=Locator(kind="item_text", char_start=0, char_end=6)`, because
-    `KnowledgeChunk.locator` is REQUIRED there. That field arrives with
-    `chunking.fragment_locator`, which computes it, in child PR 02.5 — porting it here would
-    drag `chunking.py` into a PR whose one subject is the version of the envelopes. The
-    version half of the transition is what 02.1 owns and it is ported byte for byte; the
-    locator half of `test_a_version_one_bundle_is_refused_by_its_version_not_by_a_field`
-    is deferred to 02.5 with it.
+    A version number is a claim about a shape, and the only claim queued for this envelope is
+    `KnowledgeChunk.locator` — required by spec §3.7 invariant 2, computed by
+    `chunking.fragment_locator`, and landing with it in child PR 02.5. So the two halves are
+    asserted as ONE biconditional rather than as two independent facts: while chunks carry no
+    locator this envelope is "1", and the PR that makes the locator required is the PR that
+    makes this "2". Bump the number without the field and this goes red; add the field without
+    the number and it goes red too. That is the check rule 5 asks for — the number and the
+    shape bound in code, not in two comments that "should" agree.
+
+    The second half is the freeze itself, at the number that is actually current: substitute
+    ANY other version into an emitted document and the refusal names `schema_version` and
+    nothing else. That is what "an incompatible change needs a new version rather than a
+    silent mutation" buys, and it is checkable today without pretending a later shape exists.
     """
     from xbrain.knowledge.models import KnowledgeChunk
 
-    chunk = KnowledgeChunk(
-        chunk_id="item:1:post:0:0:v2",
-        surface_id="item:1:post:0",
-        owner_type="item",
-        owner_id="1",
-        surface_type="post",
-        text="cuerpo",
-        chunk_index=0,
-        char_start=0,
-        char_end=6,
-        origin="source",
-        trust_class="primary_source",
-        derived=False,
-        fingerprint="a" * 64,
-    )
-    bundle = EvidenceBundle(
+    chunks_carry_a_locator = "locator" in KnowledgeChunk.model_fields
+    assert chunks_carry_a_locator is (EvidenceBundle.model_fields["schema_version"].default == "2")
+    assert not chunks_carry_a_locator, "02.5 landed the locator: bump the bundle with it"
+
+    document = EvidenceBundle(
         item=KnowledgeItem(
             item_id="1",
             source="bookmark",
@@ -222,36 +221,13 @@ def _bundle_document() -> dict:
             created_at=datetime(2026, 1, 1, tzinfo=UTC),
             captured_at=datetime(2026, 1, 2, tzinfo=UTC),
         ),
-        chunks=(chunk,),
-    )
-    return bundle.model_dump(mode="json")
+    ).model_dump(mode="json")
+    assert document["schema_version"] == contracts_module.EVIDENCE_SCHEMA_VERSION == "1"
 
-
-def test_a_version_one_bundle_is_refused_by_its_version_not_by_a_field() -> None:
-    """The transition is EXPLICIT (U-1): a document that announces `schema_version: "1"`
-    — the shape whose chunks had no locator — is refused because it is version 1, and the
-    refusal names the version. A document at "2" whose chunk lacks the locator is refused
-    too, because the locator is what "2" means (spec §3.7 invariant 2). Neither is a
-    silent acceptance and neither is a silent mutation.
-
-    Seen red on `9dfa34e`: the version-1 document validated (same literal), and only the
-    missing key was refused — a version-1 consumer and a version-2 producer under one number.
-
-    FRONTIER ADAPTATION, declared (child PR 02.1): the second half of the snapshot's
-    assertion — *a document at "2" whose chunk lacks the locator is refused too* — needs
-    `KnowledgeChunk.locator` to be required, which lands in 02.5 with the
-    `chunking.fragment_locator` that fills it. Ported here: the half that is about the
-    VERSION, which is this PR's whole subject. The bundle at "2" therefore announces, for
-    the 02.1..02.4 window, a shape whose chunk locator is not yet required — declared in
-    the PR description, closed by 02.5.
-    """
-    document = _bundle_document()
-    assert document["schema_version"] == "2"
-
-    legacy = {**document, "schema_version": "1"}
-    with pytest.raises(ValidationError) as refused:
-        EvidenceBundle.model_validate(legacy)
-    assert {error["loc"] for error in refused.value.errors()} == {("schema_version",)}
+    for impostor in ("2", "0", "1.0"):
+        with pytest.raises(ValidationError) as refused:
+            EvidenceBundle.model_validate({**document, "schema_version": impostor})
+        assert {error["loc"] for error in refused.value.errors()} == {("schema_version",)}
 
 
 def test_the_search_envelope_moved_when_a_key_was_added_to_the_shape_it_transports() -> None:

--- a/tests/test_knowledge_contracts.py
+++ b/tests/test_knowledge_contracts.py
@@ -25,10 +25,12 @@ really does travel with an origin.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import get_args
 
 import pytest
 from pydantic import ValidationError
 
+from xbrain.knowledge import contracts as contracts_module
 from xbrain.knowledge.contracts import (
     CONTRACT_MODELS,
     TEXT_FIELDS_REQUIRING_ORIGIN,
@@ -41,8 +43,11 @@ from xbrain.knowledge.contracts import (
     SearchMatch,
     SearchResponse,
     SearchResult,
+    NOT_IMPLEMENTED_SUFFIX,
     SEARCH_SCHEMA_VERSION,
+    Strategy,
     is_str_field,
+    resolve_strategy,
 )
 from xbrain.knowledge.models import KnowledgeItem, Locator
 from xbrain.models import Author
@@ -303,6 +308,57 @@ def test_the_search_envelope_moved_when_a_key_was_added_to_the_shape_it_transpor
     with pytest.raises(ValidationError) as refused:
         SearchResponse.model_validate(legacy)
     assert {error["loc"] for error in refused.value.errors()} == {("schema_version",)}
+
+
+# FRONTIER ADDITION, declared (child PR 02.1). `resolve_strategy` ships here, but at the
+# snapshot every test that exercises it lives in `tests/test_knowledge_evaluation.py` and
+# `tests/test_knowledge_search_service.py` — both later children, and both coupled to
+# services 02.1 does not ship. Porting nothing would land the function untested in the PR
+# that introduces it. These three tests are the three outcomes of its own docstring.
+
+
+def test_an_implemented_strategy_runs_and_degrades_nothing() -> None:
+    """The first outcome. `lexical` is the one member with a backend in this build."""
+    assert resolve_strategy("lexical") == ("lexical", ())
+
+
+def test_a_declared_strategy_with_no_backend_degrades_and_says_so() -> None:
+    """The second outcome, and the one F-2 exists for (spec §9.3).
+
+    `search` echoed the strategy it was ASKED for, so `strategy="hybrid"` came back labelled
+    `hybrid` over results produced entirely by bm25. Degradation is not refusal — *lexical
+    sigue operativo* — but it has to be NAMED, and the name is the requested strategy, so a
+    reader can tell which one did not run.
+    """
+    for declared in set(get_args(Strategy)) - contracts_module.IMPLEMENTED_STRATEGIES:
+        strategy, degraded = resolve_strategy(declared)
+        assert strategy == contracts_module.FALLBACK_STRATEGY == "lexical"
+        assert degraded == (f"{declared}{NOT_IMPLEMENTED_SUFFIX}",)
+
+
+def test_an_undeclared_strategy_is_a_validation_error_never_a_degradation() -> None:
+    """The third outcome. A typo answered with lexical results becomes a measurement: the
+    report would be headed `lexicl` and scored by a retriever nobody asked for. The message
+    names both sets, because "unknown" is useless without "known"."""
+    with pytest.raises(ValueError) as refused:
+        resolve_strategy("lexicl")
+    assert "lexicl" in str(refused.value)
+    assert "hybrid_graph" in str(refused.value)
+
+
+def test_the_implemented_set_is_read_at_call_time_not_closed_over(monkeypatch) -> None:
+    """Plan 03 adds its member to `IMPLEMENTED_STRATEGIES` and both surfaces stop degrading
+    with no other change — so the lookup must reach the module global when it is CALLED.
+
+    Asserted by injecting a hypothetical backend rather than by reading the source: a
+    `frozenset` captured at import time would keep degrading `vector` here, and the test
+    then does not depend on `vector` staying unimplemented forever.
+    """
+    assert resolve_strategy("vector") == ("lexical", ("vector_not_implemented",))
+    monkeypatch.setattr(
+        contracts_module, "IMPLEMENTED_STRATEGIES", frozenset({"lexical", "vector"})
+    )
+    assert resolve_strategy("vector") == ("vector", ())
 
 
 def test_responses_reject_an_unknown_field() -> None:

--- a/tests/test_knowledge_contracts.py
+++ b/tests/test_knowledge_contracts.py
@@ -1,7 +1,8 @@
 # tests/test_knowledge_contracts.py
 """The frozen external schemas (Plan 01 §3.5, spec §7, steps 19-20).
 
-These shapes are frozen at `schema_version: "1"` NOW, while the services that fill them do
+These shapes are frozen per envelope NOW (`SearchResponse` "1", `EvidenceBundle` "2" since
+U-1, the graph envelope "1"), while the services that fill them do
 not exist yet. That is the point: spec §7.1 says CLI JSON and MCP are adapters over the same
 service and must not implement two formats, and the way two formats appear is that the
 second adapter is written months after the first, against whatever the first happened to
@@ -40,6 +41,7 @@ from xbrain.knowledge.contracts import (
     SearchMatch,
     SearchResponse,
     SearchResult,
+    SEARCH_SCHEMA_VERSION,
     is_str_field,
 )
 from xbrain.knowledge.models import KnowledgeItem, Locator
@@ -144,11 +146,163 @@ def test_a_search_match_serializes_its_excerpt_next_to_its_origin() -> None:
 # ---------------------------------------------------------------------------
 
 
+# The version each envelope carries TODAY, and why (U-1, round 07). `SearchResponse` and
+# `GraphExpansionResponse` is still the Plan 01 freeze: nothing in its shape moved.
+# `EvidenceBundle` is at "2" because round 06
+# made `KnowledgeChunk.locator` REQUIRED, and under `extra="forbid"` that is the incompatible
+# change the freeze exists to name: the Pydantic consumer of version 1 refuses a bundle with
+# the key (`chunks.0.locator: Extra inputs are not permitted`, measured against the exact
+# `origin/develop` model) and the new consumer refuses a version-1 document (`Field
+# required`). Two producers announcing one version that do not interoperate is the silent
+# mutation spec §7.1 forbids; the number is what makes the refusal honest.
+# `SearchResponse` is at "2" for the same rule read forwards (B2): `SearchMatch` gained the
+# `title` spec §4 makes accompany a chunk, and a DEFAULTED key is additive only for the new
+# consumer — the version-1 one forbids it, so the number moves for its refusal to name the
+# version. A bump nobody needs makes two adapters disagree; a bump nobody made makes them
+# disagree silently, which is worse.
+ENVELOPE_VERSIONS: dict[type, str] = {
+    SearchResponse: "2",
+    EvidenceBundle: "2",
+    GraphExpansionResponse: "1",
+}
+
+
 @pytest.mark.parametrize("model", [SearchResponse, EvidenceBundle, GraphExpansionResponse])
-def test_every_response_declares_schema_version_one(model) -> None:
+def test_every_response_declares_its_schema_version(model) -> None:
     """Spec §7.1: every contract carries `schema_version`, and an incompatible change needs
-    a new version rather than a silent mutation."""
-    assert model.model_fields["schema_version"].default == "1"
+    a new version rather than a silent mutation. Seen red on `9dfa34e`: `EvidenceBundle`
+    still said "1" over a shape its own version-1 model refuses."""
+    assert model.model_fields["schema_version"].default == ENVELOPE_VERSIONS[model]
+    assert (
+        getattr(__import__("xbrain.knowledge.contracts", fromlist=["x"]), "EVIDENCE_SCHEMA_VERSION")
+        == ENVELOPE_VERSIONS[EvidenceBundle]
+    )
+
+
+def _bundle_document() -> dict:
+    """A bundle as `get --query` emits it: one chunk — serialised.
+
+    FRONTIER ADAPTATION, declared (child PR 02.1). The snapshot builds this chunk with
+    `locator=Locator(kind="item_text", char_start=0, char_end=6)`, because
+    `KnowledgeChunk.locator` is REQUIRED there. That field arrives with
+    `chunking.fragment_locator`, which computes it, in child PR 02.5 — porting it here would
+    drag `chunking.py` into a PR whose one subject is the version of the envelopes. The
+    version half of the transition is what 02.1 owns and it is ported byte for byte; the
+    locator half of `test_a_version_one_bundle_is_refused_by_its_version_not_by_a_field`
+    is deferred to 02.5 with it.
+    """
+    from xbrain.knowledge.models import KnowledgeChunk
+
+    chunk = KnowledgeChunk(
+        chunk_id="item:1:post:0:0:v2",
+        surface_id="item:1:post:0",
+        owner_type="item",
+        owner_id="1",
+        surface_type="post",
+        text="cuerpo",
+        chunk_index=0,
+        char_start=0,
+        char_end=6,
+        origin="source",
+        trust_class="primary_source",
+        derived=False,
+        fingerprint="a" * 64,
+    )
+    bundle = EvidenceBundle(
+        item=KnowledgeItem(
+            item_id="1",
+            source="bookmark",
+            url="https://x.com/a/status/1",
+            author=Author(handle="a", name="A"),
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            captured_at=datetime(2026, 1, 2, tzinfo=UTC),
+        ),
+        chunks=(chunk,),
+    )
+    return bundle.model_dump(mode="json")
+
+
+def test_a_version_one_bundle_is_refused_by_its_version_not_by_a_field() -> None:
+    """The transition is EXPLICIT (U-1): a document that announces `schema_version: "1"`
+    — the shape whose chunks had no locator — is refused because it is version 1, and the
+    refusal names the version. A document at "2" whose chunk lacks the locator is refused
+    too, because the locator is what "2" means (spec §3.7 invariant 2). Neither is a
+    silent acceptance and neither is a silent mutation.
+
+    Seen red on `9dfa34e`: the version-1 document validated (same literal), and only the
+    missing key was refused — a version-1 consumer and a version-2 producer under one number.
+
+    FRONTIER ADAPTATION, declared (child PR 02.1): the second half of the snapshot's
+    assertion — *a document at "2" whose chunk lacks the locator is refused too* — needs
+    `KnowledgeChunk.locator` to be required, which lands in 02.5 with the
+    `chunking.fragment_locator` that fills it. Ported here: the half that is about the
+    VERSION, which is this PR's whole subject. The bundle at "2" therefore announces, for
+    the 02.1..02.4 window, a shape whose chunk locator is not yet required — declared in
+    the PR description, closed by 02.5.
+    """
+    document = _bundle_document()
+    assert document["schema_version"] == "2"
+
+    legacy = {**document, "schema_version": "1"}
+    with pytest.raises(ValidationError) as refused:
+        EvidenceBundle.model_validate(legacy)
+    assert {error["loc"] for error in refused.value.errors()} == {("schema_version",)}
+
+
+def test_the_search_envelope_moved_when_a_key_was_added_to_the_shape_it_transports() -> None:
+    """The version policy applied to `SearchMatch.title` (B2, gate Codex on `b61e04b`).
+
+    Round 06's bundle bump did NOT move this envelope, and the reason was stated as a fact
+    about the shape: *`SearchMatch` carried `locator` from the Plan 01 freeze, so the search
+    envelope's shape did not change and its version must not.* Spec §4's title changes the
+    shape, so the same rule now points the other way — *a key added to a frozen shape BUMPS
+    the version of every envelope that transports it* — and `SearchResponse` is the one
+    envelope that transports a `SearchMatch`.
+
+    Optional-with-a-default does not exempt it. Every model here is `extra="forbid"`, so it
+    is the version-1 CONSUMER that breaks: it refuses a document carrying `title` outright,
+    and the refusal has to name the version rather than a field nobody told it about. That
+    is exactly the U-1 case, running in the other direction.
+    """
+    assert "locator" in SearchMatch.model_fields
+    assert SearchMatch.model_fields["locator"].is_required()
+    assert SearchResponse.model_fields["schema_version"].default == "2"
+    assert SEARCH_SCHEMA_VERSION == "2"
+
+    document = SearchResponse(
+        query="q",
+        strategy="lexical",
+        filters=SearchFilters(),
+        index=IndexStatusRef(manifest_version="1", built_at=datetime(2026, 1, 1, tzinfo=UTC)),
+        results=(
+            SearchResult(
+                rank=1,
+                item_id="1",
+                url="https://x.com/a/status/1",
+                author=Author(handle="a", name="A"),
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+                matches=(
+                    SearchMatch(
+                        chunk_id="c",
+                        surface_type="external_article",
+                        origin="source",
+                        trust_class="primary_source",
+                        derived=False,
+                        excerpt="x",
+                        title="On Controls and Thresholds",
+                        locator=Locator(kind="content_source", char_start=0, char_end=1),
+                    ),
+                ),
+            ),
+        ),
+    ).model_dump(mode="json")
+    assert document["schema_version"] == "2"
+    assert document["results"][0]["matches"][0]["title"] == "On Controls and Thresholds"
+
+    legacy = {**document, "schema_version": "1"}
+    with pytest.raises(ValidationError) as refused:
+        SearchResponse.model_validate(legacy)
+    assert {error["loc"] for error in refused.value.errors()} == {("schema_version",)}
 
 
 def test_responses_reject_an_unknown_field() -> None:

--- a/tests/test_knowledge_models.py
+++ b/tests/test_knowledge_models.py
@@ -96,9 +96,11 @@ def test_models_are_frozen(factory) -> None:
 def test_models_forbid_unknown_fields(factory) -> None:
     """`extra="forbid"` — a misspelled field must be an error, not a silent no-op.
 
-    Spec §7.1 freezes these shapes at `schema_version: "1"` so CLI and MCP cannot diverge.
-    A model that swallows unknown keys lets a producer "add" a field that no consumer ever
-    sees, which is the drift the freeze exists to prevent.
+    These shapes carry no `schema_version` of their own: the number lives on the envelopes
+    that transport them, and `contracts.py` states that policy once, versioning each envelope
+    independently. So a model that swallows unknown keys lets a producer "add" a field that no
+    consumer ever sees AND that no envelope number could ever announce — the drift spec §7.1
+    exists to prevent, CLI and MCP implementing two formats, arriving unversioned.
     """
     with pytest.raises(ValidationError):
         factory(definitely_not_a_field=1)


### PR DESCRIPTION
Child PR **02.1** of the knowledge-index umbrella. Base **`VGonPa/umbrella-knowledge-index-lexical`** (never `develop`).

## One subject

**Each response envelope is versioned on its own, and a strategy without a backend is named instead of faked.**

The freeze was written as one number for three envelopes (*"frozen at `schema_version: "1"`"*), and under `extra="forbid"` that number cannot be shared. Measured on the umbrella base before any edit:

```
SearchResponse.schema_version default = '1'   (want '2')
'title' in SearchMatch.model_fields = False   (want True)
SearchMatch(title=...) REFUSED: extra_forbidden at ('title',)
resolve_strategy ABSENT -> 'hybrid' is echoed back as if it ran
```

That last pair *is* the argument: the only consumer that exists refuses the new shape while accepting the old announcement — two producers under one version that do not interoperate.

So:

| Envelope | Version | Why it moved |
|---|---|---|
| `SearchResponse` | "1" → **"2"** | `SearchMatch` gains the `title` spec §4 makes accompany a chunk (**B2**) |
| `EvidenceBundle` | **"1"** | its bump *means* `KnowledgeChunk.locator` required — the field lands in **02.5**, so the number goes with it |
| `GraphExpansionResponse` | **"1"** | nothing in its shape moved |

> **Corrected after two independent review FAILs.** An earlier revision of this PR moved `EvidenceBundle` to **"2"** as well. It cannot: on this tree `"locator" in KnowledgeChunk.model_fields` is **False**, so `"2"` would announce a version whose *only* meaning is a field this build does not have — a consumer told to expect the locator finds none, and the refusal-by-version the policy exists to buy names a version that describes nothing. **A version number is a claim about a shape, so it ships with the shape.** The bundle stays at "1" here; the bump, the `locator`, `chunking.fragment_locator` and the producers that fill it land together in **02.5**, and the version-1-document-refused test moves with them. **The honest triple today: Search 2 / Evidence 1 / Graph 1** — stated identically in `contracts.py`, `models.py`, `ARCHITECTURE.md` and the tests.

**Optional-with-a-default is not an exemption** — a defaulted key is additive for the new consumer and *forbidden* for the old one, so the number moves for the refusal to name the version rather than a field nobody told it about.

`EVIDENCE_SCHEMA_VERSION` / `SEARCH_SCHEMA_VERSION` are **read off the models**, and `cli.py`'s two `knowledge inspect` payloads now read them instead of stamping `"1"` by hand — which is how 02.5's bump reaches the CLI without anyone having to remember (rule 5). Both therefore emit **"1"** today.

`resolve_strategy` turns the file's own prose (*"this PR ships only `lexical`"*) into `IMPLEMENTED_STRATEGIES`, because prose is not readable by the two surfaces that label their output with a strategy name. Three outcomes: implemented → runs; declared-but-unbacked → degrades to lexical and says `<requested>_not_implemented` (spec §9.3, *lexical sigue operativo*); undeclared → `ValueError`, because a typo answered with lexical results becomes a measurement.

## Bytes ported vs. adaptations

**Source:** `refs/heads/VGonPa/knowledge-lexical-snapshot-fix-09` @ `1d30554d86781056259532f417f5117f11ef4cf8`, tree `85a5ccf906673b5c6bc94fe30f10780d1e308139` (the FINAL corrected snapshot; `b61e04b` preserved for reference). Ported with `git checkout <snapshot> -- <path>` or byte-for-byte replacement — nothing retyped.

**Ported verbatim**
- `src/xbrain/knowledge/contracts.py` — whole file (`git checkout`, +107/−8)
- `tests/test_knowledge_contracts.py` — whole file, minus the deferrals below
- `src/xbrain/cli.py` — the 4 in-scope edits (2 imports, 2 `schema_version` reads)
- `tests/test_knowledge_cli.py` — the 2 in-scope edits

**Four adaptations, each declared in place in a comment or docstring**

1. **The snapshot's `EvidenceBundle` bump and its `test_a_version_one_bundle_is_refused_by_its_version_not_by_a_field` are deferred WHOLE to 02.5**, rather than ported with the locator half amputated. The earlier revision kept the number and dropped the field; two reviewers failed it, correctly. In its place this PR has `test_the_evidence_envelope_stays_at_one_until_the_shape_it_names_arrives`, a **present** boundary that is a binding and not a restatement: the locator's presence and the number are asserted as ONE biconditional, so a bump without the field goes red **and** the field without a bump goes red. Both directions were watched red before green.
2. **`_inspect_item` keeps its `item_surfaces(item, transcribe_command=…, vision_command=…)` call.** The snapshot's *same hunk* also collapses it to `item_surfaces(item)` (F7-7 provenance); that belongs to **02.2**. The two are contiguous non-overlapping blocks, so the import is inserted between them and 02.2 lands next to an already-present import.
3. **`ARCHITECTURE.md` and `models.py` state the full current triple** (`SearchResponse "2"`, `EvidenceBundle "1"`, graph `"1"`) where the snapshot's prose still says `"1"` for all three. ⚠️ **These two lines are stale in the snapshot itself**, against its own `contracts.py` (which is at `"2"`, docstring *"At `"2"` since `SearchMatch` gained its title"*). The B2 correction reached the code and the tests and not the prose. Porting the byte verbatim would ship a documented contradiction *inside the diff whose entire subject is that number* — the divergence rule 5 exists to stop. **The deviation is one character per line.** Found independently by two agents. **Worth propagating to the snapshot.**
4. **`resolve_strategy` gets its own three-outcome test here.** At the snapshot it is exercised only from `tests/test_knowledge_evaluation.py` (02.13) and `tests/test_knowledge_search_service.py` (02.9) — both later children, both coupled to services this PR does not ship. Porting nothing would land the function **untested in the PR that introduces it**.

**Explicitly NOT ported** (later children): `search_service.py`, `lexical.py`, `render.py`, `index_build.py`, `index_schema.py`, `index_store.py`, `get_service.py`, `config.py`/`config.toml.example`, `evaluation.py`; in `cli.py` the whole `index`/`search`/`get` block, `_render_inspect`→`render`, `IndexError_`, `cfg.vocab_path`, `_run_sweep`; in `tests/test_knowledge_cli.py` the +718-line index/search/get block and `import shlex` (unused here → ruff F401).

## Tests

**Red first, and strong.** The import-error red was rejected as weak evidence (rule 1: *a test that fails only because a symbol does not import yet is not a demonstration*). A probe run against the umbrella base reproduced the **defect itself** — the six lines quoted at the top, exit 1.

**Every new assertion was watched red on the defect it names**, by mutation:

| Mutation | Result |
|---|---|
| `EvidenceBundle` → `"2"` with no locator on the chunk | ❌ 4 red (the boundary test + the 3 table params) |
| `KnowledgeChunk.locator` added, number left at `"1"` | ❌ red — the biconditional cuts both ways |
| `_inspect_topic` → hardcoded `"1"` | ❌ red *(green before this PR: 35 passed)* |
| `_inspect_item` → hardcoded `"1"` | ❌ red |
| `IMPLEMENTED_STRATEGIES` bound as a default argument | ❌ red, other 19 green |

Then green:

```
tests/test_knowledge_contracts.py .................... 20 passed
targeted (contracts + cli + surfaces + evidence char.)  51 passed
```

## Gate

`bash scripts/check.sh` on the **proven merge result** — `git merge-tree --write-tree origin/VGonPa/umbrella-knowledge-index-lexical HEAD` = `4c498348f3054a8bac891b71b535b7b46ba030c6` = `HEAD^{tree}`, so testing HEAD *is* testing the merge (rule 4):

```
✅ Ruff (linting) · Ruff (format) · Mypy · Bandit · Vulture · Interrogate 91.0%
✅ Detect-secrets · Deptry
✅ Tests  PASS - 2188 tests        ✅ Coverage 95%    ✅ Coverage (knowledge/) 98%
⚠️  Radon  WARN - Has grade C       (pre-existing on the base, untouched by this PR)
ALL CRITICAL CHECKS PASSED
```

## Residue, declared

- **There is no longer an `EvidenceBundle` "2" window.** The previous revision opened one across 02.1..02.4 and declared it as acceptable residue; it was not, and this is the correction. Nothing persists a bundle at any number (the index stores `locator_json` per surface), so 02.5's bump needs no migration.
- **`EVIDENCE_SCHEMA_VERSION` cannot be pinned by equality, so it is pinned by injection.** It is *defined by reading* the model default, so asserting it against the same number adds nothing — and that was measured, not reasoned: reverting `_inspect_topic` alone to a hardcoded `"1"` left the suite **green (35 passed)**. `test_both_inspect_payloads_read_their_version_off_the_contract` injects a version no contract will ever declare and asserts both payloads carry it; the mutation now fails, on the topic path *and* on the item path.
- `SearchMatch.title` is **declared, not populated** — population arrives in **02.9**.
- **Internal plans excluded.** Nothing under `zz-support-files/` was read-written, added, staged or committed; the recorte report was consulted read-only from the main checkout. `git status` is clean apart from this branch's six files.

## Provenance

- Snapshot (FINAL, corrected): `1d30554d86781056259532f417f5117f11ef4cf8` · tree `85a5ccf906673b5c6bc94fe30f10780d1e308139`
- Also preserved: `refs/heads/VGonPa/knowledge-lexical-index` @ `b61e04bc57ef03c56319e8180d42efebc45d179f`
- Umbrella base at branch time, at first push and at this correction's push: `0bd9527321c8bb34bcdc4fc1316c2ad8521fb13b` (unmoved — no sync child needed)
- Correction commit: `2ae0e9138cbd3a7400ef0062f2eeae9aad078e86` (on `3eb5d12185ca857bc456051f4b925ea1a8a6aef3`)

Draft on purpose: **not self-reviewed, not merged.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCai8cpVLAQh5FCvk1xedw

