### PR TITLE
feat(knowledge): the persisted lexical scorer and its eight filters (Plan 02, child 02.4)

### DIFF
--- a/src/xbrain/knowledge/lexical.py
+++ b/src/xbrain/knowledge/lexical.py
@@ -1,0 +1,707 @@
+"""The lexical retriever over the persisted schema — the SAME scorer, a different home.
+
+This replaces `lexical_memory.InMemoryLexicalIndex` (Plan 02 §9). Plan 01 §5.3 justified
+building the baseline on FTS5 rather than a hand-written BM25 with the claim that *what dies
+in Plan 02 is where the database lives, not how it scores*; this module is where that claim
+is either kept or quietly broken. It is kept: the tokenizer, the indexed column set, the
+connective and the tie-break all come from `lexical_fts.py`, and the only thing that changed
+is the connection — `sqlite3(":memory:")` for the evaluation harness,
+`data/index/knowledge.db` for the real index. The characterization fixture
+(`tests/fixtures/knowledge_ranking.json`) is NOT regenerated, and its assertion moved here
+with the module (m-vii).
+
+FILTERS ARE `WHERE` CLAUSES, NOT QUERY TEXT (spec §5.3). All eight of spec §7.2 are pushed
+into SQL BEFORE the `MATCH` runs, over columns denormalised onto `chunks` (`created_at`,
+`source`, `primary_topic`) and `EXISTS` sub-queries over the metadata tables. The alternative
+— appending the filter's words to the query string — lets the filter compete for bm25 weight
+against the user's terms, and a filter that changes the RANKING is not a filter.
+
+TWO PLANES, TWO RETURN TYPES (spec §5.1). `search` returns `LexicalHit`s, which carry an
+excerpt and resolve back to a surface: they are citable. `search_profiles` returns
+`ProfileHit`s, which carry an item id and a score and NOTHING ELSE. The profile is a string
+nobody wrote — a post, a summary and three topic descriptions glued together — so a shape
+that could not carry an excerpt is what stops it ever being presented as a quotation.
+
+ITEM-SCOPED FILTERS FAIL CLOSED ON TOPIC-OWNED CHUNKS. A `topic_note` has no author, no date
+and no source; `created_at`, `source` and `primary_topic` are NULL on its row, so a date or
+author filter excludes it by construction. The one exception is the topic filter itself,
+which matches a topic surface against its OWN slug — otherwise filtering by a topic would
+exclude exactly the surfaces that ARE that topic.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from pydantic import ValidationError
+
+from xbrain.knowledge.contracts import SearchFilters
+from xbrain.knowledge.index_schema import REBUILD_ADVICE, IndexIncompatibleError
+from xbrain.knowledge.lexical_fts import match_expression, rank_order
+from xbrain.knowledge.models import KnowledgeChunk, Locator, SurfaceType
+from xbrain.models import Author
+
+# How much of a matching chunk is shown back. Long enough to recognise the hit, short enough
+# that a log or a report never carries an article (spec §10.8).
+EXCERPT_CHARS = 300
+
+# The candidate window of a query is counted in OWNERS, never in chunks (U-6, round 07): a
+# transcript matching in seven windows at the top of the ranking held ten chunks and two
+# owners, so a depth of ten CHUNKS answered a question about ten ITEMS with two. The window
+# starts at `OWNER_CHUNK_MULTIPLIER` chunks per owner asked for and DOUBLES while the result
+# set came back full and still holds fewer owners than asked — a set shorter than its limit
+# is the whole ranking, and there is nothing deeper to find — up to `MAX_CHUNK_DEPTH`.
+# Reaching the bound short of owners is DECLARED to the caller, never absorbed. ONE loop,
+# here, for the two consumers that need it (rule 5): the evaluation harness (`_search`) and
+# the search service (M-4, round 08), which decides `truncated` over this window.
+OWNER_CHUNK_MULTIPLIER = 4
+MAX_CHUNK_DEPTH = 10_000
+
+# The fixed SELECT skeletons. Module constants rather than inline literals so the only thing
+# the query builder concatenates at call time is a WHERE clause of bound `?` placeholders
+# plus the `rank_order` string — which is what makes the `# nosec B608` below a statement of
+# fact.
+# The surface columns ride along on a LEFT JOIN by primary key (A-1): the index STORES each
+# surface's attribution and locator, and the first version threw both away between the row
+# and the response — a quoted post came back with `attribution: null` under the poster's
+# name. LEFT, not INNER, because the retriever is also driven bare (`add` without a surface
+# row) by the characterization fixture and the evaluation harness, and a chunk whose
+# surface row is missing must still rank; it simply carries no attribution.
+#
+# The three aliases appear as LITERALS here and in `fetch_chunk`, rather than through one
+# shared f-string: bandit reads any f-string that starts with `SELECT` as B608, and a
+# suppression is a request to stop looking. `_hit` is the one reader of the alias names.
+_SELECT_CHUNKS = (
+    "SELECT chunks.*, "
+    "surfaces.attribution_handle AS surface_attribution_handle, "
+    "surfaces.attribution_name AS surface_attribution_name, "
+    "surfaces.locator_json AS surface_locator_json, "
+    "bm25(chunks_fts) AS score FROM chunks_fts "
+    "JOIN chunks ON chunks.rowid = chunks_fts.rowid "
+    "LEFT JOIN surfaces ON surfaces.surface_id = chunks.surface_id"
+)
+_COUNT_CHUNKS = "SELECT COUNT(*) FROM chunks_fts JOIN chunks ON chunks.rowid = chunks_fts.rowid"
+_SELECT_PROFILES = (
+    "SELECT profiles.item_id, bm25(profiles_fts) AS score FROM profiles_fts "
+    "JOIN profiles ON profiles.rowid = profiles_fts.rowid"
+)
+
+_CHUNK_RANK_ORDER = rank_order("chunks_fts", "chunks")
+_PROFILE_RANK_ORDER = "ORDER BY bm25(profiles_fts) ASC, profiles.item_id ASC"
+
+
+@dataclass(frozen=True)
+class LexicalHit:
+    """One ranked chunk, resolvable back to its surface and owner.
+
+    Carries the owner and the surface, not just a score: spec §3.3 requires reverse
+    resolution from a chunk to its surface and item, and a ranked id nobody can resolve is a
+    number rather than evidence.
+
+    `attribution` is the SURFACE's author — the quoted author of a quoted post, never the
+    poster (spec §3.7 invariant 3) — and `surface_locator` is where the surface lives in the
+    original data; the chunk's `char_start`/`char_end` narrow it to the match (A-1). Both are
+    `None` for a chunk indexed without its surface row.
+    """
+
+    chunk_id: str
+    surface_id: str
+    owner_type: str
+    owner_id: str
+    surface_type: SurfaceType
+    origin: str
+    trust_class: str
+    derived: bool
+    chunk_index: int
+    char_start: int
+    char_end: int
+    title: str | None
+    url: str | None
+    language: str | None
+    fingerprint: str
+    text: str
+    excerpt: str
+    score: float
+    attribution: Author | None = None
+    surface_locator: Locator | None = None
+
+
+def distinct_owners(hits: Sequence[LexicalHit]) -> int:
+    """How many distinct `(owner_type, owner_id)` a ranking prefix holds.
+
+    Public because `search_owners` STOPS on it and `search_service` has to read the same
+    number to know whether a window shorter than it asked for is the whole ranking or just
+    a shallow one (B1). Two readings of «how deep did we get» is how the window and its
+    consumer drift apart, and the drift is invisible until the exclusions bite (rule 5).
+    """
+    return len({(hit.owner_type, hit.owner_id) for hit in hits})
+
+
+@dataclass(frozen=True)
+class ProfileHit:
+    """One ranked ITEM, from the profile plane. Deliberately carries no text.
+
+    Spec §5.1.A: the profile is *a retrieval representation, not a new source returned as a
+    citation*. Two fields, and neither of them can hold a quotation.
+    """
+
+    item_id: str
+    score: float
+
+
+class LexicalIndex:
+    """FTS5 over the persisted schema. Read or write, depending on how the connection opened.
+
+    Takes a `sqlite3.Connection` rather than a path so the caller decides — and so `search`
+    can be handed a `file:…?mode=ro` connection on which a write RAISES rather than silently
+    repairing the index (spec §5.6). That is a property of the object, not a promise about
+    the code.
+    """
+
+    def __init__(self, connection: sqlite3.Connection) -> None:
+        self.connection = connection
+        self.connection.row_factory = sqlite3.Row
+
+    # -- writing -----------------------------------------------------------
+
+    def add(
+        self,
+        chunks: Sequence[KnowledgeChunk],
+        *,
+        created_at: datetime | None = None,
+        source: str | None = None,
+    ) -> int:
+        """Index a batch of chunks. Returns how many were stored.
+
+        `created_at` and `source` are the item's, DENORMALISED onto every chunk of the batch
+        so the date and source filters run before the `MATCH` with no join. They are
+        arguments rather than fields of `KnowledgeChunk` because the chunk is part of the
+        frozen contract and a retrieval-layout copy has no business on it — and because a
+        batch is always one owner's chunks, so one value per call is the honest shape. A
+        topic's chunks pass neither, which is what makes an item-scoped filter exclude them.
+
+        A chunk already present (same `chunk_id`) is skipped rather than duplicated: the
+        emitter can legitimately produce the same chunk twice across two calls, and a
+        duplicate would let one body occupy two ranks.
+
+        A blank body is skipped for the reason the emitters drop a blank surface — there is
+        nothing to retrieve — and `index build` counts the skip so the omission is visible.
+        """
+        stored = 0
+        for chunk in chunks:
+            if not chunk.text.strip():
+                continue
+            cursor = self.connection.execute(
+                "INSERT OR IGNORE INTO chunks (chunk_id, surface_id, owner_type, owner_id, "
+                "surface_type, origin, trust_class, derived, chunk_index, char_start, "
+                "char_end, text, title, url, language, fingerprint, created_at, source, "
+                "primary_topic) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    chunk.chunk_id,
+                    chunk.surface_id,
+                    chunk.owner_type,
+                    chunk.owner_id,
+                    chunk.surface_type,
+                    chunk.origin,
+                    chunk.trust_class,
+                    int(chunk.derived),
+                    chunk.chunk_index,
+                    chunk.char_start,
+                    chunk.char_end,
+                    chunk.text,
+                    chunk.title,
+                    chunk.url,
+                    chunk.language,
+                    chunk.fingerprint,
+                    _iso(created_at),
+                    source,
+                    chunk.topics[0] if chunk.topics else None,
+                ),
+            )
+            if cursor.rowcount:
+                # The FTS row carries the SAME rowid as its metadata row, which is what lets
+                # the join be a plain equality — and is why `rowid INTEGER PRIMARY KEY` is
+                # declared explicitly in `index_schema` (VACUUM renumbers an implicit one).
+                self.connection.execute(
+                    "INSERT INTO chunks_fts (rowid, text, title) VALUES (?,?,?)",
+                    (cursor.lastrowid, chunk.text, chunk.title or ""),
+                )
+                stored += 1
+        return stored
+
+    def add_profile(self, item_id: str, text: str, fingerprint: str) -> bool:
+        """Store one item profile on its own plane. Returns whether it was written."""
+        if not text.strip():
+            return False
+        cursor = self.connection.execute(
+            "INSERT OR IGNORE INTO profiles (item_id, profile_text, fingerprint) VALUES (?,?,?)",
+            (item_id, text, fingerprint),
+        )
+        if not cursor.rowcount:
+            return False
+        self.connection.execute(
+            "INSERT INTO profiles_fts (rowid, profile_text) VALUES (?,?)",
+            (cursor.lastrowid, text),
+        )
+        return True
+
+    def set_item_metadata(
+        self,
+        item_id: str,
+        *,
+        source: str = "bookmark",
+        url: str = "",
+        author_handle: str = "",
+        author_name: str = "",
+        created_at: datetime | None = None,
+        captured_at: datetime | None = None,
+        primary_topic: str | None = None,
+        note_path: str | None = None,
+        bookmark_folder: str | None = None,
+        store_fingerprint: str = "",
+        topics: tuple[str, ...] = (),
+        content_kinds: tuple[str, ...] = (),
+        surface_types: tuple[str, ...] = (),
+    ) -> None:
+        """Write the filterable metadata of one item, replacing whatever was there.
+
+        The `surface_types` argument writes MINIMAL rows into `surfaces` — enough for the
+        `has_surfaces` filter and no more. The full surface records come from `index_build`,
+        which has the emitter's output; this keeps the retriever testable on its own without
+        a second, divergent way of populating the table.
+        """
+        self.connection.execute(
+            "INSERT OR REPLACE INTO items (item_id, source, url, author_handle, author_name, "
+            "created_at, captured_at, primary_topic, note_path, bookmark_folder, "
+            "store_fingerprint) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                item_id,
+                source,
+                url,
+                author_handle,
+                author_name,
+                _iso(created_at),
+                _iso(captured_at),
+                primary_topic,
+                note_path,
+                bookmark_folder,
+                store_fingerprint,
+            ),
+        )
+        self.connection.execute("DELETE FROM item_topics WHERE item_id = ?", (item_id,))
+        for position, slug in enumerate(topics):
+            self.connection.execute(
+                "INSERT OR REPLACE INTO item_topics (item_id, slug, is_primary) VALUES (?,?,?)",
+                (item_id, slug, int(position == 0 and slug == (primary_topic or topics[0]))),
+            )
+        self.connection.execute("DELETE FROM item_content_kinds WHERE item_id = ?", (item_id,))
+        for kind in content_kinds:
+            self.connection.execute(
+                "INSERT OR REPLACE INTO item_content_kinds (item_id, kind) VALUES (?,?)",
+                (item_id, kind),
+            )
+        for surface_type in surface_types:
+            self.connection.execute(
+                "INSERT OR REPLACE INTO surfaces (surface_id, owner_type, owner_id, "
+                "surface_type, origin, trust_class, derived, locator_json, fingerprint, "
+                "char_length) VALUES (?,?,?,?,?,?,?,?,?,?)",
+                (
+                    f"item:{item_id}:{surface_type}:0",
+                    "item",
+                    item_id,
+                    surface_type,
+                    "source",
+                    "primary_source",
+                    0,
+                    "{}",
+                    "0" * 64,
+                    0,
+                ),
+            )
+
+    # -- reading -----------------------------------------------------------
+
+    def search(
+        self,
+        query: str,
+        limit: int,
+        *,
+        filters: SearchFilters | None = None,
+        surface_types: tuple[SurfaceType, ...] = (),
+        owner_ids: tuple[str, ...] = (),
+    ) -> tuple[LexicalHit, ...]:
+        """The top `limit` chunks for `query`, best first, deterministic under ties.
+
+        `surface_types` and `owner_ids` are NOT among spec §7.2's eight — they are internal
+        narrowing used by `get` (rank inside one item's long source) and by the evaluation
+        harness. They are kept off `SearchFilters` because that model is the FROZEN external
+        contract and adding to it would be the incompatible change the freeze prevents.
+
+        An empty query is a validation error, not an empty result (spec §9.3): an empty
+        result set claims something about the corpus, when the truth is that nothing was
+        asked. A non-positive limit is the same mistake wearing a different hat.
+        """
+        expression = self._expression(query, limit)
+        if expression is None:
+            return ()
+        clauses, params = self._where(expression, filters, surface_types, owner_ids)
+        sql = f"{_SELECT_CHUNKS} WHERE {' AND '.join(clauses)} {_CHUNK_RANK_ORDER} LIMIT ?"  # nosec B608
+        rows = self._fetch(sql, (*params, limit))
+        return tuple(_hit(row) for row in rows)
+
+    def search_owners(
+        self, query: str, owners: int, *, filters: SearchFilters | None = None
+    ) -> tuple[tuple[LexicalHit, ...], bool]:
+        """The ranking's prefix deep enough to hold `owners` DISTINCT owners, in rank order.
+
+        Returns `(hits, depth_exhausted)`. `hits` is a prefix of the full ranking — the
+        same rows `search` returns for the chunk limit reached — so a caller that groups
+        by owner sees a list that is prefix-consistent across depths: a deeper window only
+        appends. `depth_exhausted` is True when `MAX_CHUNK_DEPTH` was reached with fewer
+        owners than asked; the harness declares it on the case and the service declares
+        a truncation it cannot page (both say so, neither guesses).
+        """
+        chunk_limit = max(owners * OWNER_CHUNK_MULTIPLIER, 1)
+        while True:
+            hits = self.search(query, chunk_limit, filters=filters)
+            if distinct_owners(hits) >= owners or len(hits) < chunk_limit:
+                return hits, False
+            if chunk_limit >= MAX_CHUNK_DEPTH:
+                return hits, True
+            chunk_limit = min(chunk_limit * 2, MAX_CHUNK_DEPTH)
+
+    def search_profiles(
+        self, query: str, limit: int, *, filters: SearchFilters | None = None
+    ) -> tuple[ProfileHit, ...]:
+        """The top `limit` ITEMS for `query` on the profile plane (spec §5.1.A).
+
+        The two planes are NOT fused here and their bm25 scores are not comparable: they are
+        computed over different corpora, so a single sorted merge would invent a scale.
+        Fusion is Plan 03's decision, with RRF and the golden set in front of it.
+
+        AN ORIGIN FILTER YIELDS NOTHING ON THIS PLANE (G-1). `origins` is a property of the
+        TEXT that matched — spec §7.2's `--origin vlm` asks for the figure *seen in an image*
+        — and a profile is a string nobody wrote, composed from a post, a summary and three
+        topic descriptions: it has no origin to satisfy. Until round 04 the seven item-scoped
+        filters reached this plane and `origins` did not, so `search "Forecasting" --origin
+        asr` on the real corpus answered 8 items, 6 of them without one ASR surface and 7
+        without one citable match. Failing closed here is the same shape as a topic chunk
+        under an author filter: what cannot satisfy the question is not a candidate for it.
+        """
+        expression = self._expression(query, limit)
+        if expression is None:
+            return ()
+        if filters is not None and filters.origins:
+            return ()
+        clauses = ["profiles_fts MATCH ?"]
+        params: list[object] = [expression]
+        if filters is not None:
+            item_clauses, item_params = _item_clauses(filters, "profiles.item_id")
+            clauses += item_clauses
+            params += item_params
+        sql = f"{_SELECT_PROFILES} WHERE {' AND '.join(clauses)} {_PROFILE_RANK_ORDER} LIMIT ?"  # nosec B608
+        rows = self._fetch(sql, (*params, limit))
+        return tuple(ProfileHit(item_id=row["item_id"], score=float(row["score"])) for row in rows)
+
+    def explain(self, query: str, filters: SearchFilters | None = None) -> tuple[str, ...]:
+        """`EXPLAIN QUERY PLAN` for the filtered search, as sqlite's own `detail` strings.
+
+        Exposed so a test can assert that the backend USES an index for the filtered column
+        rather than scanning the corpus (m3). Asserting the SQL string would only prove that
+        we wrote that string.
+        """
+        expression = match_expression(query) or ""
+        clauses, params = self._where(expression, filters, (), ())
+        sql = f"{_SELECT_CHUNKS} WHERE {' AND '.join(clauses)} {_CHUNK_RANK_ORDER}"  # nosec B608
+        return tuple(
+            row["detail"] for row in self.connection.execute(f"EXPLAIN QUERY PLAN {sql}", params)
+        )
+
+    def scored_row_count(self, query: str, filters: SearchFilters | None = None) -> int:
+        """How many rows the filtered query hands the scorer — the second half of m3.
+
+        A filter that runs shows up as FEWER rows reaching bm25. A filter applied afterwards
+        would leave this number unchanged and only shorten the output.
+        """
+        expression = match_expression(query)
+        if expression is None:
+            return 0
+        clauses, params = self._where(expression, filters, (), ())
+        sql = f"{_COUNT_CHUNKS} WHERE {' AND '.join(clauses)}"  # nosec B608
+        row = self.connection.execute(sql, params).fetchone()
+        return int(row[0])
+
+    def fetch_chunk(self, chunk_id: str) -> LexicalHit | None:
+        """One chunk by id, with everything needed to verify its fingerprint."""
+        row = self.connection.execute(
+            "SELECT chunks.*, "
+            "surfaces.attribution_handle AS surface_attribution_handle, "
+            "surfaces.attribution_name AS surface_attribution_name, "
+            "surfaces.locator_json AS surface_locator_json, "
+            "0.0 AS score FROM chunks "
+            "LEFT JOIN surfaces ON surfaces.surface_id = chunks.surface_id "
+            "WHERE chunk_id = ?",
+            (chunk_id,),
+        ).fetchone()
+        return _hit(row) if row is not None else None
+
+    def __len__(self) -> int:
+        return int(self.connection.execute("SELECT COUNT(*) FROM chunks").fetchone()[0])
+
+    # -- internals ---------------------------------------------------------
+
+    def _expression(self, query: str, limit: int) -> str | None:
+        if not query.strip():
+            raise ValueError("la consulta está vacía")
+        if limit <= 0:
+            raise ValueError(f"limit debe ser >= 1, recibido {limit}")
+        return match_expression(query)
+
+    def _where(
+        self,
+        expression: str,
+        filters: SearchFilters | None,
+        surface_types: tuple[SurfaceType, ...],
+        owner_ids: tuple[str, ...],
+    ) -> tuple[list[str], list[object]]:
+        """The WHERE clauses and their bound parameters — never an interpolated value."""
+        clauses = ["chunks_fts MATCH ?"]
+        params: list[object] = [expression]
+        if filters is not None:
+            chunk_clauses, chunk_params = _chunk_clauses(filters)
+            clauses += chunk_clauses
+            params += chunk_params
+            item_clauses, item_params = _item_clauses(filters, "chunks.owner_id")
+            clauses += item_clauses
+            params += item_params
+            topic_clause, topic_params = _topic_clause(filters)
+            if topic_clause:
+                clauses.append(topic_clause)
+                params += topic_params
+        if surface_types:
+            clauses.append(f"chunks.surface_type IN ({_placeholders(len(surface_types))})")
+            params += list(surface_types)
+        if owner_ids:
+            clauses.append(f"chunks.owner_id IN ({_placeholders(len(owner_ids))})")
+            params += list(owner_ids)
+        return clauses, params
+
+    def _fetch(self, sql: str, params: tuple[object, ...]) -> list[sqlite3.Row]:
+        try:
+            return list(self.connection.execute(sql, params))
+        except sqlite3.OperationalError as error:
+            # A MATCH expression FTS5's parser rejects degrades to "no results", HERE AND
+            # ONLY HERE: the query was understood as data and simply held nothing FTS5
+            # could parse. The first version caught every `OperationalError` except a
+            # read-only one — chosen by substring, rule 9 in miniature — so `no such table`,
+            # `database is locked` and `disk I/O error` all came back as "the corpus holds
+            # nothing" (C-2). The parser's own error family is the closed set the branch was
+            # written for, and it is matched positively. Everything else is a base this code
+            # cannot read and is CONVERTED like the rest of the family below (U-4): the C-2
+            # fix re-raised it raw, and `no such column: surfaces.attribution_name` reached
+            # the operator as a traceback naming no command.
+            if _is_fts_parse_error(error):
+                return []
+            raise IndexIncompatibleError(
+                f"La base del índice no se puede consultar ({error}). {REBUILD_ADVICE}"
+            ) from error
+        except sqlite3.DatabaseError as error:
+            # The REST of the family — `fts5: corruption found reading blob…`, `file is not
+            # a database`, `database disk image is malformed` — is what a corrupt or
+            # amputated base raises at QUERY time, past the page-1 and schema checks of the
+            # open door (G-4). It is neither an `IndexError_` nor an `OSError`, so it
+            # reached the operator as a 68-line traceback naming no command; Plan 02 §11
+            # tabulates it as *base corrupta -> error accionable con `index build --force`*.
+            raise IndexIncompatibleError(
+                f"La base del índice no se puede consultar ({error}). {REBUILD_ADVICE}"
+            ) from error
+
+
+# What FTS5's expression parser says when it cannot parse — measured on sqlite 3.51.2 with
+# `NEAR(`, `"unterminated` and `*`. A closed, positive list: an error that is not one of these
+# is not a parse error and must not be read as an empty corpus.
+_FTS_PARSE_ERRORS: tuple[str, ...] = (
+    "fts5: syntax error",
+    "unterminated string",
+    "unknown special query",
+)
+
+
+def _is_fts_parse_error(error: sqlite3.OperationalError) -> bool:
+    message = str(error)
+    return any(message.startswith(prefix) for prefix in _FTS_PARSE_ERRORS)
+
+
+def _chunk_clauses(filters: SearchFilters) -> tuple[list[str], list[object]]:
+    """Filters that live on the DENORMALISED columns of `chunks` — no join at all.
+
+    `created_at`, `source` and `origin` are copied onto every chunk precisely so these run
+    before the `MATCH` without a per-query join. A topic-owned chunk has NULL in the first
+    two, so a date or source filter excludes it by construction — which is the right answer,
+    since a topic note has no date and no source of its own.
+    """
+    clauses: list[str] = []
+    params: list[object] = []
+    if filters.created_from is not None:
+        clauses.append("chunks.created_at >= ?")
+        params.append(filters.created_from.isoformat())
+    if filters.created_to is not None:
+        clauses.append("chunks.created_at <= ?")
+        params.append(filters.created_to.isoformat())
+    if filters.source is not None:
+        clauses.append("chunks.source = ?")
+        params.append(filters.source)
+    if filters.origins:
+        clauses.append(f"chunks.origin IN ({_placeholders(len(filters.origins))})")
+        params += list(filters.origins)
+    return clauses, params
+
+
+def _item_clauses(filters: SearchFilters, owner_column: str) -> tuple[list[str], list[object]]:
+    """Filters that need the item tables, as `EXISTS` sub-queries on the owner id.
+
+    `owner_column` is a CALLER-CHOSEN identifier from a closed set of two (`chunks.owner_id`,
+    `profiles.item_id`), never a user string — the two planes ask the same questions of the
+    same tables and a second copy of these clauses would be the divergence rule 5 is about.
+
+    What is NOT here, and where it is: `origins` is a CHUNK property (`_chunk_clauses`), and
+    on the profile plane it is answered by `search_profiles` returning nothing at all, because
+    a profile has no origin (G-1). The totality test over both planes
+    (`test_every_declared_filter_is_pushed_on_the_profile_plane_too`) is what keeps the two
+    planes agreeing on all eight, this docstring only says where each one lives.
+    """
+    clauses: list[str] = []
+    params: list[object] = []
+    if filters.author is not None:
+        clauses.append(
+            f"EXISTS (SELECT 1 FROM items WHERE items.item_id = {owner_column} "  # nosec B608
+            "AND items.author_handle = ?)"
+        )
+        params.append(filters.author)
+    if filters.content_kinds:
+        clauses.append(
+            "EXISTS (SELECT 1 FROM item_content_kinds WHERE item_content_kinds.item_id = "  # nosec B608
+            f"{owner_column} AND item_content_kinds.kind IN "
+            f"({_placeholders(len(filters.content_kinds))}))"
+        )
+        params += list(filters.content_kinds)
+    if filters.has_surfaces:
+        clauses.append(
+            f"EXISTS (SELECT 1 FROM surfaces WHERE surfaces.owner_id = {owner_column} "  # nosec B608
+            f"AND surfaces.owner_type = 'item' AND surfaces.surface_type IN "
+            f"({_placeholders(len(filters.has_surfaces))}))"
+        )
+        params += list(filters.has_surfaces)
+    if owner_column != "chunks.owner_id":
+        # The profile plane has no chunk row to read `source`/`created_at` off, so the two
+        # denormalised filters are answered from `items` instead. Same question, same table
+        # family, and the chunk plane keeps its faster path.
+        if filters.source is not None:
+            clauses.append(
+                f"EXISTS (SELECT 1 FROM items WHERE items.item_id = {owner_column} "  # nosec B608
+                "AND items.source = ?)"
+            )
+            params.append(filters.source)
+        if filters.created_from is not None:
+            clauses.append(
+                f"EXISTS (SELECT 1 FROM items WHERE items.item_id = {owner_column} "  # nosec B608
+                "AND items.created_at >= ?)"
+            )
+            params.append(filters.created_from.isoformat())
+        if filters.created_to is not None:
+            clauses.append(
+                f"EXISTS (SELECT 1 FROM items WHERE items.item_id = {owner_column} "  # nosec B608
+                "AND items.created_at <= ?)"
+            )
+            params.append(filters.created_to.isoformat())
+        if filters.topics:
+            clauses.append(
+                f"EXISTS (SELECT 1 FROM item_topics WHERE item_topics.item_id = {owner_column} "  # nosec B608
+                f"AND item_topics.slug IN ({_placeholders(len(filters.topics))}))"
+            )
+            params += list(filters.topics)
+    return clauses, params
+
+
+def _topic_clause(filters: SearchFilters) -> tuple[str, list[object]]:
+    """The topic filter on the CHUNK plane, with its one exception.
+
+    An item chunk matches through `item_topics`. A TOPIC-owned chunk matches against its own
+    slug: without that branch, filtering by a topic would exclude exactly the surfaces that
+    ARE the topic — a `topic_note` about `ai-policy` would vanish from `--topic ai-policy`,
+    which reads as "the topic has no notes" rather than as a shape of the filter.
+    """
+    if not filters.topics:
+        return "", []
+    placeholders = _placeholders(len(filters.topics))
+    clause = (
+        "(EXISTS (SELECT 1 FROM item_topics WHERE item_topics.item_id = chunks.owner_id "  # nosec B608
+        f"AND item_topics.slug IN ({placeholders})) "
+        f"OR (chunks.owner_type = 'topic' AND chunks.owner_id IN ({placeholders})))"
+    )
+    return clause, [*filters.topics, *filters.topics]
+
+
+def _placeholders(count: int) -> str:
+    """`?,?,?` for a variadic `IN` clause — derived from a COUNT, never from a caller string.
+
+    The one SQL fragment this module builds dynamically, and it is built from an integer, so
+    it cannot carry a caller's text into the statement no matter what was passed. Extracted
+    as a function so that claim is structurally true and checkable in one line, rather than a
+    promise attached to an f-string.
+    """
+    return ",".join("?" * count)
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _surface_locator(raw: str | None) -> Locator | None:
+    """The surface's locator, or None when the row carries none a `Locator` can hold.
+
+    `set_item_metadata` writes `{}` for the minimal surface rows the retriever's own tests
+    use, and a chunk indexed bare has no row at all; neither is a locator, and inventing one
+    would be the fabrication A-1 removed.
+    """
+    if not raw:
+        return None
+    try:
+        return Locator.model_validate_json(raw)
+    except ValidationError:
+        return None
+
+
+def _attribution(row: sqlite3.Row) -> Author | None:
+    handle = row["surface_attribution_handle"]
+    if handle is None:
+        return None
+    return Author(handle=handle, name=row["surface_attribution_name"] or "")
+
+
+def _hit(row: sqlite3.Row) -> LexicalHit:
+    return LexicalHit(
+        chunk_id=row["chunk_id"],
+        surface_id=row["surface_id"],
+        owner_type=row["owner_type"],
+        owner_id=row["owner_id"],
+        surface_type=row["surface_type"],
+        origin=row["origin"],
+        trust_class=row["trust_class"],
+        derived=bool(row["derived"]),
+        chunk_index=row["chunk_index"],
+        char_start=row["char_start"],
+        char_end=row["char_end"],
+        title=row["title"],
+        url=row["url"],
+        language=row["language"],
+        fingerprint=row["fingerprint"],
+        text=row["text"],
+        excerpt=row["text"][:EXCERPT_CHARS],
+        score=float(row["score"]),
+        attribution=_attribution(row),
+        surface_locator=_surface_locator(row["surface_locator_json"]),
+    )

--- a/tests/test_knowledge_lexical.py
+++ b/tests/test_knowledge_lexical.py
@@ -1,0 +1,928 @@
+# tests/test_knowledge_lexical.py
+"""The lexical retriever over the PERSISTED schema (Plan 02 §1, §4.2, steps 12, 12b, 16, 17).
+
+THIS FILE IS WHERE `tests/test_knowledge_lexical_memory.py` WENT (m-vii). Plan 02 §9 deletes
+`lexical_memory.py` — the `:memory:` wrapper — and the plan's first draft said "and its
+test", which would have left `tests/fixtures/knowledge_ranking.json` with nobody reading it:
+the chunker sweep of §7 could then change the ranking and nothing would go red, which is the
+exact hole the fixture exists to close. Every assertion of the old file is here, unchanged in
+substance, now aimed at `LexicalIndex`.
+
+WHAT MAKES THE MOVE LEGITIMATE, rather than a fixture quietly re-pointed at a new
+implementation: the scorer did not change. `lexical_fts.py` owns the tokenizer, the column
+set, the connective and the tie-break, and both the in-memory baseline and the persisted
+index compose their DDL from it. What changed is where the database lives — `:memory:` ->
+`data/index/knowledge.db` — which is precisely what Plan 01 §5.3 promised would be the only
+difference. So the fixture still pins ONE scorer across time, and it is NOT regenerated.
+
+FILTERS ARE `WHERE` CLAUSES, NEVER QUERY TEXT (spec §5.3). Appending a topic or a date to the
+query string would let the filter's own words compete for bm25 weight against the user's
+terms — a filter that changes the RANKING is not a filter. The eight filters of spec §7.2 are
+therefore asserted three ways each where it matters: that they change the result set, that
+`EXPLAIN QUERY PLAN` shows the backend using an index rather than scanning, and that the
+number of rows the scorer sees actually falls (m3 — asserting the SQL string only proves we
+wrote that string).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from xbrain.knowledge.chunking import ChunkerParams, chunk_surfaces
+from xbrain.knowledge.contracts import SearchFilters
+from xbrain.knowledge.index_schema import open_index, open_memory_index
+from xbrain.knowledge import lexical
+from xbrain.knowledge.lexical import LexicalIndex
+from xbrain.knowledge.lexical_fts import FTS_CONNECTIVE, FTS_TOKENIZE
+from xbrain.knowledge.models import KnowledgeChunk, KnowledgeSurface, Locator
+from xbrain.knowledge.surfaces import item_surfaces
+from xbrain.models import Item
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# The parameters the ranking fixture was built with, PINNED HERE and passed explicitly (M7).
+# Plan 02 §7 sweeps `target x overlap` and bumps CHUNKER_VERSION; if this read the module
+# constant, that sweep would break the fixture it exists to protect, and the comfortable fix
+# would be to regenerate it — at which point it pins nothing.
+PINNED_CHUNKER_PARAMS = ChunkerParams(target=1200, max_chars=2000, overlap=150, min_chars=40)
+
+# AND THE VERSION, for the same reason and through the same door — the gap Plan 02 §7's M7
+# note left open. It made the PARAMS an argument so the sweep could not move the fixture, and
+# then mandated a `CHUNKER_VERSION` bump when the sweep changed them. But `chunk_id` ENDS in
+# the chunker version, so the bump renames every id the fixture pins and breaks it just as
+# surely — from the very section that promised it would stay green without regenerating.
+#
+# Pinning the version loses nothing the fixture exists to protect: the version is a label in
+# the id and contributes no character to the ranking, while the SPANS come from the params,
+# which are pinned beside it. Change the chunking and this still goes red.
+PINNED_CHUNKER_VERSION = "xbrain-knowledge-chunker/v1"
+
+
+# Every item genuinely has a creation and a capture instant, so `items` declares both NOT
+# NULL and the helper below supplies them where the test does not care which they are.
+_STAMP = {
+    "created_at": datetime(2025, 1, 1, tzinfo=timezone.utc),
+    "captured_at": datetime(2025, 1, 2, tzinfo=timezone.utc),
+}
+
+
+def _index() -> LexicalIndex:
+    return LexicalIndex(open_memory_index())
+
+
+def _corpus_chunks(
+    *,
+    params: ChunkerParams = PINNED_CHUNKER_PARAMS,
+    chunker_version: str = PINNED_CHUNKER_VERSION,
+) -> list[KnowledgeChunk]:
+    """The fixture corpus, chunked with parameters the CALLER names.
+
+    Both are arguments defaulting to the PINNED values, so the characterization test gets the
+    Plan 01 provisional whatever the module defaults become, and the winner's test asks for
+    the module defaults explicitly. Neither reads a constant by accident.
+    """
+    raw = json.loads((FIXTURES / "knowledge_corpus.json").read_text(encoding="utf-8"))
+    chunks: list[KnowledgeChunk] = []
+    for item_raw in raw["items"].values():
+        item = Item.model_validate(item_raw)
+        chunks += list(
+            chunk_surfaces(
+                item_surfaces(item),
+                params=params,
+                url=item.url,
+                chunker_version=chunker_version,
+            )
+        )
+    return chunks
+
+
+def _chunk(chunk_id: str, text: str, surface_id: str = "item:x:post:0", **kwargs) -> KnowledgeChunk:
+    fields: dict = {
+        "chunk_id": chunk_id,
+        "surface_id": surface_id,
+        "owner_type": "item",
+        "owner_id": "x",
+        "surface_type": "post",
+        "text": text,
+        "chunk_index": 0,
+        "char_start": 0,
+        "char_end": len(text),
+        "origin": "source",
+        "trust_class": "primary_source",
+        "derived": False,
+        "fingerprint": "f" * 64,
+    }
+    fields.update(kwargs)
+    return KnowledgeChunk(**fields)
+
+
+# ---------------------------------------------------------------------------
+# U-4 (round 07) — a late SQLite failure at query time is the rebuild advice, never raw
+# ---------------------------------------------------------------------------
+
+
+def test_a_column_that_vanishes_after_the_door_is_the_rebuild_advice_not_a_traceback() -> None:
+    """Gate Codex F3: `_fetch` re-raised every `OperationalError` that was not an FTS parse
+    error, so a schema the door had not verified (columns, until U-4) reached the operator
+    as `OperationalError: no such column: surfaces.attribution_name` inside a 60-line
+    traceback. The door verifies columns now; this pins the OTHER half — whatever SQLite
+    raises past the door that is not the parser saying «I could not parse your query» is
+    a base this code cannot read, and it ends in the one sentence that names the rebuild.
+
+    Staged AFTER the door: the column is dropped on the open connection, which is the only
+    way a query can meet it. Seen red on `9dfa34e`: a raw `sqlite3.OperationalError`.
+    """
+    from xbrain.knowledge.index_schema import REBUILD_ADVICE, IndexIncompatibleError
+
+    index = _index()
+    index.add([_chunk("c1", "marrowgate body")])
+    index.connection.execute("ALTER TABLE surfaces DROP COLUMN attribution_name")
+
+    with pytest.raises(IndexIncompatibleError, match="no such column") as refused:
+        index.search("marrowgate", 5)
+    assert REBUILD_ADVICE in str(refused.value)
+    # The parser's own family still degrades to «no results» on a sound base — a query the
+    # parser refuses is data that held nothing, not a base this code cannot read (C-2).
+    sound = _index()
+    sound.add([_chunk("c1", "marrowgate body")])
+    assert sound.search("NEAR(a b", 5) == ()
+
+
+# ---------------------------------------------------------------------------
+# The engine — moved verbatim in substance from test_knowledge_lexical_memory.py
+# ---------------------------------------------------------------------------
+
+
+def test_fts5_and_bm25_are_available_in_this_interpreter() -> None:
+    """A precondition, asserted rather than assumed.
+
+    If FTS5 were compiled out of the local sqlite, every ranking test below would fail with
+    an opaque `sqlite3.OperationalError` from deep inside the index. Failing here, by name,
+    is the difference between "your Python has no FTS5" and "the ranking changed".
+    """
+    connection = open_memory_index()
+    connection.execute("INSERT INTO chunks_fts (rowid, text, title) VALUES (1, 'hola mundo', '')")
+    rows = connection.execute(
+        "SELECT rowid, bm25(chunks_fts) FROM chunks_fts WHERE chunks_fts MATCH ?", ("hola",)
+    ).fetchall()
+    assert rows and isinstance(rows[0][1], float)
+
+
+def test_the_tokenizer_folds_diacritics() -> None:
+    """`unicode61 remove_diacritics 2` — a Spanish query must reach an unaccented body.
+
+    The corpus is bilingual and the queries are written in Spanish; without folding,
+    "evaluacion" and "evaluación" are two different terms and half the golden set's own
+    queries would miss. ONE constant, so the persisted index and the fixture cannot drift.
+    """
+    assert "remove_diacritics 2" in FTS_TOKENIZE
+    index = _index()
+    index.add([_chunk("c1", "La evaluación automática de agentes")])
+    assert [hit.chunk_id for hit in index.search("evaluacion", limit=5)] == ["c1"]
+
+
+def test_there_is_no_stemming_and_the_limit_is_documented_not_hidden() -> None:
+    """FTS5 has no multilingual stemmer, and an English one would wreck the Spanish half.
+
+    So "agent" does not match "agents" — a REAL limitation of the lexical baseline, and one
+    the vector layer of Plan 03 has to beat. Pinning it as a test is what keeps the published
+    baseline honest: a limit nobody wrote down gets quietly attributed to the corpus instead
+    of to the tokenizer.
+    """
+    index = _index()
+    index.add([_chunk("c1", "evaluating agents in production")])
+    assert index.search("agent", limit=5) == ()
+    assert index.search("agents", limit=5)
+
+
+# ---------------------------------------------------------------------------
+# 16 — stable tie-break
+# ---------------------------------------------------------------------------
+
+
+def test_ties_break_on_chunk_id_ascending() -> None:
+    """Step 16 / spec §3.7.8: the order is STABLE under ties.
+
+    Two chunks with identical text get an identical bm25 score, and sqlite's row order for a
+    tie is an implementation detail — so without an explicit second key the ranking would
+    differ between rebuilds of the same data. Seen red by dropping `, chunk_id ASC` from
+    `rank_order`: the pair comes back in insertion order and reverses when inserted the other
+    way round.
+    """
+    text = "identical body text for both chunks"
+    forward = _index()
+    forward.add([_chunk("b:2", text), _chunk("a:1", text)])
+    backward = _index()
+    backward.add([_chunk("a:1", text), _chunk("b:2", text)])
+    assert [h.chunk_id for h in forward.search("identical", limit=5)] == ["a:1", "b:2"]
+    assert [h.chunk_id for h in backward.search("identical", limit=5)] == ["a:1", "b:2"]
+
+
+def test_the_query_is_escaped_not_interpolated() -> None:
+    """A quote or an FTS operator in a query must not become syntax.
+
+    Spec §9.3 asks for a stable validation error rather than a crash, and the golden set
+    contains literal queries like `@simonw` and `11.37%` whose punctuation FTS5 would
+    otherwise read as operators.
+    """
+    index = _index()
+    index.add([_chunk("c1", "the handle is @simonw here")])
+    assert [h.chunk_id for h in index.search("@simonw", limit=5)] == ["c1"]
+    assert index.search('"unbalanced', limit=5) == ()
+    assert index.search("NEAR(", limit=5) == ()
+
+
+def test_an_empty_query_is_a_validation_error() -> None:
+    """Step 14 / spec §9.3: an empty query is a stable error, not an empty result set.
+
+    Empty results would say "nothing in your corpus matches", which is a claim about the
+    corpus; the truth is that nothing was asked.
+    """
+    index = _index()
+    with pytest.raises(ValueError, match="vacía"):
+        index.search("   ", limit=5)
+
+
+def test_a_non_positive_limit_is_a_validation_error() -> None:
+    """Spec §9.3 / Plan 02 §11: `--limit 0` or negative is a validation error.
+
+    `LIMIT 0` returns nothing, which would read as "your corpus has no match" — a claim about
+    the corpus made by a malformed request.
+    """
+    index = _index()
+    with pytest.raises(ValueError, match="limit"):
+        index.search("anything", limit=0)
+
+
+# ---------------------------------------------------------------------------
+# 17 — the characterization fixture, MOVED here from the deleted module's test
+# ---------------------------------------------------------------------------
+
+RANKING_QUERIES = (
+    "Quillfeather",
+    "Marrowgate protocol",
+    "Bramblewick",
+    "Cindervale checklist",
+    "Thistledown",
+    "Pelicanine",
+    # Two distinctive terms that never co-occur in one chunk (M3). The six above CANNOT
+    # discriminate the connective — their rankings are byte-identical under a conjunction and
+    # a disjunction — so a change to the query semantics, which moves every recall number
+    # downstream, would pass this fixture in silence.
+    "Marrowgate Zephyrine",
+)
+
+
+def test_ranking_matches_the_characterization_fixture() -> None:
+    """Step 17: the SAME pinned top-10 the Plan 01 baseline produced, on the persisted schema.
+
+    THIS IS THE ASSERTION FROM PLAN 01 §7 STEP 25, MOVED (m-vii) — not a new one, and the
+    fixture is NOT regenerated. It is green because the scorer is unchanged: same tokenizer,
+    same indexed columns, same `bm25()`, same explicit tie-break, all composed from
+    `lexical_fts.py`. Only the connection string moved.
+
+    Built with `PINNED_CHUNKER_PARAMS` passed EXPLICITLY (M7), so Plan 02 §7's sweep — which
+    changes the module constant — cannot move this fixture. The sweep winner is pinned
+    separately under its own `CHUNKER_VERSION`, and the report compares the two.
+
+    Red whenever chunking, tokenization, the indexed column set, the ORDER BY or the fixture
+    corpus change. Those are exactly the five things that silently alter every downstream
+    recall number.
+    """
+    expected = json.loads((FIXTURES / "knowledge_ranking.json").read_text(encoding="utf-8"))
+    index = _index()
+    index.add(_corpus_chunks())
+    actual = {
+        query: [hit.chunk_id for hit in index.search(query, limit=10)] for query in RANKING_QUERIES
+    }
+    assert actual == expected["rankings"]
+
+
+def test_the_ranking_fixture_records_the_parameters_it_was_built_with() -> None:
+    """A pinned ranking with no record of its parameters is unreproducible.
+
+    Without them, the day the test goes red nobody can tell whether the ranking changed or
+    the parameters did — and the fixture would be regenerated to make it green, losing the
+    signal entirely.
+    """
+    fixture = json.loads((FIXTURES / "knowledge_ranking.json").read_text(encoding="utf-8"))
+    assert fixture["chunker_params"] == {
+        "target": PINNED_CHUNKER_PARAMS.target,
+        "max_chars": PINNED_CHUNKER_PARAMS.max_chars,
+        "overlap": PINNED_CHUNKER_PARAMS.overlap,
+        "min_chars": PINNED_CHUNKER_PARAMS.min_chars,
+    }
+    assert fixture["tokenize"] == FTS_TOKENIZE
+    assert fixture["connective"] == FTS_CONNECTIVE
+
+
+def test_a_hit_resolves_back_to_its_item_and_surface() -> None:
+    """Spec §3.3: reverse resolution from a chunk to its surface and owner.
+
+    A ranked id nobody can resolve is not evidence, it is a number.
+    """
+    index = _index()
+    index.add(_corpus_chunks())
+    (hit,) = index.search("Quillfeather", limit=1)
+    assert hit.owner_id in {"k03", "k12"}
+    assert hit.surface_type in {"external_article", "user_note"}
+    assert "Quillfeather" in hit.excerpt
+
+
+def test_a_surface_with_no_chunks_contributes_nothing() -> None:
+    """An empty index answers a query with no results, not with an error."""
+    empty_surface = KnowledgeSurface(
+        surface_id="item:z:post:0",
+        owner_type="item",
+        owner_id="z",
+        surface_type="post",
+        text="",
+        origin="source",
+        trust_class="primary_source",
+        derived=False,
+        locator=Locator(kind="item_text"),
+        fingerprint="a" * 64,
+    )
+    index = _index()
+    index.add(chunk_surfaces((empty_surface,)))
+    assert index.search("anything", limit=5) == ()
+
+
+# ---------------------------------------------------------------------------
+# M3 — the query semantics: bm25 ranks, the connective does not pre-empty
+# ---------------------------------------------------------------------------
+
+
+def test_a_question_shaped_query_is_not_emptied_by_its_own_length() -> None:
+    """M3: ANDing every term makes a long question demand that ALL of it sit in ONE chunk.
+
+    Measured on the real corpus BEFORE the connective changed: 18 of the 21 scorable cases
+    received not a single row. WHAT IS ASSERTED IS WHAT THE CHANGE GUARANTEES: the chunk
+    holding the distinctive term is RETRIEVED — not that it ranks first, which is bm25's job
+    and depends on corpus statistics.
+    """
+    chunks = _corpus_chunks()
+    index = _index()
+    index.add(chunks)
+    wanted = {c.chunk_id for c in chunks if "Marrowgate" in c.text}
+    assert len(wanted) == 1, "the fixture must hold the term in exactly one chunk"
+
+    hits = index.search("¿Qué dice el protocolo Marrowgate sobre los umbrales?", limit=10)
+
+    assert hits, "a question with one matching term must not come back empty"
+    assert wanted <= {hit.chunk_id for hit in hits}, (
+        f"the chunk holding the distinctive term was not retrieved: {[h.chunk_id for h in hits]}"
+    )
+
+
+def test_a_rare_term_outranks_a_term_that_matches_almost_everything() -> None:
+    """The property that makes disjunction safe, pinned: IDF does the discriminating.
+
+    The objection to OR is that any one common word drags the whole corpus in. It does bring
+    it in as CANDIDATES — and bm25 then ranks it last, because a term present in nearly every
+    chunk carries almost no inverse document frequency.
+    """
+    index = _index()
+    index.add(_corpus_chunks())
+
+    hits = index.search("Zephyrine quality", limit=10)
+
+    assert len(hits) > 1, "the common term must genuinely widen the candidate set"
+    assert "Zephyrine" in hits[0].excerpt, (
+        f"a term matching almost everything outranked a term matching one chunk: {hits[0]}"
+    )
+
+
+def test_terms_are_still_data_and_never_syntax() -> None:
+    """The connective changed; the quoting did not, and it is the security property."""
+    from xbrain.knowledge.lexical_fts import match_expression
+
+    assert match_expression("@simonw 11.37%") == '"@simonw" OR "11.37%"'
+    assert match_expression('NEAR( a"b') == '"NEAR" OR "a" OR "b"'
+    assert match_expression("   ") is None
+
+    index = _index()
+    index.add([_chunk("c1", "Contacta con @simonw sobre el 11.37% de mejora")])
+    assert index.search("@simonw 11.37%", limit=5)
+
+
+def test_idf_is_relative_to_THIS_corpus_and_that_limit_is_declared() -> None:
+    """The declared limit of the disjunction, pinned as a measurement rather than a warning.
+
+    IDF is a property of the INDEXED CORPUS, not of the language, so a word that is a
+    function word to a reader can still be rare to the index. Measured 2026-09-01 with the
+    SHIPPED chunker (v2, `800/0`) on `data/items.json` sha256 `f76341a3…`: `el` sits in 1 of
+    the 49 fixture chunks (2.0 %) and in **6,070 of the 22,286** real-corpus chunks
+    (**27.2 %**), so the fixture ranks it high and the real corpus does not — both bm25
+    behaving correctly on the corpus it was given. This is what a vector layer is for
+    (Plan 03).
+
+    THE ASSERTION BELOW CHUNKS AT v1 (`_corpus_chunks()` defaults to `PINNED_CHUNKER_PARAMS`),
+    which is why it says 43 and not 49; the ratio is 1-in-something either way and the point
+    is the CONTRAST with the real corpus. The prose used to quote `5,748 of 18,319 (31.4 %)`
+    — the v1 figure, left standing after this branch changed the chunker to v2 (F-4).
+    """
+    index = _index()
+    index.add(_corpus_chunks())
+
+    def document_frequency(term: str) -> int:
+        return index.connection.execute(
+            "SELECT COUNT(*) FROM chunks_fts WHERE chunks_fts MATCH ?", (f'"{term}"',)
+        ).fetchone()[0]
+
+    assert document_frequency("el") == 1, (
+        "the fixture corpus is English-dominated, which is WHY a Spanish function word is "
+        "distinctive here; if this moved, the limit above is being measured on a different "
+        "population (CLAUDE.md rule 2)"
+    )
+    assert document_frequency("quality") > document_frequency("Marrowgate")
+
+
+# ---------------------------------------------------------------------------
+# 12 / 12b — the EIGHT filters of spec §7.2, pushed into SQL before scoring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def filtered_index() -> LexicalIndex:
+    """Two items that differ on EVERY filter axis and share the query term.
+
+    Sharing the term is the point: with both matching the text, a filter that does nothing
+    leaves both in the result, so every assertion below can only pass because the filter ran.
+    """
+    index = _index()
+    index.add(
+        [
+            _chunk(
+                "c-old",
+                "the shared marrowgate term appears here",
+                surface_id="item:old:post:0",
+                owner_id="old",
+                origin="source",
+                surface_type="post",
+            )
+        ],
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        source="bookmark",
+    )
+    index.add(
+        [
+            _chunk(
+                "c-new",
+                "the shared marrowgate term appears here too",
+                surface_id="item:new:image_description:0",
+                owner_id="new",
+                origin="vlm",
+                surface_type="image_description",
+                derived=True,
+                trust_class="machine_extracted",
+            )
+        ],
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        source="own_tweet",
+    )
+    index.set_item_metadata(
+        "old",
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        source="bookmark",
+        author_handle="karpathy",
+        author_name="Andrej",
+        url="https://x.com/karpathy/1",
+        captured_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+        topics=("agent-evaluation",),
+        content_kinds=("external_article",),
+        surface_types=("post", "external_article"),
+    )
+    index.set_item_metadata(
+        "new",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        source="own_tweet",
+        author_handle="vgonpa",
+        author_name="Victor",
+        url="https://x.com/vgonpa/2",
+        captured_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+        topics=("ai-policy",),
+        content_kinds=("x_video",),
+        surface_types=("post", "image_description"),
+    )
+    return index
+
+
+def _owners(index: LexicalIndex, **filter_kwargs) -> set[str]:
+    filters = SearchFilters(**filter_kwargs)
+    return {hit.owner_id for hit in index.search("marrowgate", limit=10, filters=filters)}
+
+
+def test_filter_created_from_and_to(filtered_index: LexicalIndex) -> None:
+    """Filter 1 & 2: the date window, on the DENORMALISED column, before the MATCH."""
+    assert _owners(filtered_index) == {"old", "new"}
+    assert _owners(filtered_index, created_from=datetime(2026, 1, 1, tzinfo=timezone.utc)) == {
+        "new"
+    }
+    assert _owners(filtered_index, created_to=datetime(2025, 6, 1, tzinfo=timezone.utc)) == {"old"}
+
+
+def test_filter_source(filtered_index: LexicalIndex) -> None:
+    """Filter 3: `--mine` maps to `source=own_tweet` (spec §7.2)."""
+    assert _owners(filtered_index, source="own_tweet") == {"new"}
+    assert _owners(filtered_index, source="bookmark") == {"old"}
+
+
+def test_filter_author(filtered_index: LexicalIndex) -> None:
+    """Filter 4: a JOIN onto `items`, not a substring of the query."""
+    assert _owners(filtered_index, author="karpathy") == {"old"}
+    assert _owners(filtered_index, author="nobody") == set()
+
+
+def test_filter_topics(filtered_index: LexicalIndex) -> None:
+    """Filter 5: `EXISTS` over `item_topics` — the assignment, never the query text.
+
+    Spec §3.7.5: *topics and filters are not invented from the query text; they come from the
+    store/vocabulary.*
+    """
+    assert _owners(filtered_index, topics=("agent-evaluation",)) == {"old"}
+    assert _owners(filtered_index, topics=("ai-policy",)) == {"new"}
+
+
+def test_filter_content_kinds(filtered_index: LexicalIndex) -> None:
+    """Filter 6 (m2): `item_content_kinds` is a table this plan introduces.
+
+    It was declared in `SearchFilters` by Plan 01 with no column behind it, which is why the
+    evaluation harness had to report cases using it as UNMEASURED rather than 0.0. Seen red
+    by dropping the table: the filter then matches nothing and both assertions fail.
+    """
+    assert _owners(filtered_index, content_kinds=("external_article",)) == {"old"}
+    assert _owners(filtered_index, content_kinds=("x_video",)) == {"new"}
+
+
+def test_filter_origins(filtered_index: LexicalIndex) -> None:
+    """Filter 7: `chunks.origin` — a chunk-level property, so no join at all."""
+    assert _owners(filtered_index, origins=("vlm",)) == {"new"}
+    assert _owners(filtered_index, origins=("source",)) == {"old"}
+
+
+def test_filter_has_surfaces(filtered_index: LexicalIndex) -> None:
+    """Filter 8 (m2): an aggregate `EXISTS` over `surfaces`, the other one with no column."""
+    assert _owners(filtered_index, has_surfaces=("external_article",)) == {"old"}
+    assert _owners(filtered_index, has_surfaces=("image_description",)) == {"new"}
+    assert _owners(filtered_index, has_surfaces=("post",)) == {"old", "new"}
+
+
+def test_every_declared_filter_is_actually_pushed_to_sql(filtered_index: LexicalIndex) -> None:
+    """The TOTALITY half: no field of `SearchFilters` may be silently ignored.
+
+    A filter the backend drops does not error — it returns MORE results, which looks like a
+    permissive query rather than a broken one. So the eight declared fields are enumerated
+    from the model and each is asserted to narrow the result set. Adding a ninth field to the
+    frozen contract without wiring it here goes red.
+    """
+    narrowing = {
+        "created_from": {"created_from": datetime(2026, 1, 1, tzinfo=timezone.utc)},
+        "created_to": {"created_to": datetime(2025, 6, 1, tzinfo=timezone.utc)},
+        "source": {"source": "own_tweet"},
+        "author": {"author": "karpathy"},
+        "topics": {"topics": ("ai-policy",)},
+        "content_kinds": {"content_kinds": ("x_video",)},
+        "origins": {"origins": ("vlm",)},
+        "has_surfaces": {"has_surfaces": ("external_article",)},
+    }
+    assert set(narrowing) == set(SearchFilters.model_fields), (
+        "a filter was added to the frozen contract without a test that it reaches SQL"
+    )
+    for name, kwargs in narrowing.items():
+        assert _owners(filtered_index, **kwargs) == {"old"} or _owners(
+            filtered_index, **kwargs
+        ) == {"new"}, f"filter {name} did not narrow the result set"
+
+
+def test_the_filter_is_applied_before_scoring_not_after(filtered_index: LexicalIndex) -> None:
+    """Step 12 (m3): the plan asks for THREE pieces of evidence, and asserting the SQL string
+    is none of them — that only proves we wrote that string.
+
+    1. `EXPLAIN QUERY PLAN` shows sqlite using an index on the filtered column rather than
+       scanning every chunk;
+    2. the number of rows the scorer is handed actually FALLS;
+    3. the filter changes the TOP-1, which is the user-visible consequence.
+
+    PIECE 1 NAMES THE INDEX, and the previous version of it could not fail (F-1, rule 1). It
+    asked for `any("chunks" in step and "SCAN" not in step)`, which is satisfied by
+    `SEARCH chunks USING INTEGER PRIMARY KEY (rowid=?)` — the step an external-content FTS5
+    join emits UNCONDITIONALLY, filter or no filter. Measured on this very fixture, the
+    predicate was `True` with `SearchFilters()`, with `SearchFilters(source=...)` and with
+    `SearchFilters(origins=...)` alike, so it distinguished nothing. Naming `chunks_source` is
+    the falsifiable form: the unfiltered plan does not contain it (seen red by driving this
+    same assertion with `SearchFilters()`), and neither does the plan of a DIFFERENT filter —
+    `origins` narrows through `chunks_origin` — so the assertion is tied to the filter under
+    test, and it goes red if the `source` clause stops reaching the `WHERE` (also seen red).
+    """
+    plan = filtered_index.explain("marrowgate", SearchFilters(source="own_tweet"))
+    assert any(step.startswith("SEARCH chunks USING INDEX chunks_source") for step in plan), plan
+
+    unfiltered_rows = filtered_index.scored_row_count("marrowgate", SearchFilters())
+    filtered_rows = filtered_index.scored_row_count("marrowgate", SearchFilters(source="own_tweet"))
+    assert filtered_rows < unfiltered_rows
+
+    top_unfiltered = filtered_index.search("marrowgate", limit=1)[0].owner_id
+    top_filtered = filtered_index.search(
+        "marrowgate", limit=1, filters=SearchFilters(source="own_tweet")
+    )[0].owner_id
+    assert top_unfiltered != top_filtered
+
+
+def test_an_unknown_topic_is_rejected_by_the_index_not_silently_empty() -> None:
+    """Step 13 belongs to the service, but the index must not INVENT a match either.
+
+    A slug that is in no assignment simply narrows to nothing here; the service is what turns
+    that into an error listing the valid slugs, because only the service knows the vocabulary.
+    """
+    index = _index()
+    index.add([_chunk("c1", "marrowgate")])
+    index.set_item_metadata("x", topics=("agent-evaluation",), **_STAMP)
+    assert index.search("marrowgate", limit=5, filters=SearchFilters(topics=("nope",))) == ()
+
+
+def test_a_topic_owned_chunk_matches_its_own_slug(filtered_index: LexicalIndex) -> None:
+    """A `topic_note` of topic X satisfies `--topic X`, though it has no `item_topics` row.
+
+    Without this branch the topic filter would exclude exactly the surfaces that ARE the
+    topic, which reads as "the topic has no notes" — a claim about the corpus produced by the
+    filter's own shape.
+    """
+    filtered_index.add(
+        [
+            _chunk(
+                "t1",
+                "the marrowgate note of the topic itself",
+                surface_id="topic:ai-policy:topic_note:0",
+                owner_type="topic",
+                owner_id="ai-policy",
+                surface_type="topic_note",
+                origin="llm",
+                trust_class="llm_synthesis",
+                derived=True,
+            )
+        ]
+    )
+    owners = _owners(filtered_index, topics=("ai-policy",))
+    assert owners == {"new", "ai-policy"}
+
+
+def test_item_scoped_filters_exclude_topic_chunks(filtered_index: LexicalIndex) -> None:
+    """A topic surface has no author, no date and no source, so it FAILS CLOSED on those.
+
+    Including it would answer "posts by @karpathy" with a topic overview nobody wrote as
+    @karpathy — the derived/primary confusion provenance exists to prevent.
+    """
+    filtered_index.add(
+        [
+            _chunk(
+                "t1",
+                "the marrowgate note",
+                surface_id="topic:ai-policy:topic_note:0",
+                owner_type="topic",
+                owner_id="ai-policy",
+                surface_type="topic_note",
+                origin="llm",
+                trust_class="llm_synthesis",
+                derived=True,
+            )
+        ]
+    )
+    assert "ai-policy" not in _owners(filtered_index, author="karpathy")
+    assert "ai-policy" not in _owners(filtered_index, source="own_tweet")
+    assert "ai-policy" not in _owners(
+        filtered_index, created_from=datetime(2020, 1, 1, tzinfo=timezone.utc)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Security — the query builder concatenates constants, never values
+# ---------------------------------------------------------------------------
+
+
+def test_placeholders_can_only_ever_be_commas_and_question_marks() -> None:
+    """The one dynamically built SQL fragment is derived from an INTEGER.
+
+    That is what makes the `# nosec B608` honest: the variadic `IN` clause is the shape
+    sqlite3 cannot parameterise wholesale, so the placeholder GROUP has to be built — but it
+    is built from a count, so no caller string can reach the statement.
+    """
+    from xbrain.knowledge.lexical import _placeholders
+
+    for n in range(0, 8):
+        assert set(_placeholders(n)) <= {"?", ","}
+    assert _placeholders(3) == "?,?,?"
+
+
+def test_a_filter_value_containing_sql_is_bound_not_interpolated() -> None:
+    """A hostile filter value is DATA. Defence in depth, and cheap."""
+    index = _index()
+    index.add([_chunk("c1", "ordinary body text")])
+    hits = index.search(
+        "ordinary", limit=5, filters=SearchFilters(author="x'; DROP TABLE chunks; --")
+    )
+    assert hits == ()
+    assert len(index) == 1, "the table is still there"
+
+
+def test_the_index_never_writes_when_opened_read_only(tmp_path: Path) -> None:
+    """Step 11: `search` opens the database read-only, so a write RAISES (spec §5.6).
+
+    Not "we checked and it does not write" — the connection cannot. Seen red by opening it
+    read-write: the insert succeeds and the query has repaired an index nobody asked it to.
+    """
+    path = tmp_path / "knowledge.db"
+    writer = LexicalIndex(open_index(path, create=True))
+    writer.add([_chunk("c1", "marrowgate body")])
+    writer.connection.commit()
+    writer.connection.close()
+
+    reader = LexicalIndex(open_index(path, read_only=True))
+    assert [h.chunk_id for h in reader.search("marrowgate", limit=5)] == ["c1"]
+    with pytest.raises(sqlite3.OperationalError):
+        reader.add([_chunk("c2", "another body")])
+
+
+# ---------------------------------------------------------------------------
+# The profile plane (spec §5.1.A)
+# ---------------------------------------------------------------------------
+
+
+def test_the_profile_plane_returns_items_not_citable_chunks() -> None:
+    """Spec §5.1: the profile finds the item as a conceptual UNIT.
+
+    It returns an item id and a score and NOTHING ELSE — no excerpt, no chunk id, no surface.
+    A profile is a string nobody wrote (a tweet, a summary and three topic descriptions glued
+    together), so returning it as evidence would present a machine's collage as something
+    someone said. The shape of `ProfileHit` is what makes that structurally impossible.
+    """
+    from xbrain.knowledge.lexical import ProfileHit
+
+    index = _index()
+    index.add_profile("i1", "agent evaluation harnesses and their pitfalls", "a" * 64)
+    index.add_profile("i2", "unrelated cooking notes", "b" * 64)
+
+    hits = index.search_profiles("evaluation", limit=5)
+    assert [h.item_id for h in hits] == ["i1"]
+    assert set(ProfileHit.__dataclass_fields__) == {"item_id", "score"}
+
+
+def test_the_profile_plane_honours_the_same_filters() -> None:
+    """A filter that applies to items must apply on both planes, or the two disagree.
+
+    `origins` is the one that did NOT (G-1): it lives on `chunks.origin`, the profile plane
+    applied only the item-scoped clauses, and `search "Forecasting" --origin asr` on the real
+    corpus answered 8 items of which 6 had no ASR surface at all. A profile is a string
+    nobody wrote and has no origin, so under an origin filter it contributes NOTHING — the
+    same fail-closed shape as a topic chunk under an author filter.
+
+    Seen red before the fix: `origins=("vlm",)` returned both profiles.
+    """
+    index = _index()
+    index.add_profile("i1", "agent evaluation harnesses", "a" * 64)
+    index.add_profile("i2", "agent evaluation notes", "b" * 64)
+    index.set_item_metadata("i1", source="bookmark", author_handle="karpathy", **_STAMP)
+    index.set_item_metadata("i2", source="own_tweet", author_handle="vgonpa", **_STAMP)
+
+    hits = index.search_profiles("evaluation", limit=5, filters=SearchFilters(source="own_tweet"))
+    assert [h.item_id for h in hits] == ["i2"]
+    assert (
+        index.search_profiles("evaluation", limit=5, filters=SearchFilters(origins=("vlm",))) == ()
+    )
+
+
+@pytest.fixture()
+def profiled_index() -> LexicalIndex:
+    """Two PROFILES whose items differ on every filter axis and share the query term.
+
+    The profile-plane twin of `filtered_index`: with both profiles matching the text, a
+    filter the profile plane ignores leaves both in the result, so every assertion below can
+    only pass because the filter reached `search_profiles`.
+    """
+    index = _index()
+    index.add_profile("old", "the shared marrowgate profile", "a" * 64)
+    index.add_profile("new", "the shared marrowgate profile too", "b" * 64)
+    index.set_item_metadata(
+        "old",
+        created_at=datetime(2025, 1, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2025, 1, 2, tzinfo=timezone.utc),
+        source="bookmark",
+        author_handle="karpathy",
+        topics=("agent-evaluation",),
+        content_kinds=("external_article",),
+        surface_types=("post", "external_article"),
+    )
+    index.set_item_metadata(
+        "new",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        captured_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+        source="own_tweet",
+        author_handle="vgonpa",
+        topics=("ai-policy",),
+        content_kinds=("x_video",),
+        surface_types=("post", "image_description"),
+    )
+    return index
+
+
+def test_every_declared_filter_is_pushed_on_the_profile_plane_too(
+    profiled_index: LexicalIndex,
+) -> None:
+    """The TOTALITY half for the SECOND plane (G-1, spec §7.2, acceptance 6: *the eight*).
+
+    `test_every_declared_filter_is_actually_pushed_to_sql` enumerates the eight fields of
+    `SearchFilters` against `index.search` only, and `origins` slipped through the profile
+    plane for exactly that reason: seven filters were asserted on both planes, one on one.
+    The expected set is spelled out per filter rather than "old or new", because the honest
+    answer for `origins` is the EMPTY set — a profile has no origin — and "narrowed to
+    nothing" is a different claim from "narrowed to the other item".
+
+    Seen red before the fix: `origins` returned `{"old", "new"}`.
+    """
+    expected = {
+        "created_from": ({"created_from": datetime(2026, 1, 1, tzinfo=timezone.utc)}, {"new"}),
+        "created_to": ({"created_to": datetime(2025, 6, 1, tzinfo=timezone.utc)}, {"old"}),
+        "source": ({"source": "own_tweet"}, {"new"}),
+        "author": ({"author": "karpathy"}, {"old"}),
+        "topics": ({"topics": ("ai-policy",)}, {"new"}),
+        "content_kinds": ({"content_kinds": ("x_video",)}, {"new"}),
+        "origins": ({"origins": ("vlm",)}, set()),
+        "has_surfaces": ({"has_surfaces": ("external_article",)}, {"old"}),
+    }
+    assert set(expected) == set(SearchFilters.model_fields), (
+        "a filter was added to the frozen contract without a test that it reaches the profile plane"
+    )
+
+    def owners(**kwargs) -> set[str]:
+        hits = profiled_index.search_profiles(
+            "marrowgate", limit=10, filters=SearchFilters(**kwargs)
+        )
+        return {hit.item_id for hit in hits}
+
+    assert owners() == {"old", "new"}, "the fixture must match both before any filter"
+    for name, (kwargs, wanted) in expected.items():
+        assert owners(**kwargs) == wanted, f"filter {name} did not narrow the profile plane"
+
+
+def test_a_missing_table_is_an_error_not_an_empty_result() -> None:
+    """C-2: `_fetch` used to absorb EVERY `OperationalError` except a read-only one and
+    return `[]`, so `no such table`, `database is locked` and `disk I/O error` all came back
+    as "the corpus holds nothing" — and the decision was made by substring of the message,
+    which is CLAUDE.md rule 9 in miniature.
+
+    The catch now absorbs exactly what it was written for — an expression FTS5's parser
+    rejects — and everything else is an ERROR. Seen red before the fix: `search` returned
+    `()` over an index whose `chunks_fts` had been dropped. Since U-4 (round 07) the error
+    is the actionable one rather than the raw `OperationalError` this test used to pin: a
+    base missing a table past the door is the same operator situation as a corrupt one,
+    and the sentence names the rebuild — while still carrying SQLite's own words.
+    """
+    from xbrain.knowledge.index_schema import IndexIncompatibleError
+
+    index = _index()
+    index.add(_corpus_chunks())
+    index.connection.execute("DROP TABLE chunks_fts")
+    with pytest.raises(IndexIncompatibleError, match="no such table"):
+        index.search("marrowgate", 5)
+
+
+def test_a_database_error_at_query_time_is_the_rebuild_advice_not_a_traceback() -> None:
+    """G-4 in `_fetch`: what the open-door probe does not catch, the query turns into the
+    same sentence. `sqlite3.DatabaseError` (the parent of `OperationalError`) is what FTS5
+    raises on a corrupt or missing shadow table — `fts5: corruption found reading blob…` —
+    and it is neither an `IndexError_` nor an `OSError`, so it reached the operator raw.
+
+    The parser's own errors keep degrading to `[]` (the test below), an `OperationalError`
+    that is not a parse error keeps propagating as itself (C-2), and everything else in the
+    `DatabaseError` family becomes `IndexIncompatibleError` with the rebuild advice.
+
+    Seen red before the fix: `sqlite3.DatabaseError` propagated out of `search`.
+    """
+    from xbrain.knowledge.index_schema import IndexIncompatibleError
+
+    index = _index()
+    index.add(_corpus_chunks())
+    index.connection.execute("DROP TABLE chunks_fts_data")
+    with pytest.raises(IndexIncompatibleError, match="xbrain index build --force"):
+        index.search("marrowgate", 5)
+
+
+def test_only_an_fts_syntax_error_degrades_to_no_results() -> None:
+    """The other half of C-2: what the catch was FOR still degrades, so narrowing it did not
+    turn a hostile query into a traceback.
+
+    `match_expression` quotes every term, so no expression built by `search` can reach the
+    parser malformed; the branch is exercised through `_fetch` directly with the three
+    error families FTS5's parser emits (measured on sqlite 3.51.2: `fts5: syntax error`,
+    `unterminated string`, `unknown special query`).
+    """
+    index = _index()
+    index.add(_corpus_chunks())
+    sql = f"{lexical._SELECT_CHUNKS} WHERE chunks_fts MATCH ? {lexical._CHUNK_RANK_ORDER} LIMIT ?"
+    for malformed in ("NEAR(", '"unterminated', "*"):
+        assert index._fetch(sql, (malformed, 5)) == [], malformed

--- a/tests/test_knowledge_lexical.py
+++ b/tests/test_knowledge_lexical.py
@@ -614,14 +614,44 @@ def test_the_filter_is_applied_before_scoring_not_after(filtered_index: LexicalI
     `SEARCH chunks USING INTEGER PRIMARY KEY (rowid=?)` — the step an external-content FTS5
     join emits UNCONDITIONALLY, filter or no filter. Measured on this very fixture, the
     predicate was `True` with `SearchFilters()`, with `SearchFilters(source=...)` and with
-    `SearchFilters(origins=...)` alike, so it distinguished nothing. Naming `chunks_source` is
-    the falsifiable form: the unfiltered plan does not contain it (seen red by driving this
-    same assertion with `SearchFilters()`), and neither does the plan of a DIFFERENT filter —
-    `origins` narrows through `chunks_origin` — so the assertion is tied to the filter under
-    test, and it goes red if the `source` clause stops reaching the `WHERE` (also seen red).
+    `SearchFilters(origins=...)` alike, so it distinguished nothing. So piece 1 must name an
+    index that the unfiltered plan does NOT contain — and it must name one the planner cannot
+    talk itself out of.
+
+    IT NAMES `sqlite_autoindex_items_1`, VIA `author`, AND NOT `chunks_source` VIA `source`,
+    BECAUSE A QUERY PLAN IS A COST DECISION AND COST DECISIONS ARE NOT PORTABLE. Measured on
+    this same fixture across the two interpreters this project supports:
+
+        filter      SQLite 3.51.2 (py3.13)              SQLite 3.50.4 (py3.12, CI)
+        source      SEARCH chunks USING INDEX           (no such step — the plan is
+                    chunks_source                        BYTE-IDENTICAL to unfiltered)
+        origins     SEARCH chunks USING INDEX           (idem)
+                    chunks_origin
+        author      SEARCH items ... USING INDEX        SEARCH items USING INDEX
+                    sqlite_autoindex_items_1            sqlite_autoindex_items_1
+
+    On 3.50.4 the planner drives the MATCH and applies `source` as a RESIDUAL filter on the
+    rowid lookup: the predicate still reaches the `WHERE`, it simply does not drive an index,
+    and the plan it produces is the one MUTATING THIS MODULE TO FILTER AFTER SCORING produces
+    on 3.51.2. An assertion that cannot separate the correct implementation from that mutant
+    on the very interpreter CI runs is not a guard, and `ANALYZE` does not rescue it — it
+    degrades both versions to a plain `SCAN chunks`.
+
+    `author` is stable across both because its clause is an `EXISTS` subquery keyed on
+    `items.item_id`, so reaching `items` by its primary key is STRUCTURAL rather than a
+    cost-model preference: whatever strategy the planner picks, it must look the row up.
+
+    Falsifiability is asserted rather than asserted-about: the unfiltered plan is required NOT
+    to name that index, so the pair goes red if the `author` clause stops reaching the `WHERE`
+    (seen red by mutation, on both interpreters). Pieces 2 and 3 stay on `source` — they read
+    row counts and results, never a plan, so they are planner-agnostic by construction, and
+    piece 2 is what catches the filter-moved-after-scoring mutant (scored rows 2 -> 2 under
+    the mutant against 2 -> 1 correct, with the user-visible answer identical in both).
     """
-    plan = filtered_index.explain("marrowgate", SearchFilters(source="own_tweet"))
-    assert any(step.startswith("SEARCH chunks USING INDEX chunks_source") for step in plan), plan
+    plan = filtered_index.explain("marrowgate", SearchFilters(author="karpathy"))
+    assert any("sqlite_autoindex_items_1" in step for step in plan), plan
+    unfiltered_plan = filtered_index.explain("marrowgate", SearchFilters())
+    assert not any("sqlite_autoindex_items_1" in step for step in unfiltered_plan), unfiltered_plan
 
     unfiltered_rows = filtered_index.scored_row_count("marrowgate", SearchFilters())
     filtered_rows = filtered_index.scored_row_count("marrowgate", SearchFilters(source="own_tweet"))


### PR DESCRIPTION
Plan 02 child 02.4, onto the umbrella `VGonPa/umbrella-knowledge-index-lexical` (tip `225fe149`, unmoved). Acceptance owner: **Plan 02 §15.6**.

Two new files, **+1,665 / −0**, no production file touched:

| File | Lines |
|---|---|
| `src/xbrain/knowledge/lexical.py` | 707 — **byte-identical** to snapshot `1d30554` |
| `tests/test_knowledge_lexical.py` | 958 |

## What ships, and why it is one PR

`LexicalIndex` over the FTS5 schema child 02.3 landed: `MATCH` expression building, `bm25()` with the explicit `chunk_id` tie-break, the profile plane, and **all eight `SearchFilters` fields pushed into the SQL `WHERE` before scoring**.

The eight are **inseparable from the scorer**. A filter the backend drops does not error — it returns *more* rows, which reads as a permissive query rather than a broken one. So the totality guard enumerates `SearchFilters.model_fields` and requires every field to narrow the result set; a ninth field added to the frozen contract without wiring goes red. Splitting the scorer from the filters, or landing a `filters=` argument that is ignored, would ship exactly the silent-permissive failure the guard exists to catch.

## Filter-before-score: three pieces of evidence, not an SQL string

Asserting the SQL string only proves we wrote that string (rule 1). `test_the_filter_is_applied_before_scoring_not_after` takes:

1. `EXPLAIN QUERY PLAN` **names a real index** absent from the unfiltered plan;
2. the **row count handed to the scorer falls**;
3. the **top-1 changes** (the user-visible consequence).

### The EXPLAIN arm names `sqlite_autoindex_items_1` via `author`, not `chunks_source` via `source`

**A query plan is a cost decision, and cost decisions are not portable.** The first push of this branch was **red on CI** on this very guard while `scripts/check.sh` exited 0 locally. Measured on the same fixture across the two interpreters the project supports (CI pins **python 3.12**, also the declared minimum):

| filter | SQLite 3.51.2 (py3.13) | SQLite 3.50.4 (py3.12, CI) |
|---|---|---|
| `source` | `SEARCH chunks USING INDEX chunks_source` | *no such step* — plan **byte-identical to unfiltered** |
| `origins` | `SEARCH chunks USING INDEX chunks_origin` | idem |
| `author` | `SEARCH items … USING INDEX sqlite_autoindex_items_1` | `SEARCH items USING INDEX sqlite_autoindex_items_1` |

On 3.50.4 the planner drives the `MATCH` and applies `source` as a **residual filter** on the rowid lookup. The predicate *does* reach the `WHERE` — it simply does not drive an index. And the plan that produces is **the same plan the filter-moved-after-scoring mutant produces on 3.51.2**, so on the interpreter CI actually runs the assertion could not separate the correct implementation from the defect it exists to catch. `ANALYZE` does not rescue it — it degrades both versions to a plain `SCAN chunks`.

`author` is stable across both because its clause is an `EXISTS` keyed on `items.item_id`: reaching `items` by primary key is **structural**, not a cost preference, so every strategy must do it. Falsifiability is *asserted*, not described — the unfiltered plan is required **not** to name that index.

**Pieces 2 and 3 stay on `source`, untouched.** They read row counts and results, never a plan, so they are planner-agnostic by construction.

### Seen RED by mutation

| Mutation | 3.51.2 | 3.50.4 (CI) |
|---|---|---|
| **A** — filters never reach `WHERE` (`_where`) | both guards fail | — |
| **C** — `author` clause never reaches `WHERE` (`lexical.py:578`) | both guards fail | both guards fail |
| **B** — filtering moved *after* scoring | `…before_scoring…` fails | `…before_scoring…` fails |

Mutation **B** is why the second guard exists. Same SQL minus the predicates, the identical answer recomputed in Python:

| | scored rows unfiltered | filtered | falls? | user-visible owners |
|---|---|---|---|---|
| correct | 2 | **1** | yes | `{'new'}` |
| mutant B | 2 | **2** | no | `{'new'}` |

The answer is still right; the defect is invisible in the results and visible only in the plan and the count. `test_every_declared_filter_is_actually_pushed_to_sql` **passes** under B — which is the proof the two guards are not redundant.

## Temporary F2 boundary — declared

`tests/test_knowledge_lexical.py` is the green subset of the corrected snapshot (`1d30554`, 1,027 lines). Omitted, because each needs the **locator / chunker v2 that lands in child 02.5**:

- helper field `locator` (snapshot line 119) — the `Locator` import survives, still used by another test;
- `test_the_measured_winner_has_its_own_pinned_ranking` (326–359) — reads `knowledge_ranking_v2.json`, asserts `chunker_version == CHUNKER_VERSION`;
- `test_the_two_pinned_rankings_are_not_the_same_ranking` (360–381) — needs both fixtures;
- `test_the_sweep_cannot_move_the_characterization_fixture` (382–421) — needs the swept parameters.

They return with 02.5.

### Byte-level deviation from the planned 930 / +1,637, re-derived

The stated 930 is arithmetically right for the *raw* cut, but the raw cut is not green. Deleting the three blocks orphaned two imports only they used (`DEFAULT_CHUNKER_PARAMS`, `CHUNKER_VERSION` — ruff `F401`), and a contiguous three-block deletion leaves **three** top-level blank lines where the formatter wants two. Both forced by ruff, neither a judgement call:

```
930 − 1 (blank line) − 1 (`from xbrain.knowledge.ids import CHUNKER_VERSION`) = 928
```

The EXPLAIN-arm correction then adds **+38 / −8** (the retargeted assertion and the measurement recorded in its docstring), giving **958** and a diff of **+1,665**. Bytes were ported, not retyped: `git diff VGonPa/knowledge-lexical-snapshot-fix-09 -- src/xbrain/knowledge/lexical.py` is **empty**.

## Quality gate

`bash scripts/check.sh` — **true exit code 0**, read from `$?` and not from the banner (rule 9):

```
✅ Ruff (linting) ✅ Ruff (format) ✅ Mypy ✅ Bandit ✅ Vulture
✅ Interrogate 90.8% ✅ Detect-secrets ✅ Deptry
✅ Tests PASS - 2244 tests (2244 passed, 1 xfailed)
✅ Coverage 94%  ✅ Coverage (knowledge/) 95%
⚠️  Radon WARN - Has grade C (pre-existing, non-blocking)
```

Suite green on **both** interpreters: 37 passed on 3.51.2/py3.13 and 37 passed on 3.50.4/py3.12.

## Scope

Out, and absent from the diff: locator/chunker v2, `build`/`update`/`status`, the search service, `get`/render/CLI/config/evaluation/docs, embeddings, graph, MCP, recap, automation. Every import in both files resolves to a module already on the umbrella. No internal `zz-support-files/` artifact is staged.

Draft — not for merge, and not ready, pending formal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXdvJMSZMZu3CEXeUBAr8u