### PR TITLE
feat(knowledge): the persisted index schema, its door and its two deletions (02.3)

### DIFF
--- a/src/xbrain/knowledge/index_schema.py
+++ b/src/xbrain/knowledge/index_schema.py
@@ -1,0 +1,679 @@
+"""The persisted index: its DDL, how it is opened, and the two deletion orders (Plan 02 §2).
+
+The index is DERIVED and RECONSTRUCTIBLE (spec §5.6). It lives under `data/index/`, it is
+never versioned, and nothing in it is a second source of truth: `get` reads the store, and
+`search` hydrates verification from the live store. What lives here is a retrieval structure
+and the metadata needed to filter BEFORE scoring.
+
+THREE DECISIONS IN THIS FILE FAIL SILENTLY WHEN THEY ARE WRONG, which is why each is pinned
+by behaviour in `tests/test_knowledge_index_schema.py`:
+
+**1. `rowid` is an explicit `INTEGER PRIMARY KEY` on `chunks` and on `profiles` (m1).** Both
+FTS5 tables are EXTERNAL CONTENT tables: they store no text and read it back from their
+content table by rowid. SQLite documents that `VACUUM` may renumber the rowids of a table
+that lacks an `INTEGER PRIMARY KEY` — so an implicit rowid would leave every FTS entry
+pointing at a DIFFERENT row, and the index would return wrong text without raising anything.
+`chunk_id` stays the contract's identity (`TEXT UNIQUE NOT NULL`); it simply stops being the
+physical key.
+
+**2. A delete RETRACTS the old text — and what matters is that it happens at all, not the
+order (F-7).** With external content, `chunks_fts` stores no text: a `'delete'` command has
+to be handed the original values, which is why both deletion functions SELECT the row before
+touching anything. Because the values are captured first, running the two statements in the
+other order is harmless — measured on sqlite 3.51.2, retract-then-delete and
+delete-then-retract both leave zero rows behind. This file used to claim the opposite
+(*"reversing these two statements produces phantom results"*), and the claim was the wrong
+guard to give the next maintainer: the defect that actually exists is omitting the retraction,
+which leaves an orphan FTS entry that an `INNER JOIN` HIDES until the rowid is reused — and
+then the query returns a chunk whose body is a completely different one. That is what
+`tests/test_knowledge_index_schema.py` pins, by reusing the rowid. The retraction lives in
+exactly two functions (`delete_chunk_rows`, `delete_profile_rows`) and nowhere else.
+
+**3. `profiles_fts` is external content over `profiles`, which stores `profile_text`.** Plan
+02 §2 sketched it as `content=''`. A contentless FTS5 table cannot be deleted from without
+supplying the ORIGINAL text, which a contentless table by definition does not keep — so the
+incremental update path (`index update` removes an item) would have had no way to retract a
+profile. Storing the text makes deletion possible at all, and makes it the SAME operation as
+on the chunk plane rather than a second, subtly different one. The cost is one copy of the
+profile composition on disk; the alternative was `contentless_delete=1`, which pins a minimum
+SQLite version for no gain here.
+
+**WHAT IS NOT HERE, ON PURPOSE.** There is no `verification` column on `surfaces` (M5): a
+stored verdict cannot be invalidated when the verdict changes, so a `FAIL` revoked by
+`verify --audit` would keep being served as the `PASS` it used to be. `search` hydrates it
+from the live store with the same freshness check `generate._verdict_badge` applies.
+
+And there is no `FOREIGN KEY` on `chunks.surface_id`. SQLite does not enforce foreign keys
+unless `PRAGMA foreign_keys=ON`, so a `REFERENCES` clause with the pragma off is a claim in
+the DDL that nothing checks — prose in the column where a guard belongs. The property it
+would assert (no chunk without its surface) is asserted where it can actually be checked:
+over the output of `index build`, by a test.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterable, Iterator, Sequence
+from contextlib import contextmanager
+from functools import cache
+from pathlib import Path
+from typing import NamedTuple
+
+from xbrain.knowledge.lexical_fts import FTS_TOKENIZE, fts5_table_sql
+from xbrain.models import _reject_local_path_traversal
+
+# Bumped when the physical layout changes in a way an existing database cannot answer. The
+# manifest records it and a mismatch refuses the query ENTIRELY (spec §9.3) — never a partial
+# answer over a schema the code no longer understands.
+# "2" since C-3/A-3: `items` carries the per-item omission counters, so the manifest's
+# `skipped` is a SUM over rows the incremental path already maintains, rather than a figure
+# carried over from the previous manifest and wrong after the first `update`.
+# "3" since U-5 (round 07): `chunks.fingerprint` hashes the whole evidence projection
+# (`chunking.chunk_evidence` — provenance, owner, position, attribution, narrowed locator),
+# and a v2 base's fingerprints were computed over the text alone, so every one of its rows
+# would fail verification. The door refuses it by name, with the rebuild, rather than
+# answering «22,286 chunks excluded».
+SCHEMA_VERSION = "3"
+
+DB_FILENAME = "knowledge.db"
+MANIFEST_FILENAME = "manifest.json"
+DEFAULT_INDEX_DIR_NAME = "index"
+
+# The plain tables, declared so the DDL and the suite cannot drift: a table created without
+# being declared, or declared without being created, goes red.
+TABLES: frozenset[str] = frozenset(
+    {
+        "items",
+        "item_topics",
+        "item_content_kinds",
+        "surfaces",
+        "chunks",
+        "profiles",
+        "topics",
+        "source_failures",
+        "unfetched_links",
+    }
+)
+
+# The two RETRIEVAL PLANES (spec §5.1). Separate tables on purpose: the profile finds the
+# item as a conceptual unit, the chunks find the fragment where a fact lives. One shared
+# table would let a profile — a string nobody wrote — surface as a citable `SearchMatch`,
+# which Plan 01 forbids.
+FTS_TABLES: frozenset[str] = frozenset({"chunks_fts", "profiles_fts"})
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS items (
+    item_id           TEXT PRIMARY KEY,
+    source            TEXT NOT NULL,
+    url               TEXT NOT NULL,
+    author_handle     TEXT NOT NULL,
+    author_name       TEXT NOT NULL,
+    created_at        TEXT NOT NULL,
+    captured_at       TEXT NOT NULL,
+    primary_topic     TEXT,
+    note_path         TEXT,
+    bookmark_folder   TEXT,
+    store_fingerprint TEXT NOT NULL,
+    -- What the emitter DECLINED for this item, counted where the item is (A-3). The
+    -- manifest's `skipped` is a SUM over these, so an incremental update that deletes and
+    -- rewrites the row keeps the total exact without re-walking the corpus.
+    skipped_empty_text INTEGER NOT NULL DEFAULT 0,
+    skipped_decorative INTEGER NOT NULL DEFAULT 0,
+    skipped_no_speech  INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS items_author ON items (author_handle);
+CREATE INDEX IF NOT EXISTS items_source ON items (source);
+
+CREATE TABLE IF NOT EXISTS item_topics (
+    item_id    TEXT NOT NULL,
+    slug       TEXT NOT NULL,
+    is_primary INTEGER NOT NULL,
+    PRIMARY KEY (item_id, slug)
+);
+CREATE INDEX IF NOT EXISTS item_topics_slug ON item_topics (slug);
+
+CREATE TABLE IF NOT EXISTS item_content_kinds (
+    item_id TEXT NOT NULL,
+    kind    TEXT NOT NULL,
+    PRIMARY KEY (item_id, kind)
+);
+CREATE INDEX IF NOT EXISTS item_content_kinds_kind ON item_content_kinds (kind);
+
+CREATE TABLE IF NOT EXISTS surfaces (
+    surface_id         TEXT PRIMARY KEY,
+    owner_type         TEXT NOT NULL,
+    owner_id           TEXT NOT NULL,
+    surface_type       TEXT NOT NULL,
+    origin             TEXT NOT NULL,
+    trust_class        TEXT NOT NULL,
+    derived            INTEGER NOT NULL,
+    attribution_handle TEXT,
+    attribution_name   TEXT,
+    title              TEXT,
+    url                TEXT,
+    locator_json       TEXT NOT NULL,
+    language           TEXT,
+    fingerprint        TEXT NOT NULL,
+    char_length        INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS surfaces_owner ON surfaces (owner_type, owner_id);
+CREATE INDEX IF NOT EXISTS surfaces_type ON surfaces (owner_id, surface_type);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    rowid         INTEGER PRIMARY KEY,
+    chunk_id      TEXT NOT NULL UNIQUE,
+    surface_id    TEXT NOT NULL,
+    owner_type    TEXT NOT NULL DEFAULT 'item',
+    owner_id      TEXT NOT NULL DEFAULT '',
+    surface_type  TEXT NOT NULL DEFAULT 'post',
+    origin        TEXT NOT NULL DEFAULT 'source',
+    trust_class   TEXT NOT NULL DEFAULT 'primary_source',
+    derived       INTEGER NOT NULL DEFAULT 0,
+    chunk_index   INTEGER NOT NULL DEFAULT 0,
+    char_start    INTEGER NOT NULL DEFAULT 0,
+    char_end      INTEGER NOT NULL DEFAULT 0,
+    text          TEXT NOT NULL,
+    title         TEXT,
+    url           TEXT,
+    language      TEXT,
+    fingerprint   TEXT NOT NULL DEFAULT '',
+    -- Denormalised ON PURPOSE: these are the filters spec §7.2 asks for most often, and a
+    -- copy here lets the `WHERE` run BEFORE the `MATCH` without a JOIN per query. The cost
+    -- is one copy per chunk, paid in `build`, which is explicit and manual.
+    created_at    TEXT,
+    source        TEXT,
+    primary_topic TEXT
+);
+CREATE INDEX IF NOT EXISTS chunks_owner ON chunks (owner_type, owner_id);
+CREATE INDEX IF NOT EXISTS chunks_surface_type ON chunks (surface_type);
+CREATE INDEX IF NOT EXISTS chunks_created_at ON chunks (created_at);
+CREATE INDEX IF NOT EXISTS chunks_source ON chunks (source);
+CREATE INDEX IF NOT EXISTS chunks_origin ON chunks (origin);
+CREATE INDEX IF NOT EXISTS chunks_surface ON chunks (surface_id);
+
+CREATE TABLE IF NOT EXISTS profiles (
+    rowid        INTEGER PRIMARY KEY,
+    item_id      TEXT NOT NULL UNIQUE,
+    profile_text TEXT NOT NULL,
+    fingerprint  TEXT NOT NULL DEFAULT ''
+);
+
+CREATE TABLE IF NOT EXISTS topics (
+    slug                  TEXT PRIMARY KEY,
+    description           TEXT NOT NULL,
+    overview              TEXT,
+    notes_json            TEXT NOT NULL DEFAULT '[]',
+    synthesized_at        TEXT,
+    post_count_at_synth   INTEGER,
+    stale                 INTEGER NOT NULL DEFAULT 1,
+    primary_item_ids_json TEXT NOT NULL DEFAULT '[]',
+    secondary_item_ids_json TEXT NOT NULL DEFAULT '[]',
+    vocab_fingerprint     TEXT NOT NULL,
+    synthesis_fingerprint  TEXT
+);
+
+CREATE TABLE IF NOT EXISTS source_failures (
+    item_id        TEXT NOT NULL,
+    kind           TEXT NOT NULL,
+    url            TEXT NOT NULL,
+    failure_reason TEXT NOT NULL,
+    error          TEXT,
+    http_status    INTEGER,
+    attempts       INTEGER
+);
+CREATE INDEX IF NOT EXISTS source_failures_item ON source_failures (item_id);
+
+-- m7: links NEVER attempted, or downloaded with no extractable body. NOT failures, and the
+-- two facts are kept apart because a link nobody tried is not a link that returned a 404.
+CREATE TABLE IF NOT EXISTS unfetched_links (
+    item_id TEXT NOT NULL,
+    url     TEXT NOT NULL,
+    reason  TEXT NOT NULL,
+    detail  TEXT
+);
+CREATE INDEX IF NOT EXISTS unfetched_links_item ON unfetched_links (item_id);
+
+{fts5_table_sql("chunks_fts", content="chunks")};
+{fts5_table_sql("profiles_fts", columns=("profile_text",), content="profiles")};
+"""
+
+
+class IndexError_(Exception):
+    """Base class for the index's actionable errors — never a raw traceback (spec §9.3)."""
+
+
+class IndexMissingError(IndexError_):
+    """The index has not been built yet. Names the command that builds it (step 30)."""
+
+
+class IndexIncompatibleError(IndexError_):
+    """The manifest was written by a different schema, emitter or chunker (step 29).
+
+    Raised INSTEAD of answering. Spec §9.3: an incompatible manifest is never queried
+    partially — a partial answer over a schema the code no longer understands is a wrong
+    answer wearing a right one's shape.
+
+    It is ALSO what a corrupt database raises (F-3). Both are the same operator situation —
+    *what is on disk is not what this code can read, and the fix is to rebuild* — so they end
+    with the same sentence rather than with two that have to be kept in step.
+    """
+
+
+# The advice every incompatibility ends with. ONE string, so the CLI, the services and the
+# tests all name the same command; it lives here, beside the error that carries it, rather
+# than in `index_build`, which cannot be imported from this module.
+REBUILD_ADVICE = "Reconstruye el índice con `xbrain index build --force`."
+
+
+def corrupt_base_error(path: Path, error: sqlite3.DatabaseError) -> IndexIncompatibleError:
+    """The ONE sentence for a base this code cannot read — the open door and every later read.
+
+    Built here, beside `REBUILD_ADVICE`, so `_prove_readable` and `reading_base` cannot
+    drift into two wordings of one fact (rule 5). SQLite's own text rides in parentheses:
+    it is what distinguishes a torn page from a file that is not a database at all.
+    """
+    return IndexIncompatibleError(
+        f"La base del índice en {path} no se puede leer ({error}). {REBUILD_ADVICE}"
+    )
+
+
+@contextmanager
+def reading_base(path: Path) -> Iterator[None]:
+    """Turn a `sqlite3.DatabaseError` raised inside the block into the rebuild advice (D-1).
+
+    `sqlite3.connect` is lazy and the open door reads page 1, `sqlite_master` and one `MATCH`
+    per FTS plane — so a page damaged under `items`, `chunks` or `topics` surfaced at the
+    first MAINTENANCE read that touched it: `count_rows`, `_stored_fingerprints`,
+    `stored_topic_rows`, each a raw `DatabaseError` out of `status`, `search` and `update`,
+    a 61-line traceback naming no command, while CLAUDE.md declared G-4 closed on the three
+    (the round-06 gate, D-1). `LexicalIndex._fetch` already converts at QUERY time; this is
+    the same conversion for the reads that are not queries, in one place, wrapped around
+    them rather than remembered at each.
+
+    `DatabaseError` is the whole family on purpose — `OperationalError` included — because
+    the door already treats it so (`_fetch`, C-2): the index has no concurrent writer by
+    design (spec §9.2), so what the family means here is *the file is not what this code
+    can read*, and the honest remedy is the rebuild the sentence names.
+    """
+    try:
+        yield
+    except sqlite3.DatabaseError as error:
+        raise corrupt_base_error(path, error) from error
+
+
+def db_path(index_dir: Path) -> Path:
+    """Where the SQLite database lives inside the index directory."""
+    return index_dir / DB_FILENAME
+
+
+def manifest_path(index_dir: Path) -> Path:
+    """Where the manifest lives inside the index directory."""
+    return index_dir / MANIFEST_FILENAME
+
+
+def resolve_index_dir(data_dir: Path, name: str) -> Path:
+    """`data_dir / name`, resolved and PROVEN to stay inside `data_dir` (§12.6, m8).
+
+    Two checks, and they are not the same check. `_reject_local_path_traversal` — reused
+    rather than reimplemented, so the repo has one definition of "this path is not allowed to
+    climb" — rejects an absolute path and any literal `..`. It does NOT establish containment:
+    a symlink under `data/` pointing anywhere on the filesystem passes it untouched. The
+    `is_relative_to` on the RESOLVED paths is what actually contains it.
+    """
+    _reject_local_path_traversal(name)
+    root = data_dir.resolve()
+    resolved = (data_dir / name).resolve()
+    if not resolved.is_relative_to(root):
+        raise ValueError(
+            f"El directorio del índice {name!r} resuelve a {resolved}, fuera de {root}. "
+            "Ajusta `[index].dir` en config.toml a una ruta contenida en data/."
+        )
+    return resolved
+
+
+def create_schema(connection: sqlite3.Connection) -> None:
+    """Create every table, both FTS planes and the indexes. Idempotent."""
+    connection.executescript(_SCHEMA)
+
+
+def require_database(index_dir: Path) -> Path:
+    """The database file, or the ONE actionable error for its absence (G-2).
+
+    The advice depends on what is left beside the missing file. With no manifest the index
+    was simply never built, and plain `xbrain index build` builds it. With a manifest still
+    standing — the operator deleted the 52 MB database by hand and kept the 1 KB document —
+    plain `build` REFUSES (*Ya existe un índice*), so naming it would send the operator into
+    a dead end in two hops; the honest command is the forced rebuild. One function, called by
+    every door — `open_index`, `update`, `open_for_query` and, since round 07 (U-2),
+    `status` (`index_build._index_contents`), which used to test `exists()` by itself and
+    read a standing manifest over a missing base as an index never built — so the doors
+    cannot disagree on which command that is. `tests/test_knowledge_seams.py` enumerates the
+    doors structurally and `test_knowledge_index_invalidation.py` swaps this function for a
+    sentinel that every door must repeat.
+    """
+    database = db_path(index_dir)
+    if database.exists():
+        return database
+    if manifest_path(index_dir).exists():
+        raise IndexMissingError(
+            f"No hay base de datos en {database} pero su manifest sigue en pie: el índice "
+            f"quedó incompleto. {REBUILD_ADVICE}"
+        )
+    raise IndexMissingError(f"No hay índice en {index_dir}. Constrúyelo con `xbrain index build`.")
+
+
+def open_index(path: Path, *, read_only: bool = False, create: bool = False) -> sqlite3.Connection:
+    """Open the index database. Creates it ONLY when `create=True`, which only `build` passes.
+
+    `read_only=True` opens `file:…?mode=ro`, so a stray write is an `OperationalError`
+    instead of a silent repair — spec §5.6 is explicit that a query never modifies or repairs
+    the index. A promise not to write is not the same property as being unable to.
+
+    THE WRITE DOOR DOES NOT CREATE A FILE EITHER (G-2). It used to `mkdir + connect +
+    create_schema` whenever the file was absent, which is how `index update --dry-run` left
+    an EMPTY database under a manifest that was still standing: the consistency check then
+    raised the right error with the file already on disk, and the next `search` — which
+    checked `exists()` and a compatible manifest — answered «Sin resultados» with exit 0 over
+    zero rows while `status` said incomplete. Measured on the real corpus through the CLI
+    (2026-09-01): a 167,936-byte `knowledge.db` from a dry run. Creation is now opt-in and
+    named, so the instrument that says "let me see what would happen" cannot change what
+    happens next.
+    """
+    if read_only:
+        require_database(path.parent)
+        connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        connection.row_factory = sqlite3.Row
+        return _probe_fts(_verify_schema(_prove_readable(connection, path), path), path)
+    existed = path.exists()
+    if not existed and not create:
+        require_database(path.parent)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(path)
+    connection.row_factory = sqlite3.Row
+    _prove_readable(connection, path)
+    if existed:
+        # An EXISTING database is verified, never repaired: `create_schema` is idempotent,
+        # so a dropped table would be silently re-created EMPTY and `index update` would
+        # then carry on as if nothing had happened (C-2). A fresh file is the only one
+        # that gets its schema created here.
+        _probe_fts(_verify_schema(connection, path), path)
+    create_schema(connection)
+    return connection
+
+
+def _prove_readable(connection: sqlite3.Connection, path: Path) -> sqlite3.Connection:
+    """Force the first page read HERE, and turn a corrupt file into actionable advice (F-3).
+
+    `sqlite3.connect` is LAZY: it opens a corrupt file without complaint and the
+    `DatabaseError` surfaces later, at whatever statement happens to touch the disk first —
+    inside `search`, inside `index status`, inside `index update`. `sqlite3.DatabaseError` is
+    not an `IndexError_` and not an `OSError`, so it escaped the CLI's `_OPERATOR_ERRORS` and
+    all three commands printed a raw traceback naming no command, which is precisely the row
+    Plan 02 §11 tabulates as *error accionable con `index build --force`*.
+
+    One probe, at the one door every path already goes through, so no caller has to remember.
+    """
+    try:
+        connection.execute("SELECT count(*) FROM sqlite_master")
+    except sqlite3.DatabaseError as error:
+        connection.close()
+        raise corrupt_base_error(path, error) from error
+    return connection
+
+
+class ColumnSpec(NamedTuple):
+    """What `PRAGMA table_info` says about one column: the parts a query depends on."""
+
+    type: str
+    notnull: int
+    pk: int
+
+
+@cache
+def declared_columns() -> dict[str, dict[str, ColumnSpec]]:
+    """`{table: {column: spec}}` of the DDL THIS code ships — read, never restated (U-4).
+
+    The reference is `create_schema` run on `:memory:` and read back through `PRAGMA
+    table_info`, so the door verifies exactly the schema the code creates and the two cannot
+    drift (rule 5): a column added to `_SCHEMA` is required of every base without anybody
+    remembering to list it here. `pk` is in the spec because the m1 guard — `chunks.rowid`
+    an explicit `INTEGER PRIMARY KEY`, or `VACUUM` may repoint every FTS entry — was «the
+    DDL assertion and not a behavioural test», and a base whose `chunks` was recreated
+    without it is one this code must not read. Cached: it costs one in-memory schema per
+    process and the answer is a constant of the code.
+    """
+    connection = open_memory_index()
+    try:
+        return {
+            table: {
+                row["name"]: ColumnSpec(str(row["type"]), int(row["notnull"]), int(row["pk"]))
+                for row in connection.execute(f"PRAGMA table_info({table})")
+            }
+            for table in sorted(TABLES | FTS_TABLES)
+        }
+    finally:
+        connection.close()
+
+
+def _verify_schema(connection: sqlite3.Connection, path: Path) -> sqlite3.Connection:
+    """Refuse a database that lacks a table — or a COLUMN — this code queries (C-2, U-4).
+
+    `_prove_readable` proves the FILE is SQLite; it says nothing about what is inside. Both
+    round-03 gates dropped `chunks_fts` behind a healthy manifest and got a normal answer:
+    `LexicalIndex._fetch` absorbed the `no such table` as "no rows", so `search` returned
+    the profile-plane candidates — or nothing — with `degraded: ["no_embeddings"]` and not
+    one word about the missing table, indistinguishable from a corpus that holds nothing.
+    Spec §9.3 asks for an actionable error; Plan 02 §11 tabulates a base the code cannot
+    read as *error accionable con `index build --force`*. Same operator situation as a
+    corrupt file, same sentence.
+
+    AND THE COLUMNS (U-4, round 07 — gate Codex F3). Table names were the whole check, so
+    `ALTER TABLE surfaces DROP COLUMN attribution_name` — `quick_check: ok`, every table
+    present — passed every door: `status` certified the base healthy, `update` re-sealed the
+    manifest over it with exit 0, and `search` failed late in a raw `OperationalError: no
+    such column` naming no command. The effective schema is the columns the queries read;
+    they are compared against `declared_columns` — name, type, `NOT NULL` and the
+    primary-key flag — so a missing or redefined column is refused here, with its name.
+    Extra columns are tolerated: a base that holds more than this code reads is readable.
+
+    Checked against `TABLES | FTS_TABLES`, the declared set, so a table added to the DDL is
+    verified without anybody remembering to add it here.
+    """
+    present = {
+        row["name"]
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+    }
+    missing = sorted((TABLES | FTS_TABLES) - present)
+    if missing:
+        connection.close()
+        raise IndexIncompatibleError(
+            f"La base del índice en {path} está incompleta: faltan las tablas "
+            f"{', '.join(missing)}. {REBUILD_ADVICE}"
+        )
+    absent, redefined = _column_drift(connection)
+    if absent or redefined:
+        connection.close()
+        raise IndexIncompatibleError(
+            f"La base del índice en {path} está incompleta: "
+            + (f"faltan las columnas {', '.join(absent)}" if absent else "")
+            + ("; " if absent and redefined else "")
+            + (f"columnas con otra definición {', '.join(redefined)}" if redefined else "")
+            + f". {REBUILD_ADVICE}"
+        )
+    return connection
+
+
+def _column_drift(connection: sqlite3.Connection) -> tuple[list[str], list[str]]:
+    """`(absent, redefined)` — `table.column` names, sorted — against `declared_columns`."""
+    absent: list[str] = []
+    redefined: list[str] = []
+    for table, columns in declared_columns().items():
+        stored = {
+            row["name"]: ColumnSpec(str(row["type"]), int(row["notnull"]), int(row["pk"]))
+            for row in connection.execute(f"PRAGMA table_info({table})")
+        }
+        for column, spec in columns.items():
+            if column not in stored:
+                absent.append(f"{table}.{column}")
+            elif stored[column] != spec:
+                redefined.append(f"{table}.{column}")
+    return sorted(absent), sorted(redefined)
+
+
+# One trivial `MATCH` per FTS plane — LITERALS keyed by table, like `_COUNT_STATEMENTS`, and
+# a test asserts the key set equals `FTS_TABLES` so a plane added to the DDL is probed too.
+_FTS_PROBES: dict[str, str] = {
+    "chunks_fts": "SELECT count(*) FROM chunks_fts WHERE chunks_fts MATCH ?",
+    "profiles_fts": "SELECT count(*) FROM profiles_fts WHERE profiles_fts MATCH ?",
+}
+_PROBE_TERM = '"xbrain-index-probe"'
+
+
+def _probe_fts(connection: sqlite3.Connection, path: Path) -> sqlite3.Connection:
+    """Run the query `search` runs, so the OPEN door sees what the query would see (G-4).
+
+    `_prove_readable` reads page 1 and `_verify_schema` reads `sqlite_master`; neither
+    touches an FTS5 SHADOW table (`chunks_fts_data`, `…_idx`, `…_config`) or a page beyond
+    the first. With `chunks_fts_data` dropped on the real corpus, `search` died with a
+    68-line traceback ending in `DatabaseError: fts5: corruption found reading blob 10 from
+    table "chunks_fts"`, while `status` — which never issues a `MATCH` — exited 0 and called
+    the index healthy, and `update --dry-run` returned normally. The diagnostic instrument
+    was the one that lied (rule 9).
+
+    A `MATCH` on a term nobody indexed costs 0.01 ms per plane (measured on the 52 MB real
+    index) and raises exactly where `search` would. `PRAGMA quick_check` would see more
+    (152 ms) but reports the fts5 corruption as a ROW, not an exception, and a probe that
+    has to parse its answer is a second guard to keep in step. What the probe still cannot
+    reach — a corrupt segment a real query hits later — `LexicalIndex._fetch` turns into the
+    same sentence.
+    """
+    try:
+        for statement in _FTS_PROBES.values():
+            connection.execute(statement, (_PROBE_TERM,)).fetchone()
+    except sqlite3.DatabaseError as error:
+        connection.close()
+        raise IndexIncompatibleError(
+            f"La base del índice en {path} no se puede consultar ({error}). {REBUILD_ADVICE}"
+        ) from error
+    return connection
+
+
+def quick_check(connection: sqlite3.Connection) -> str:
+    """`PRAGMA quick_check` as one sentence: `` when the base is sound, else the first finding.
+
+    THE DIAGNOSTIC INSTRUMENT SEES MORE THAN THE OPEN DOOR (B-1, round 05). `_prove_readable`
+    reads page 1, `_verify_schema` reads `sqlite_master`, `_probe_fts` runs one `MATCH` per
+    FTS plane — and 16 KB of `0xff` written over pages 17–20 of the real 52 MB index sat where
+    none of them looks: `quick_check` reported «btreeInitPage() returns error code 11» while
+    `status` said `incomplete: false`. A query that touches the page still fails closed
+    (`_fetch`, G-4), so no instrument lied; but `status` is the EXPLICIT command an operator
+    runs to find out, and it can pay what this costs on the 52 MB real index where a query
+    cannot: 155–167 ms measured by the gate; 362–850 ms, median 425, re-measured in round
+    05 at load average 8.6 (5 runs, `quick_check(1)`, read-only connection). `status` runs it; the open door does not, on purpose — `quick_check` reports
+    fts5 corruption as a ROW, not an exception, so the door keeps its positive `MATCH` probe
+    and this reader parses the answer here, once.
+
+    A `DatabaseError` raised by the pragma itself (a header too damaged to read) is the same
+    fact and is returned as the sentence.
+    """
+    try:
+        rows = connection.execute("PRAGMA quick_check(1)").fetchall()
+    except sqlite3.DatabaseError as error:
+        return str(error)
+    first = str(rows[0][0]) if rows else ""
+    return "" if first == "ok" else " ".join(first.split())
+
+
+def open_memory_index() -> sqlite3.Connection:
+    """The SAME schema on `sqlite3(":memory:")` — what the evaluation harness measures on.
+
+    Plan 01 §5.3 justifies sharing the scorer with the persisted index on the grounds that
+    *what dies in Plan 02 is where the database lives, not how it scores*. This function is
+    what keeps that literally true: one DDL, one tokenizer, one `bm25()`, one tie-break, and
+    the only difference is the connection string.
+    """
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    create_schema(connection)
+    return connection
+
+
+def delete_chunk_rows(connection: sqlite3.Connection, chunk_ids: Sequence[str]) -> int:
+    """Remove chunks from BOTH planes, in the only order that works. Returns how many.
+
+    THE RETRACTION IS THE WHOLE FUNCTION — not the order of its two statements (F-7).
+    `chunks_fts` is external content and stores no text, so the `'delete'` command must be
+    HANDED the original values; that is what the `SELECT` above is for, and it is why running
+    the `DELETE` first is harmless (measured: both orders leave zero rows behind).
+
+    What is NOT harmless is omitting the `'delete'`. The tokens then stay behind pointing at
+    a rowid that no longer exists, the `INNER JOIN` hides the orphan for as long as nothing
+    reuses that rowid, and the moment `index update` does, the query returns a chunk whose
+    body is a different one entirely. Silent, and invisible to any test that only checks that
+    the deleted word stops matching.
+
+    Which is why the deletion lives in one function instead of at each call site: a call site
+    that forgets the retraction is the failure, and there is nowhere to forget it from here.
+    """
+    deleted = 0
+    for chunk_id in chunk_ids:
+        row = connection.execute(
+            "SELECT rowid, text, title FROM chunks WHERE chunk_id = ?", (chunk_id,)
+        ).fetchone()
+        if row is None:
+            continue
+        connection.execute(
+            "INSERT INTO chunks_fts(chunks_fts, rowid, text, title) VALUES('delete', ?, ?, ?)",
+            (row["rowid"], row["text"], row["title"] or ""),
+        )
+        connection.execute("DELETE FROM chunks WHERE rowid = ?", (row["rowid"],))
+        deleted += 1
+    return deleted
+
+
+def delete_profile_rows(connection: sqlite3.Connection, item_ids: Sequence[str]) -> int:
+    """Remove item profiles from both planes, retracting first and for the same reason."""
+    deleted = 0
+    for item_id in item_ids:
+        row = connection.execute(
+            "SELECT rowid, profile_text FROM profiles WHERE item_id = ?", (item_id,)
+        ).fetchone()
+        if row is None:
+            continue
+        connection.execute(
+            "INSERT INTO profiles_fts(profiles_fts, rowid, profile_text) VALUES('delete', ?, ?)",
+            (row["rowid"], row["profile_text"]),
+        )
+        connection.execute("DELETE FROM profiles WHERE rowid = ?", (row["rowid"],))
+        deleted += 1
+    return deleted
+
+
+def delete_item_rows(connection: sqlite3.Connection, item_ids: Iterable[str]) -> None:
+    """Every row an item owns, across the metadata tables. Chunks and profiles go separately.
+
+    Split from the two functions above because those two carry the FTS ordering constraint
+    and these do not: a metadata table is an ordinary delete. Keeping them apart means the
+    constrained path stays small enough to read in one screen.
+
+    The six statements are LITERALS rather than an f-string over a table-name tuple. The
+    f-string version was safe — the names came from a module constant — but it made `bandit`
+    report B608 and needed a suppression, and a suppression is a request to stop looking. Six
+    literals need no argument from anybody.
+    """
+    statements = (
+        "DELETE FROM items WHERE item_id = ?",
+        "DELETE FROM item_topics WHERE item_id = ?",
+        "DELETE FROM item_content_kinds WHERE item_id = ?",
+        "DELETE FROM source_failures WHERE item_id = ?",
+        "DELETE FROM unfetched_links WHERE item_id = ?",
+        "DELETE FROM surfaces WHERE owner_type = 'item' AND owner_id = ?",
+    )
+    for item_id in item_ids:
+        for statement in statements:
+            connection.execute(statement, (item_id,))
+
+
+def tokenizer() -> str:
+    """The tokenizer string this schema was created with — recorded in the manifest."""
+    return FTS_TOKENIZE

--- a/src/xbrain/knowledge/lexical_fts.py
+++ b/src/xbrain/knowledge/lexical_fts.py
@@ -96,6 +96,48 @@ CREATE VIRTUAL TABLE IF NOT EXISTS chunk_fts USING fts5 (
 # the ranking would differ between two builds of the same data.
 RANK_ORDER = "ORDER BY bm25(chunk_fts) ASC, chunk.chunk_id ASC"
 
+# The INDEXED COLUMNS, in order, and they are part of the SCORER — not a layout detail.
+# `bm25()` weights every column of the table it is given, so adding or removing one changes
+# every score in the corpus. Exported for the same reason as the tokenizer: the in-memory
+# baseline and the persisted index MUST declare the identical set, or the characterization
+# fixture would be pinning two different scorers and would have to be regenerated the day
+# they diverged — at which point it pins nothing (Plan 01 §5.3, m16).
+FTS_COLUMNS: tuple[str, ...] = ("text", "title")
+
+
+def fts5_table_sql(
+    name: str, *, columns: tuple[str, ...] = FTS_COLUMNS, content: str | None = None
+) -> str:
+    """The `CREATE VIRTUAL TABLE … USING fts5(…)` for `name`, with the ONE tokenizer.
+
+    `content` names the EXTERNAL content table when there is one. An external-content table
+    stores no text of its own and reads it back from `content` by rowid, which halves the
+    on-disk footprint of a 12-million-character corpus — and is why the content table's
+    rowid must be an explicit `INTEGER PRIMARY KEY` (`VACUUM` renumbers an implicit one) and
+    why a delete must retract the OLD text before the row disappears.
+
+    `name` and `columns` are identifiers this module's own callers choose; they never carry a
+    user string, which is what keeps the f-string below a composition of constants rather
+    than SQL built from input.
+    """
+    parts = [*columns]
+    if content is not None:
+        parts += [f"content='{content}'", "content_rowid='rowid'"]
+    parts.append(f"tokenize = '{FTS_TOKENIZE}'")
+    body = ",\n    ".join(parts)
+    return f"CREATE VIRTUAL TABLE IF NOT EXISTS {name} USING fts5 (\n    {body}\n)"
+
+
+def rank_order(fts_table: str, meta_table: str) -> str:
+    """`ORDER BY bm25(<fts>) ASC, <meta>.chunk_id ASC` — the ONE ranking order.
+
+    The tie-break is EXPLICIT (spec §3.7.8). Two chunks with identical text score
+    identically, and sqlite's row order for a tie is an implementation detail — so without
+    the second key the ranking would differ between two builds of the same data.
+    """
+    return f"ORDER BY bm25({fts_table}) ASC, {meta_table}.chunk_id ASC"
+
+
 # FTS5 reads punctuation as syntax: `@`, `"`, `*`, `(`, `NEAR`, `-`. The golden set has
 # literal queries — `@simonw`, `11.37%` — whose characters would otherwise become operators
 # or a syntax error. Every term is therefore quoted as an FTS5 string literal, so the query

--- a/tests/test_knowledge_index_schema.py
+++ b/tests/test_knowledge_index_schema.py
@@ -1,0 +1,461 @@
+# tests/test_knowledge_index_schema.py
+"""The persisted index schema (Plan 02 §2, steps 1, 1b, 2).
+
+THREE PROPERTIES CARRY THE WEIGHT HERE, and each one fails SILENTLY when it is wrong —
+which is why they are pinned by behaviour rather than by reading the DDL back.
+
+* **`chunks.rowid` is an explicit `INTEGER PRIMARY KEY` (m1).** `chunks_fts` is an FTS5
+  table of EXTERNAL content: it stores no text and reads it from `chunks` by rowid. SQLite
+  documents that `VACUUM` may renumber the rowids of a table that has no `INTEGER PRIMARY
+  KEY` — so an implicit rowid would leave every FTS entry pointing at a different chunk,
+  returning wrong text with no error at all. Guarded STRUCTURALLY, because *may* is not
+  *does*: measured on this interpreter, `VACUUM` did not renumber either way, so a
+  behavioural test would pass for a reason unrelated to the property.
+* **The read-only connection really is read-only.** Spec §3.7.12: `search`, `get` and `index
+  status` are read operations, and §5.6 says a query never repairs the index silently. A
+  connection opened read-write "but we promise not to write" is a promise, not a property.
+* **`data/index/` is git-ignored**, asserted through `git check-ignore` rather than by
+  reading `.gitignore` — the file has patterns and negations, and what matters is git's own
+  answer.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from xbrain.knowledge.index_schema import (
+    FTS_TABLES,
+    SCHEMA_VERSION,
+    TABLES,
+    create_schema,
+    db_path,
+    manifest_path,
+    open_index,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    create_schema(connection)
+    return connection
+
+
+# ---------------------------------------------------------------------------
+# 1 — the DDL creates every table and both FTS planes
+# ---------------------------------------------------------------------------
+
+
+def test_the_ddl_creates_every_declared_table() -> None:
+    """Step 1: every table of Plan 02 §2 exists after `create_schema`.
+
+    Asserted against the DECLARED set (`TABLES`), not against a literal list written twice:
+    a table added to the DDL without being declared, or declared without being created, goes
+    red. Seen red by deleting `profiles_fts` from the DDL.
+    """
+    connection = _connection()
+    present = {
+        row["name"]
+        for row in connection.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert TABLES <= present
+    assert FTS_TABLES <= present
+
+
+def test_every_fts_plane_has_an_open_door_probe() -> None:
+    """G-4's totality half: a plane added to the DDL without a probe goes red here.
+
+    The probes are literals keyed by table (bandit reads an f-string over a table name as
+    B608, and a suppression is a request to stop looking), so the key set is asserted equal
+    to `FTS_TABLES` the way `_COUNT_STATEMENTS` is asserted against the counted planes.
+    """
+    from xbrain.knowledge.index_schema import _FTS_PROBES
+
+    assert set(_FTS_PROBES) == FTS_TABLES
+
+
+def test_the_two_fts_planes_are_separate_tables() -> None:
+    """Spec §5.1: the profile finds the ITEM, the chunks find the FRAGMENT.
+
+    They are separate tables on purpose — Plan 01 forbids the profile from ever being a
+    citation, and one shared table would let a profile row surface as a `SearchMatch`.
+    """
+    assert FTS_TABLES == frozenset({"chunks_fts", "profiles_fts"})
+
+
+def test_the_schema_version_is_declared() -> None:
+    """The manifest records it, and a mismatch refuses the query entirely (spec §9.3).
+
+    "2" since C-3/A-3: `items` gained the three per-item omission columns the manifest's
+    `skipped` is summed from, and a v1 base has no such columns. "3" since U-5 (round 07):
+    `chunks.fingerprint` hashes the whole evidence projection — provenance, ownership,
+    position, attribution, narrowed locator — and a v2 base's fingerprints were computed
+    over the text alone, so every row of it would fail verification: the door must refuse
+    it by name rather than answer «22,286 chunks excluded». The pin exists so a layout
+    change cannot ship without the bump that makes an existing index refuse the query.
+    """
+    assert SCHEMA_VERSION == "3"
+
+
+# ---------------------------------------------------------------------------
+# 1b — the rowid cannot be implicit
+# ---------------------------------------------------------------------------
+
+
+def test_chunks_rowid_is_an_explicit_integer_primary_key() -> None:
+    """m1, and THIS is the test that guards it — not the VACUUM round-trip below.
+
+    SQLite documents that `VACUUM` **may** renumber the rowids of a table that is not
+    declared `INTEGER PRIMARY KEY`. *May*. Measured on this interpreter (sqlite 3.51.2, 20
+    rows, half deleted, then `VACUUM`): it did **not** renumber, with either declaration. So
+    a behavioural test that waits for the renumbering to happen is a test that passes for a
+    reason unrelated to the property — CLAUDE.md rule 1 — and would keep passing on the day a
+    different build, a different page layout or a bigger table did renumber.
+
+    The structural assertion is reliable and it is the guard. Seen red by declaring
+    `chunk_id TEXT PRIMARY KEY`: `rowid` is then not a declared column at all.
+    """
+    connection = _connection()
+    columns = {row["name"]: row for row in connection.execute("PRAGMA table_info(chunks)")}
+    assert "rowid" in columns, (
+        "`chunks.rowid` must be DECLARED: an implicit rowid may be renumbered by VACUUM, "
+        "silently repointing every external-content FTS entry at a different chunk"
+    )
+    assert columns["rowid"]["pk"] == 1
+    assert columns["rowid"]["type"] == "INTEGER"
+    assert columns["chunk_id"]["pk"] == 0
+    profile_columns = {
+        row["name"]: row for row in connection.execute("PRAGMA table_info(profiles)")
+    }
+    assert profile_columns["rowid"]["pk"] == 1, "the profile plane has the same trap"
+
+
+def test_the_index_still_answers_the_same_after_a_vacuum(tmp_path: Path) -> None:
+    """A regression guard, and its docstring says exactly what it does and does not prove.
+
+    It proves the index survives a `VACUUM` on a FILE database with reclaimed pages: the same
+    query returns the same `chunk_id`s. It does NOT prove the declaration above is what makes
+    that true — see that test for the measurement. Kept because the failure it would catch
+    (an index that stops answering after a compaction) is real and cheap to check.
+    """
+    path = tmp_path / "knowledge.db"
+    connection = open_index(path, create=True)
+    for index in range(1, 21):
+        _insert_chunk(connection, f"c{index:02d}", f"quillfeather body number {index}")
+    connection.executescript(
+        "INSERT INTO chunks_fts(chunks_fts, rowid, text, title) "
+        "SELECT 'delete', rowid, text, title FROM chunks WHERE chunk_id < 'c10';"
+        "DELETE FROM chunks WHERE chunk_id < 'c10';"
+    )
+    connection.commit()
+
+    def ranked() -> list[str]:
+        return [
+            row[0]
+            for row in connection.execute(
+                "SELECT chunks.chunk_id FROM chunks_fts JOIN chunks "
+                "ON chunks.rowid = chunks_fts.rowid WHERE chunks_fts MATCH ? "
+                "ORDER BY chunks.chunk_id",
+                ('"quillfeather"',),
+            )
+        ]
+
+    before = ranked()
+    assert before, "the fixture must retrieve something before the vacuum"
+    connection.execute("VACUUM")
+    assert ranked() == before
+
+
+def test_a_deleted_chunk_leaves_no_tokens_behind_for_a_reused_rowid(tmp_path: Path) -> None:
+    """Step 7b, ASSERTING THE FAILURE THAT ACTUALLY HAPPENS — not the one the plan sketched.
+
+    Plan 02 §3 says the `'delete'` command must be issued BEFORE the row is removed, and
+    tests it by deleting a chunk and querying for a word that lived only in it. Written that
+    way the test passes with the two statements in EITHER order (verified), because
+    `delete_chunk_rows` reads the old values BEFORE deleting and hands them to FTS5 as
+    parameters — the `'delete'` command never re-reads the content table, so once you have
+    captured the values the ordering constraint is gone. A test that cannot come out any
+    other way is not a test (rule 2).
+
+    The failure that IS real is omitting the retraction. FTS5 keeps the tokens under the old
+    rowid; an `INNER JOIN` hides that while the rowid is unused, and then a LATER chunk lands
+    on the reused rowid and starts matching a word it never contained. Measured: with the
+    retraction dropped, a query for `marrowgate` returns `c2`, whose body is *"a totally
+    different body"*.
+
+    Seen red by deleting the `'delete'` statement from `delete_chunk_rows`.
+    """
+    from xbrain.knowledge.index_schema import delete_chunk_rows
+
+    connection = open_index(tmp_path / "knowledge.db", create=True)
+    _insert_chunk(connection, "c1", "the marrowgate protocol is documented here")
+    connection.commit()
+    (freed,) = connection.execute("SELECT rowid FROM chunks WHERE chunk_id = 'c1'").fetchone()
+
+    delete_chunk_rows(connection, ["c1"])
+    connection.execute(
+        "INSERT INTO chunks (rowid, chunk_id, surface_id, text) VALUES (?,?,?,?)",
+        (freed, "c2", "item:x:post:c2", "a totally different body"),
+    )
+    connection.execute(
+        "INSERT INTO chunks_fts (rowid, text, title) VALUES (?,?,?)",
+        (freed, "a totally different body", ""),
+    )
+    connection.commit()
+
+    rows = connection.execute(
+        "SELECT chunks.chunk_id FROM chunks_fts JOIN chunks ON chunks.rowid = chunks_fts.rowid "
+        "WHERE chunks_fts MATCH ?",
+        ('"marrowgate"',),
+    ).fetchall()
+    assert rows == [], f"a chunk that never held the term matched it: {[r[0] for r in rows]}"
+    assert connection.execute("SELECT COUNT(*) FROM chunks").fetchone()[0] == 1
+
+
+def test_deleting_a_profile_removes_its_terms_from_the_index(tmp_path: Path) -> None:
+    """The same order, the same trap, on the OTHER plane.
+
+    `profiles_fts` is external content over `profiles` for exactly this reason: Plan 02 §2
+    sketched it as `content=''`, and a contentless FTS5 table cannot be deleted from without
+    the ORIGINAL text, which a contentless table by definition does not keep. Storing the
+    profile text in `profiles` makes incremental deletion possible at all, and makes it the
+    same operation as on the chunk plane instead of a second, subtly different one.
+
+    Asserted on `profiles_fts` DIRECTLY rather than through a join, so an orphan entry is
+    visible here instead of being hidden until a rowid is reused. Seen red by dropping the
+    `'delete'` statement from `delete_profile_rows`.
+    """
+    from xbrain.knowledge.index_schema import delete_profile_rows
+
+    connection = open_index(tmp_path / "knowledge.db", create=True)
+    _insert_profile(connection, "i1", "zephyrine appears only in this profile")
+    _insert_profile(connection, "i2", "an ordinary profile")
+    connection.commit()
+
+    delete_profile_rows(connection, ["i1"])
+    connection.commit()
+
+    rows = connection.execute(
+        "SELECT rowid FROM profiles_fts WHERE profiles_fts MATCH ?", ('"zephyrine"',)
+    ).fetchall()
+    assert rows == []
+    assert connection.execute("SELECT COUNT(*) FROM profiles").fetchone()[0] == 1
+
+
+# ---------------------------------------------------------------------------
+# Read-only is a property, not a promise (spec §3.7.12, §5.6)
+# ---------------------------------------------------------------------------
+
+
+def test_a_read_only_connection_refuses_to_write(tmp_path: Path) -> None:
+    """Spec §5.6: *the query operation does not modify or repair the index silently.*
+
+    Opened with `file:…?mode=ro`, so an accidental write is an `OperationalError` rather
+    than a repair nobody asked for. Seen red by opening it read-write.
+    """
+    path = tmp_path / "knowledge.db"
+    open_index(path, create=True).close()
+    connection = open_index(path, read_only=True)
+    with pytest.raises(sqlite3.OperationalError):
+        connection.execute("INSERT INTO chunks (chunk_id, surface_id, text) VALUES ('x','y','z')")
+
+
+def test_opening_a_missing_index_read_only_is_an_actionable_error(tmp_path: Path) -> None:
+    """Step 30: an absent index names `xbrain index build`, never a raw traceback."""
+    from xbrain.knowledge.index_schema import IndexMissingError
+
+    with pytest.raises(IndexMissingError, match="xbrain index build"):
+        open_index(tmp_path / "nope.db", read_only=True)
+
+
+def test_opening_a_missing_database_for_writing_does_not_create_it(tmp_path: Path) -> None:
+    """G-2's second closure: the WRITE door does not create a file outside `build`.
+
+    `open_index(path)` used to `mkdir + connect + create_schema` whenever the file was
+    absent, which is what let `index update --dry-run` leave an empty base under a standing
+    manifest. Creation is now an explicit `create=True`, which only `build` passes; every
+    other writer finds the absence and names the command. And the advice depends on what
+    is left: with a manifest beside the missing file, plain `xbrain index build` REFUSES
+    (a manifest exists), so the sentence has to name `--force`.
+
+    Seen red before the fix: the file existed after the first call.
+    """
+    from xbrain.knowledge.index_schema import IndexMissingError, manifest_path
+
+    path = tmp_path / "index" / "knowledge.db"
+    with pytest.raises(IndexMissingError, match="xbrain index build"):
+        open_index(path)
+    assert not path.exists() and not path.parent.exists()
+
+    path.parent.mkdir()
+    manifest_path(path.parent).write_text("{}", encoding="utf-8")
+    with pytest.raises(IndexMissingError, match="xbrain index build --force"):
+        open_index(path)
+    assert not path.exists()
+
+    open_index(path, create=True).close()
+    assert path.exists()
+
+
+# ---------------------------------------------------------------------------
+# U-4 (round 07) — the schema the door verifies is the EFFECTIVE one: columns too
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "table, column",
+    # `chunks.trust_class` rather than `chunks.origin`: SQLite refuses to drop a column an
+    # index depends on, and `chunks_origin` is one — the staging must survive, or nothing
+    # is tested.
+    [("surfaces", "attribution_name"), ("chunks", "trust_class"), ("items", "store_fingerprint")],
+)
+def test_a_base_missing_a_column_this_code_reads_is_refused_at_the_door(
+    tmp_path: Path, table: str, column: str
+) -> None:
+    """Gate Codex F3 (round 07): `_verify_schema` compared TABLE names, so a base with a
+    column dropped (`ALTER TABLE surfaces DROP COLUMN attribution_name`, `quick_check: ok`)
+    passed the door — `status` certified it healthy, `update` re-sealed the manifest over
+    it with exit 0, and `search` died late in a raw `OperationalError: no such column`.
+    The schema this code needs is the DDL it ships, column by column; the reference is
+    read from that DDL on a `:memory:` connection, never restated, and a column missing
+    from the base names the table, the column and the rebuild.
+
+    Seen red on `9dfa34e`: the door opened.
+    """
+    from xbrain.knowledge.index_schema import REBUILD_ADVICE, IndexIncompatibleError
+
+    path = tmp_path / "knowledge.db"
+    open_index(path, create=True).close()
+    connection = sqlite3.connect(path)
+    connection.execute(f"ALTER TABLE {table} DROP COLUMN {column}")
+    connection.commit()
+    connection.close()
+
+    for open_ in (lambda: open_index(path, read_only=True), lambda: open_index(path)):
+        with pytest.raises(IndexIncompatibleError) as refused:
+            open_()
+        assert f"{table}.{column}" in str(refused.value)
+        assert REBUILD_ADVICE in str(refused.value)
+
+
+def test_a_chunks_table_without_its_explicit_rowid_is_refused_at_the_door(tmp_path: Path) -> None:
+    """The m1 guard, MECHANISED. CLAUDE.md says the explicit `INTEGER PRIMARY KEY` on
+    `chunks` is «the DDL assertion and not a behavioural test that would pass for the wrong
+    reason» — a `VACUUM` MAY renumber an implicit rowid and repoint every FTS entry. The
+    column comparison sees the `pk` flag, so a base whose `chunks` lost the explicit key
+    (recreated by hand, or by a tool that rewrote the table) is refused before a query
+    could read text under the wrong rowid.
+    """
+    from xbrain.knowledge.index_schema import IndexIncompatibleError
+
+    path = tmp_path / "knowledge.db"
+    open_index(path, create=True).close()
+    connection = sqlite3.connect(path)
+    connection.executescript(
+        """
+        CREATE TABLE chunks_implicit AS SELECT * FROM chunks WHERE 0;
+        DROP TABLE chunks;
+        ALTER TABLE chunks_implicit RENAME TO chunks;
+        """
+    )
+    connection.commit()
+    connection.close()
+
+    with pytest.raises(IndexIncompatibleError, match="chunks.rowid"):
+        open_index(path, read_only=True)
+
+
+def test_the_declared_columns_are_read_from_the_ddl_this_code_ships() -> None:
+    """The reference has ONE definition — `create_schema` on `:memory:` — so the door and
+    the DDL cannot drift (rule 5): every declared table is in it, the two FTS planes have
+    their columns, and `chunks.rowid` carries the primary-key flag the m1 guard depends on.
+    """
+    from xbrain.knowledge.index_schema import declared_columns
+
+    reference = declared_columns()
+    assert set(reference) == TABLES | FTS_TABLES
+    assert set(reference["chunks_fts"]) == {"text", "title"}
+    assert reference["chunks"]["rowid"].pk == 1
+    assert reference["profiles"]["rowid"].pk == 1
+    assert reference["surfaces"]["attribution_name"].notnull == 0
+
+
+# ---------------------------------------------------------------------------
+# 2 — the index is derived data and lives outside Git
+# ---------------------------------------------------------------------------
+
+
+def test_the_index_directory_is_git_ignored() -> None:
+    """Step 2: `data/index/` is derived and reconstructible, and never versioned (spec §5.6).
+
+    Asked of GIT, not of `.gitignore`: the file has patterns and a negation (`!data/.gitkeep`)
+    and what matters is git's own verdict. Seen red by adding `!data/index/`.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["git", "check-ignore", "-q", "data/index/manifest.json"],  # noqa: S607
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    assert result.returncode == 0, "data/index/ must be ignored by git"
+
+
+def test_the_index_paths_are_derived_from_the_index_directory(tmp_path: Path) -> None:
+    """One place decides where the database and the manifest live."""
+    assert db_path(tmp_path) == tmp_path / "knowledge.db"
+    assert manifest_path(tmp_path) == tmp_path / "manifest.json"
+
+
+def test_an_index_directory_outside_the_data_root_is_rejected(tmp_path: Path) -> None:
+    """§12.6 (m8): rejecting `..` is NOT the same as checking containment.
+
+    `_reject_local_path_traversal` catches a literal `..`; a SYMLINK pointing outside passes
+    it and fails only a real containment check. So `resolve_index_dir` resolves the path and
+    asserts `is_relative_to(data_dir.resolve())`. Seen red by dropping the `is_relative_to`
+    call: the symlink case then builds a database outside `data/`.
+    """
+    from xbrain.knowledge.index_schema import resolve_index_dir
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (data_dir / "escape").symlink_to(outside)
+
+    assert resolve_index_dir(data_dir, "index") == (data_dir / "index").resolve()
+    with pytest.raises(ValueError, match="fuera de"):
+        resolve_index_dir(data_dir, "escape")
+    with pytest.raises(ValueError, match="relativ"):
+        resolve_index_dir(data_dir, "/etc")
+    with pytest.raises(ValueError, match=r"\.\."):
+        resolve_index_dir(data_dir, "../elsewhere")
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _insert_chunk(connection: sqlite3.Connection, chunk_id: str, text: str) -> None:
+    cursor = connection.execute(
+        "INSERT INTO chunks (chunk_id, surface_id, text) VALUES (?,?,?)",
+        (chunk_id, f"item:x:post:{chunk_id}", text),
+    )
+    connection.execute(
+        "INSERT INTO chunks_fts (rowid, text, title) VALUES (?,?,?)",
+        (cursor.lastrowid, text, ""),
+    )
+
+
+def _insert_profile(connection: sqlite3.Connection, item_id: str, text: str) -> None:
+    cursor = connection.execute(
+        "INSERT INTO profiles (item_id, profile_text) VALUES (?,?)", (item_id, text)
+    )
+    connection.execute(
+        "INSERT INTO profiles_fts (rowid, profile_text) VALUES (?,?)", (cursor.lastrowid, text)
+    )


### PR DESCRIPTION
Child **02.3** of the knowledge-index umbrella: **the persisted index schema only**.
Base `VGonPa/umbrella-knowledge-index-lexical` @ `aa416e1`.

## What this adds

| File | | Lines |
|---|---|---|
| `src/xbrain/knowledge/index_schema.py` | **new** | +679 |
| `tests/test_knowledge_index_schema.py` | **new** | +461 |
| `src/xbrain/knowledge/lexical_fts.py` | modified, **strictly additive** | +42 / **−0** |

**Total `+1182 / −0`.** Three files, zero deletions anywhere.

The DDL, the opening gate, column-drift detection, the FTS probes, and the two
deletion paths that retract tokens. **Nothing that queries it** — the scorer
(`lexical.py`), the build, `get`/`render`, the CLI, config, eval and docs are
later children and none of them is touched here.

## Why the module and its test are one PR

They are one unit of *review*, not two. Every decision in the DDL is invisible
in the DDL — an explicit `rowid`, a retraction before a delete, an external
content table — and is only legible as the behaviour that goes wrong without
it. Splitting them would put 679 lines of un-exercised SQL in one PR and its
only justification in another; the reviewer of the first would have nothing to
read it against. The 461 test lines are what make the 679 reviewable.

## The three decisions that fail silently

**1. `chunks.rowid` is an explicit `INTEGER PRIMARY KEY`** (also `profiles`).
Both FTS5 planes are EXTERNAL CONTENT: they store no text and read it back from
their content table by rowid. SQLite documents that `VACUUM` **may** renumber
the rowids of a table that lacks one — every FTS entry would then point at a
different row, and the index would return wrong text raising nothing.

The guard is **structural, not behavioural, on purpose**: *may* is not *does*.
Measured on this interpreter (sqlite 3.51.2, 20 rows, half deleted, then
`VACUUM`) it did **not** renumber under either declaration — so a round-trip
test would pass for a reason unrelated to the property, and keep passing the
day a different build does renumber. That is CLAUDE.md rule 1.

**2. A delete RETRACTS the old text.** The order of the two statements is *not*
the property — both functions `SELECT` the row before touching anything, so the
values are already captured and either order leaves zero rows behind. The real
defect is **omitting** the retraction: tokens stay under a rowid that no longer
exists, an `INNER JOIN` hides the orphan for as long as nothing reuses it, and
the moment `index update` does, the query returns a chunk whose body is a
completely different one.

**3. `profiles_fts` is external content over `profiles`, which stores the text.**
It was sketched as `content=''`; a contentless FTS5 table cannot be deleted from
without the ORIGINAL text it by definition does not keep, so the incremental
path would have had no way to retract a profile at all.

## Red-first evidence

Both named guards were proved red **by mutation**, not by the module being
absent — a missing-module `ImportError` proves only that an import exists.

| Mutation | Test | Result |
|---|---|---|
| `chunk_id TEXT PRIMARY KEY` replacing the explicit `rowid` | `test_chunks_rowid_is_an_explicit_integer_primary_key` | **FAILED** — ``` `chunks.rowid` must be DECLARED ``` |
| the `'delete'` retraction dropped from `delete_chunk_rows` | `test_a_deleted_chunk_leaves_no_tokens_behind_for_a_reused_rowid` | **FAILED** — `a chunk that never held the term matched it: ['c2']` |

The second is the one that matters: `c2`'s body is *"a totally different body"*.
Not an error — a **wrong answer wearing a right one's shape**. The test only
catches it because it *reuses the freed rowid*; the version this plan originally
sketched (delete a chunk, search its unique word) passes with the bug present.

Reverted, both green: **19/19** in the new file.

## `lexical_fts.py` is additive, and that is load-bearing

The finished monolith **deletes** `_SCHEMA`, `RANK_ORDER` and `create_schema`.
This PR does **not**, because `lexical_memory.py` still consumes all three:

- `src/xbrain/knowledge/lexical_memory.py:22` — imports `RANK_ORDER, create_schema, match_expression`
- `src/xbrain/knowledge/lexical_memory.py:76` — calls `create_schema`
- `src/xbrain/knowledge/lexical_memory.py:158` — interpolates `RANK_ORDER`
- `tests/test_knowledge_lexical_memory.py:30,86` — imports and calls `create_schema`

Shipping the deletion here would leave the tree red at a child boundary. It is
deferred to **02.13**, per the matrix's own F1/R1 rows. Proof of additivity:
`git diff --numstat` reports **`42  0`**, and lines 1–97 are byte-identical to
`aa416e1`.

Old and new agree today, checked by execution rather than by prose:
`rank_order("chunk_fts","chunk") == RANK_ORDER` → `True`, and
`fts5_table_sql("chunk_fts") + ";" in _SCHEMA` → `True`.

## Boundary deviation from the matrix estimate (+1184/−2 → **+1182/−0**)

**The matrix figure is stale, and the difference is a deliberate boundary, not a
shortfall.** That estimate of `+1,184 / 1,186 touched` was computed against the
monolith, and it included the snapshot's `lexical_fts.py` docstring hunk (+4/−2)
— the hunk whose text asserts that **the chunker v2 is shipped and emits 22,286
chunks**. That statement is *not true on this child*: v2 arrives at **02.5**.
Porting the hunk now would land a false claim in this tree to make a line count
match, so it is **deferred to 02.5**, and its absence is the entire reason
"touched" is 1,182 rather than 1,186 — the −2 in the estimate was that hunk's two
deleted lines, and this child deletes nothing at all. Separately, **preserving the
old `_SCHEMA` / `RANK_ORDER` / `create_schema` API costs two formatter lines**: the
40 new API lines are byte-identical to the snapshot, but `ruff format` requires two
blank lines after a top-level `def` before the next top-level statement, and the
snapshot satisfied that for free by *deleting* the 4-line `RANK_ORDER` block, which
freed two adjacent blanks it could reuse. This child is forbidden that deletion, so
it must supply the separators itself (verified: with only one, `ruff format --check`
fails). The coherent child is therefore **+1182 / −0**, and both differences are
consequences of the same rule — a child must not ship a later child's state, and
must not leave the tree red at its own boundary.

## Gate

`bash scripts/check.sh` — see the run log in the PR checks.

One environment note worth recording: the worktree's venv had drifted to
**ruff 0.16.5** while `uv.lock` pins **0.15.13**, and the unsynced binary
reported **693 errors repo-wide** in files this PR never touches (`RUF100`,
`UP017` …). After `uv sync --extra dev`, ruff is clean. This is CLAUDE.md
rule 9 — two instruments, opposite answers, and the fix was naming which
surface was being read.

## Scope

Deliberately **not** here: scorer/search, chunking changes, locator/Evidence v2,
build/update/status, get/render/CLI/config/eval/docs, embeddings, graph, MCP,
recap, automation.

Acceptance: Plan 02 §15.14, §10.1b, §10.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2EqeparawBZBeYrBVbYoG
