### PR TITLE
feat(knowledge): honest provenance — no producer for ASR/VLM surfaces (child 02.2)

### DIFF
--- a/src/xbrain/cli.py
+++ b/src/xbrain/cli.py
@@ -2827,11 +2827,7 @@ def _inspect_item(corpus, item_id: str, *, want_surfaces: bool, want_chunks: boo
         )
     from xbrain.knowledge.surfaces import knowledge_item
 
-    surfaces = item_surfaces(
-        item,
-        transcribe_command=cfg.transcribe_command,
-        vision_command=cfg.vision_command,
-    )
+    surfaces = item_surfaces(item)
     from xbrain.knowledge.contracts import EVIDENCE_SCHEMA_VERSION
 
     payload: dict = {

--- a/src/xbrain/knowledge/models.py
+++ b/src/xbrain/knowledge/models.py
@@ -196,9 +196,19 @@ class KnowledgeSurface(BaseModel):
 
     `producer` and `produced_at` answer spec §3.4's *method or component that produced it*
     and *instant of capture/generation*. They are populated from data already in the store
-    (`enriched.executor`, `MediaPhotoDescribed.description_version`/`described_at`, the
-    configured transcribe/vision command, `TopicPage.synthesized_at`) and are `None` only
-    where the format genuinely does not record it.
+    (`enriched.executor`, `MediaPhotoDescribed.description_version`/`described_at`,
+    `TopicPage.synthesized_at`, `content.fetched_at`) and are `None` where the format
+    genuinely does not record it — which INCLUDES `video_transcript` and `video_frame`
+    (F7-7, round 08): the `x_video` source records neither the transcriber nor the vision
+    command that wrote the text. Until round 08 those two surfaces carried the command
+    CONFIGURED when the surface was emitted; measured on the real corpus, changing
+    `[transcribe].command` to `whisper-large-v3` made `get` serve `producer:
+    whisper-large-v3` for a transcript parakeet wrote, text and fingerprints identical — a
+    provenance claim the store cannot back, and spec §3.4 says the unknown is not filled in
+    by intuition. It is `None` now, the origin (`asr`/`vlm`, `machine_generated`) is still
+    declared, and the honest fix — stamping the producer on the source when `digest-video`
+    attaches the transcript, as `caption_contract` does for frames — is a store change
+    outside Plan 02, recorded as an open issue for Plan 03.
     """
 
     model_config = _FROZEN

--- a/src/xbrain/knowledge/surfaces.py
+++ b/src/xbrain/knowledge/surfaces.py
@@ -189,12 +189,7 @@ def _surface(
     )
 
 
-def item_surfaces(
-    item: Item,
-    *,
-    transcribe_command: str | None = None,
-    vision_command: str | None = None,
-) -> tuple[KnowledgeSurface, ...]:
+def item_surfaces(item: Item) -> tuple[KnowledgeSurface, ...]:
     """Every indexable surface of one item, in a deterministic order.
 
     Order: the post, then each content source in `content.sources` order (a video
@@ -203,10 +198,17 @@ def item_surfaces(
     because two runs over the same store must produce the same ids and the same ranking
     (spec §3.7.8).
 
-    `transcribe_command` and `vision_command` are the only producers that do NOT live in the
-    store, so they are passed in. Which backend produced a transcript is not bookkeeping:
-    CLAUDE.md records that parakeet does not fail on Spanish audio, it INVENTS — so a reader
-    must be able to recover, after the fact, what wrote the words they are reading.
+    NO PRODUCER IS PASSED IN, ON PURPOSE (F7-7, round 08). The first version took
+    `transcribe_command` and `vision_command` and stamped them on the transcript and frame
+    surfaces as `producer` — the command CONFIGURED at emission time, which is not the one
+    that wrote the words: changing `[transcribe].command` changed the served provenance of
+    every transcript with text and fingerprints identical (measured on the real corpus).
+    Spec §3.4: *lo desconocido no se rellena por intuición*. The store records no
+    transcriber, so those two surfaces carry `producer=None`, and there is no parameter
+    through which an adapter could reintroduce the claim. Which backend wrote a transcript
+    matters — CLAUDE.md records that parakeet does not fail on Spanish audio, it INVENTS —
+    which is exactly why it has to be RECORDED where the text is attached (`digest-video`,
+    the `caption_contract` pattern), a store change Plan 03 owns, not inferred here.
     """
     surfaces: list[KnowledgeSurface] = []
     fetched_at = item.content.fetched_at if item.content else None
@@ -226,15 +228,7 @@ def item_surfaces(
         )
 
     for index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES)):
-        surfaces += _content_source_surfaces(
-            item,
-            index,
-            source,
-            keys[index],
-            fetched_at,
-            transcribe_command=transcribe_command,
-            vision_command=vision_command,
-        )
+        surfaces += _content_source_surfaces(item, index, source, keys[index], fetched_at)
 
     for media_index, photo in iter_described_photos(item):
         surfaces.append(
@@ -336,9 +330,6 @@ def _content_source_surfaces(
     source: ContentSourceSuccess,
     source_key: str,
     fetched_at: datetime | None,
-    *,
-    transcribe_command: str | None,
-    vision_command: str | None,
 ) -> list[KnowledgeSurface]:
     """The surfaces one content source contributes.
 
@@ -384,7 +375,8 @@ def _content_source_surfaces(
                 source_key=source_key,
                 text=source.text,
                 title=source.title,
-                producer=transcribe_command,
+                # The store records no transcriber: unknown stays unknown (F7-7, spec §3.4).
+                producer=None,
                 produced_at=fetched_at,
                 language=source.language,
                 locator=Locator(**locator_base, url=source.url),  # type: ignore[arg-type]
@@ -401,7 +393,8 @@ def _content_source_surfaces(
                 source_key=video_frame_source_key(source_key, frame_index),
                 text=frame.description,
                 title=source.title,
-                producer=vision_command,
+                # Nor which vision command captioned the frame (F7-7).
+                producer=None,
                 produced_at=fetched_at,
                 locator=Locator(
                     kind="video_frame",

--- a/tests/test_knowledge_surfaces.py
+++ b/tests/test_knowledge_surfaces.py
@@ -118,14 +118,27 @@ def test_summary_producer_and_produced_at_come_from_the_enrichment() -> None:
     )
 
 
-def test_configured_commands_become_the_producer_of_asr_and_vlm_surfaces() -> None:
-    """The transcript's producer is the transcribe command, not a guess.
+def test_asr_and_vlm_surfaces_carry_no_producer_because_the_store_records_none() -> None:
+    """F7-7 / gate Codex F1 (round 08): spec §3.4 — *método o componente que la produjo* —
+    and *lo desconocido no se rellena por intuición: permanece desconocido hasta que el dato
+    conserve su productor*. The `x_video` source records no transcriber and no vision
+    command; the emitter used to stamp the command CONFIGURED at emission time, so changing
+    `[transcribe].command` changed the served provenance of a transcript nobody re-ran,
+    with text and fingerprints identical (measured on the real corpus). A configured command
+    is not evidence of what wrote the words. Plan 01 M4's own last row is the honest
+    reading: `None` where the format does not conserve it.
 
-    It is the one producer that does NOT live in the store, so it is passed in. CLAUDE.md
-    documents why it matters: parakeet does not fail on Spanish audio, it INVENTS — so
-    which backend produced a transcript is exactly the kind of thing a reader must be able
-    to recover after the fact.
+    The emitter therefore CANNOT be handed a producer for these two surfaces — there is no
+    parameter to pass one through, so no adapter can reintroduce the claim — and `produced_at`
+    still comes from `content.fetched_at`, which the store DOES record. The ASR/VLM origin
+    itself is still declared (`origin`, `trust_class`, the `machine_generated` warning).
+    Recording the producer at `digest-video`/frame time is the store change Plan 03 owns.
+
+    Seen red on `36f694b`: `item_surfaces` accepted `transcribe_command`/`vision_command`
+    and stamped them.
     """
+    import inspect
+
     item = _item(
         content=Content(
             fetched_at=datetime(2026, 3, 1, tzinfo=UTC),
@@ -144,14 +157,15 @@ def test_configured_commands_become_the_producer_of_asr_and_vlm_surfaces() -> No
             ],
         )
     )
-    surfaces = item_surfaces(
-        item,
-        transcribe_command="scripts/xbrain-transcribe-auto",
-        vision_command="scripts/xbrain-vision",
-    )
-    assert _by_type(surfaces, "video_transcript")[0].producer == "scripts/xbrain-transcribe-auto"
-    assert _by_type(surfaces, "video_frame")[0].producer == "scripts/xbrain-vision"
-    assert _by_type(surfaces, "video_transcript")[0].produced_at == datetime(2026, 3, 1, tzinfo=UTC)
+    parameters = set(inspect.signature(item_surfaces).parameters)
+    assert parameters.isdisjoint({"transcribe_command", "vision_command"}), parameters
+    surfaces = item_surfaces(item)
+    transcript = _by_type(surfaces, "video_transcript")[0]
+    frame = _by_type(surfaces, "video_frame")[0]
+    assert transcript.producer is None and frame.producer is None
+    assert transcript.produced_at == datetime(2026, 3, 1, tzinfo=UTC)
+    assert transcript.origin == "asr" and "machine_generated" in transcript.warnings
+    assert frame.origin == "vlm" and "machine_generated" in frame.warnings
 
 
 # ---------------------------------------------------------------------------
@@ -454,7 +468,11 @@ def test_surfaces_never_carry_a_verdict() -> None:
 
 
 def test_an_item_without_content_still_emits_post_and_summary() -> None:
-    """961 of 2 404 items (40 %) have no `content` at all — that is not an error.
+    """960 of 2 404 items (40 %) have no `content` at all — that is not an error.
+
+    Measured 2026-09-01 on `data/items.json`, sha256 `f76341a3…`. NOTE the population: this
+    is *no `content` block*, which is NOT *no primary surface* — the second is 0 of 2,404,
+    because every one of these still emits a `post` (F-5).
 
     Plan 01 §9: they emit `post` + `summary` + topics, with `content_kinds=()`.
     """
@@ -580,8 +598,10 @@ def test_the_video_digest_never_borrows_the_enrichment_executor_as_its_producer(
     the result would look populated and be manufactured. `producer` is the field that answers
     *what wrote these words*, and a wrong answer there is worse than no answer.
 
-    Measured 2026-08-31 over 2,404 items with the commands configured: `producer` is populated
-    on 6,923 item surfaces and absent only on `post` (2,404) and `video_digest` (216).
+    Re-derived 2026-09-02 over 2,404 items, after round 08 stopped stamping the configured
+    commands on ASR/VLM surfaces (F7-7): `producer` is populated on 4,575 item surfaces and
+    absent on `post` (2,404), `video_transcript` (152), `video_frame` (2,197) and
+    `video_digest` (216) — every one a surface whose producer the store does not record.
     """
     item = _item(
         enriched=Enrichment(
@@ -604,7 +624,7 @@ def test_the_video_digest_never_borrows_the_enrichment_executor_as_its_producer(
             ],
         ),
     )
-    surfaces = item_surfaces(item, transcribe_command="asr", vision_command="vlm")
+    surfaces = item_surfaces(item)
     digest = next(s for s in surfaces if s.surface_type == "video_digest")
     summary = next(s for s in surfaces if s.surface_type == "summary")
 


### PR DESCRIPTION
Child **02.2** of the Plan 02 umbrella (`VGonPa/umbrella-knowledge-index-lexical`), stacked on the already-landed 02.1. **Draft — not for merge, opened before any formal external review.**

## Exact scope — one thing

`video_transcript` and `video_frame` surfaces must carry `producer=None`, because **the store does not record which command actually produced their text**.

`item_surfaces` took `transcribe_command`/`vision_command` and stamped them as `producer`. Those are the commands **configured at emission time**, not the ones that wrote the words. Spec §3.4: *lo desconocido no se rellena por intuición*.

The parameters are **removed**, not defaulted to `None` — so no adapter can reintroduce the claim through a seam.

What the store *does* record still ships: `produced_at` from `content.fetched_at`, and the ASR/VLM `origin` with its `machine_generated` warning.

## The defect, measured in this worktree

Same item, same stored text, only `[transcribe].command` changed:

| configured command | served `producer` | surface fingerprint |
|---|---|---|
| `scripts/xbrain-transcribe-auto` | `scripts/xbrain-transcribe-auto` | `dcfca7e5f59231d2` |
| `whisper-large-v3` | `whisper-large-v3` | `dcfca7e5f59231d2` |

Identical text, identical fingerprint, **different provenance served** — a claim the store cannot back.

After the change, both configs are impossible: `producer=None`, fingerprint still `dcfca7e5f59231d2`.

## Rule 6 — nothing derived is invalidated

`producer` does **not** feed `surface_fingerprint`. The fingerprints above are byte-identical before and after the fix, so no stored chunk, verdict or badge is retired by this change. Verified by execution, not by reading.

## Red → green evidence

Test ported and run **alone**, against the unmodified emitter:

```
FAILED tests/test_knowledge_surfaces.py::test_asr_and_vlm_surfaces_carry_no_producer_because_the_store_records_none
E  AssertionError: {'item', 'transcribe_command', 'vision_command'}
1 failed, 25 passed
```

After the production change: `26 passed`.

The test is not a signature-only pin — it also asserts `producer is None` on both surfaces while `produced_at`, `origin` and the `machine_generated` warning survive. Its sibling `test_the_video_digest_never_borrows_the_enrichment_executor_as_its_producer` remains the control: `summary.producer == "claude-code"` still comes from the store, so this is a **targeted** `None`, not a blanket one (CLAUDE.md rule 1).

## Quality gate

`scripts/check.sh` → **ALL CRITICAL CHECKS PASSED**

- Ruff lint · Ruff format · Mypy · Bandit · Detect-secrets · Deptry — PASS
- **Tests: 2188 passed**, 1 xfailed
- Coverage **94.60%** (min 78) · `knowledge/` **98%** (min 90)
- Vulture PASS · Interrogate 91.0% PASS
- Radon: grade C WARN — pre-existing and warn-only; both touched modules are A/B, and this change only *removes* parameters

Focused: `pytest -k "knowledge or surface or evidence or contract or cli"` → 562 passed.

## Diff — no later-child leakage

4 files, **+70 / −51 = 121 lines touched**, matching the delivery matrix's declared `70 altas / 121 tocadas` for 02.2 exactly.

| file | what |
|---|---|
| `src/xbrain/knowledge/surfaces.py` | whole diff vs. snapshot is 02.2 scope; ported verbatim |
| `src/xbrain/knowledge/models.py` | **only** the `producer`/`produced_at` docstring hunk (`-199,3 +200,13`) |
| `src/xbrain/cli.py` | **only** the `item_surfaces(...)` call site (5 lines → 1) |
| `tests/test_knowledge_surfaces.py` | test owner for this child |

Deliberately **excluded** (later children): persisted schema/DDL, chunking, `locator` becoming required, `build`/`update`/`search`/`get`/`render`, config, evaluation harness, embeddings, graph, MCP.

**02.1 preserved exactly.** The snapshot's `models.py` header rewrites the envelope prose to `SearchResponse "1" / EvidenceBundle "2"`; 02.1 as landed deliberately chose `SearchResponse "2" / EvidenceBundle "1"`, deferring the bundle bump until `locator` ships in 02.5. That hunk is **untouched** here.

One in-scope hunk is unrelated to provenance and disclosed rather than hidden: a docstring-only correction in `test_an_item_without_content_still_emits_post_and_summary` (961 → 960, plus the population it was measured on). The delivery matrix assigns this test file wholly to 02.2, and no later child owns it.

## Internal plans are NOT committed

The spec, the Plan 02 document and the atomic-cut report were read as authoritative sources but **no plan, spec, report, code-review or scratch file enters Git**. `zz-support-files/` is gitignored (`.gitignore:19`), and `git status --porcelain -uall` shows no untracked files. The commit contains exactly the four files above.

## Status

Draft, not ready. Do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjSDPCV2rrWV2zzzmZkoXv