### PR TITLE
feat(knowledge): the three inputs read once, the signal bound to those bytes, the manifest sealed (Plan 02, child 02.6)

### DIFF
--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -1,0 +1,746 @@
+"""`index build`, `index update`, `index status` and the manifest (Plan 02 §2, §3).
+
+THE MANIFEST IS THE CONTRACT BETWEEN A BUILD AND EVERY LATER QUERY. Spec §5.6 enumerates what
+it must record; `MANIFEST_FIELDS` is that enumeration in one place, asserted as a set by the
+suite so a field dropped from the writer cannot quietly disappear from a document nobody
+reads until a query answers under the wrong chunker.
+
+TWO SIGNALS, TWO COSTS, TWO PLACES (B3). Indexing is MANUAL BY DECISION (spec §9.2), so the
+failure that actually happens is not corruption — it is *you ran `enrich` and did not
+reindex*. Two different instruments answer two different questions:
+
+| `StoreSignal` — mtime + size | one `os.stat` | EVERY query | "the store moved" |
+| `store_fingerprint` — sha256 per item | loads the store | build/update/status | "WHICH items changed, and how many" |
+
+The cheap one can give false positives (a `touch` with no edit) and that is accepted: a false
+positive costs one warning, a false negative costs serving stale evidence as fresh. It fails
+towards the warning, the same direction `origin: unknown -> llm_synthesis` fails.
+
+THE PER-ITEM FINGERPRINT IS OVER THE SURFACES, NOT OVER `(fetched_at, enriched_at)` as Plan
+01 §10 sketched, and CLAUDE.md rule 6 is both reasons. First, `content.fetched_at` cannot
+reach an item whose `content` is `None` — 960 of 2,404 in the real store, measured
+2026-09-01 on sha256 `f76341a3…` — because there is
+nothing to stamp. Second, a timestamp is a PROXY: a summary edited by hand, or any repair
+that rewrites text without touching a clock, changes the indexable corpus and leaves the
+proxy unmoved, so the index would keep serving the old body under a fingerprint asserting it
+is current. Hashing the emitted surface fingerprints asks the question directly — *did the
+text this index holds change?* — and it reaches every item. The cost is one emitter pass over
+the store per `update`/`status`, which is measured and published in the execution report.
+
+NOTHING HERE WRITES TO THE STORE. `items.json`, `vocab.yaml` and `topics.json` are read and
+never touched, and no command of this plan takes a snapshot, because none of them is
+destructive: `data/index/` is derived and reconstructible by definition (spec §5.6).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import MISSING, dataclass, field
+from dataclasses import fields as dataclass_fields
+from datetime import datetime
+from pathlib import Path
+
+from xbrain.executors.api import iter_content_sources
+from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams
+from xbrain.knowledge.ids import CHUNKER_VERSION, SURFACE_VERSION, surface_fingerprint
+from xbrain.knowledge.index_schema import (
+    REBUILD_ADVICE,
+    SCHEMA_VERSION,
+    IndexIncompatibleError,
+    IndexMissingError,
+    manifest_path,
+)
+from xbrain.knowledge.lexical_fts import FTS_CONNECTIVE, FTS_TOKENIZE
+from xbrain.knowledge.models import KnowledgeSurface, TopicRecord
+from xbrain.knowledge.surfaces import (
+    CONTENT_KIND_TO_SURFACE_TYPES,
+    item_surfaces,
+    item_topics,
+)
+from xbrain.models import Item, Topic, TopicPage
+from xbrain.rubrics import parse_vocab
+from xbrain.store import parse_store, parse_topic_pages
+
+# Spec §5.6, field by field, in one place. The suite asserts the written document's key set
+# equals this, so writer and contract cannot drift apart.
+MANIFEST_FIELDS: frozenset[str] = frozenset(
+    {
+        "schema_version",
+        "built_at",
+        "store_fingerprint",
+        "store_signal",
+        "vocab_fingerprint",
+        "topics_fingerprint",
+        "surface_version",
+        "chunker_version",
+        "chunker_params",
+        # Beyond spec §5.6 ON PURPOSE: these two DECIDE every recall number. The connective
+        # change of Plan 01 M3 moved mean recall@10 from 0.1429 to 0.8099 without touching
+        # the chunker, and a manifest that recorded the chunker but not the query semantics
+        # would let two incomparable baselines look like one measurement.
+        "tokenize",
+        "connective",
+        "embeddings",
+        "counts",
+        "skipped",
+        "failed",
+    }
+)
+
+# `REBUILD_ADVICE` is imported from `index_schema`, beside the error that carries it: a
+# corrupt database raises the same error with the same advice, and two copies of the sentence
+# would be two things that have to be kept in step (rule 5).
+UPDATE_ADVICE = "Actualiza el índice con `xbrain index update`."
+
+# The NESTED schema of the manifest, each set defined ONCE and read by the writer, the reader
+# and the consistency check (B1, round 06). `counts` holds exactly the five planes
+# `count_rows` counts; `skipped` exactly the four causes spec §5.6 names; `chunker_params`
+# exactly the fields of `ChunkerParams`. A plane added to `_COUNT_STATEMENTS` is therefore
+# required of every manifest, compared by `manifest_mismatch` and refused when absent, with
+# nobody remembering to add it in three places.
+COUNT_PLANES: frozenset[str] = frozenset({"items", "topics", "surfaces", "chunks", "profiles"})
+SKIPPED_CAUSES: frozenset[str] = frozenset(
+    {"empty_text", "decorative", "no_speech", "failed_sources"}
+)
+CHUNKER_PARAM_NAMES: frozenset[str] = frozenset(
+    field_.name for field_ in dataclass_fields(ChunkerParams)
+)
+
+
+@dataclass(frozen=True)
+class StoreSignal:
+    """The CHEAP change signal: `mtime_ns` and size of the THREE inputs (spec §5.6, P1a).
+
+    Three `os.stat`, so a query can afford it on every call. A missing file yields zeros
+    rather than raising: a query must still be able to say *the index is behind* when the
+    store has been moved away, and raising from inside `search` is the wrong place to learn
+    it.
+
+    THREE FILES, NOT ONE (P1a, gate Codex round 05). Spec §5.6 names `data/items.json` as
+    the file the cheap signal watches, and that is what the first version stat'ed — but the
+    index derives from `vocab.yaml` and `topics.json` too: a topic description enters every
+    assigned item's PROFILE (spec §5.1.A), and overviews and notes are chunks the index
+    serves. The manifest already recorded their deep fingerprints; the query door never
+    compared them, so `xbrain topics` — which writes `topics.json` and never `items.json` —
+    left every later `search` answering over the old topic plane with nothing declared, the
+    silent staleness spec §9.3 forbids, on two of the three inputs. One signal over the
+    three files, one comparison, three `stat` calls.
+
+    A manifest written before round 05 carries no vocab/topics entries: they read back as
+    zeros, compare unequal to the live files, and the index is declared behind until the
+    next `update` re-seals the manifest. That is the direction this signal is meant to
+    fail in — towards the warning — and it costs one `index update`.
+    """
+
+    items_json_mtime_ns: int
+    items_json_size: int
+    vocab_yaml_mtime_ns: int = 0
+    vocab_yaml_size: int = 0
+    topics_json_mtime_ns: int = 0
+    topics_json_size: int = 0
+
+    @classmethod
+    def of(
+        cls, items_path: Path, vocab_path: Path | None = None, topics_path: Path | None = None
+    ) -> StoreSignal:
+        """The signal of the three inputs AS THEY ARE ON DISK NOW — the query-time side."""
+        items_mtime, items_size = _stat_signal(items_path)
+        vocab_mtime, vocab_size = _stat_signal(vocab_path)
+        topics_mtime, topics_size = _stat_signal(topics_path)
+        return cls(
+            items_json_mtime_ns=items_mtime,
+            items_json_size=items_size,
+            vocab_yaml_mtime_ns=vocab_mtime,
+            vocab_yaml_size=vocab_size,
+            topics_json_mtime_ns=topics_mtime,
+            topics_json_size=topics_size,
+        )
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "items_json_mtime_ns": self.items_json_mtime_ns,
+            "items_json_size": self.items_json_size,
+            "vocab_yaml_mtime_ns": self.vocab_yaml_mtime_ns,
+            "vocab_yaml_size": self.vocab_yaml_size,
+            "topics_json_mtime_ns": self.topics_json_mtime_ns,
+            "topics_json_size": self.topics_json_size,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: object) -> StoreSignal:
+        """The signal as a manifest recorded it — validated, never cast (B1).
+
+        The two `items.json` entries are REQUIRED; the four vocab/topics entries are the
+        round-05 additions and default to zero, which is the documented compatibility
+        promise: a pre-round-05 manifest compares unequal to the live files and is declared
+        behind until its first `update`. Required and optional are read off THIS dataclass
+        — a field with a default is optional — so the schema has one definition.
+        """
+        return cls(**_closed_int_mapping(raw, "store_signal", *_signal_keys()))
+
+
+def _stat_signal(path: Path | None) -> tuple[int, int]:
+    """`(mtime_ns, size)` of one input file, or `(0, 0)` when it is absent or not given."""
+    if path is None:
+        return 0, 0
+    try:
+        stat = path.stat()
+    except OSError:
+        return 0, 0
+    return stat.st_mtime_ns, stat.st_size
+
+
+@dataclass(frozen=True)
+class IndexInputs:
+    """The three inputs of the index AND the cheap signal of the snapshot they were read from.
+
+    The signal travels WITH the objects because it describes them (P1b): a signal taken from
+    the path at any other moment describes whatever file is there at that moment, which is
+    what let the manifest certify an `items.json` the base had never seen.
+    """
+
+    store: dict[str, Item]
+    vocab: list[Topic]
+    topic_pages: dict[str, TopicPage]
+    signal: StoreSignal
+
+
+def load_index_inputs(
+    items_path: Path, vocab_path: Path | None = None, topics_path: Path | None = None
+) -> IndexInputs:
+    """Read the three inputs and return them WITH the signal of the bytes that were read.
+
+    THE SIGNAL IS BOUND TO THE SNAPSHOT, NOT TO THE PATH (P1b, gate Codex round 05). `build`
+    and `update` used to seal the manifest with `StoreSignal.of(items_path)` taken AFTER the
+    rows were committed — a `stat` of whatever file the path pointed at by then. The caller
+    had loaded the store minutes earlier (the CLI loads it before calling in), so a save that
+    landed in that window put the base under the OLD objects and the manifest under the NEW
+    file's mtime and size: `search` then compared equal signals and answered over stale rows
+    with nothing declared, while `status` — which loads the store — saw the changed item.
+    The gate's probe A: `raceonlytoken` in the file, not in the base, `degraded:
+    ("no_embeddings",)`, `items_changed=1`, `behind=False`.
+
+    Every file is read through ITS OWN HANDLE and the signal is `os.fstat` of that handle,
+    taken BEFORE the read. The store's writers replace files atomically (`os.replace`), so an
+    open handle keeps the inode it opened and the bytes parsed are the bytes that inode holds:
+    the signal describes exactly what was parsed, by construction, and a replacement that
+    lands during the read leaves the path pointing at a NEWER inode, which the query-time
+    `StoreSignal.of` then reports as different — the index declares itself behind. For a
+    writer that rewrites in place instead (`save_vocab` uses `write_text`), taking the stat
+    before the read means a write that lands mid-read produces an older signal than the
+    content, so the index is again declared behind rather than certified fresh: the same
+    direction, the warning.
+
+    A MISSING file reads as its empty value and a zero signal, exactly as `load_store`,
+    `load_vocab`, `load_topic_pages` and `StoreSignal.of` treat it. A file that exists and
+    cannot be read RAISES (A-2): an unreadable store is not an empty one, and every door
+    that loads through here closes on the error instead of answering over nothing.
+    """
+    items_text, items_mtime, items_size = _read_bound(items_path)
+    vocab_text, vocab_mtime, vocab_size = _read_bound(vocab_path)
+    topics_text, topics_mtime, topics_size = _read_bound(topics_path)
+    return IndexInputs(
+        store=parse_store(items_text) if items_text is not None else {},
+        vocab=parse_vocab(vocab_text) if vocab_text is not None else [],
+        topic_pages=parse_topic_pages(topics_text) if topics_text is not None else {},
+        signal=StoreSignal(
+            items_json_mtime_ns=items_mtime,
+            items_json_size=items_size,
+            vocab_yaml_mtime_ns=vocab_mtime,
+            vocab_yaml_size=vocab_size,
+            topics_json_mtime_ns=topics_mtime,
+            topics_json_size=topics_size,
+        ),
+    )
+
+
+def _bound_signal(
+    signal: StoreSignal | None, items_path: Path, vocab_path: Path | None, topics_path: Path | None
+) -> StoreSignal:
+    """The signal `build`/`update` seal into the manifest: the caller's, or a stat taken NOW.
+
+    The caller who LOADED the objects is the only one who can say which snapshot they are —
+    `load_index_inputs` hands the signal over with them, and the CLI passes it through. A
+    caller that passes none gets the three paths stat'ed HERE, before the first row is
+    written — never after the commit, which is where the first version took it and how the
+    manifest came to certify a file the base had never seen (P1b). That fallback binds
+    nothing to the objects; it is honest only for a caller that wrote the files itself a
+    moment ago (the suite's fixtures), and the docstring of `build` says so.
+    """
+    if signal is not None:
+        return signal
+    return StoreSignal.of(items_path, vocab_path, topics_path)
+
+
+def _read_bound(path: Path | None) -> tuple[str | None, int, int]:
+    """`(text, mtime_ns, size)` of one input, the stat taken on the handle the text came from.
+
+    `(None, 0, 0)` for an ABSENT or unnamed file — and for nothing else (A-2, round 08).
+    The first version caught every `OSError`, so a file that EXISTS and cannot be read — a
+    `chmod 000`, a directory standing in its place, an `EIO` from a failing mount — loaded
+    as the empty store reserved for a missing one: the cheap signal still stat'ed fine, so
+    no door saw anything wrong, and on the real index `status` reported `items_removed
+    2404` as healthy, `search` answered zero results with exit 0, `update` planned the
+    deletion of every item and `build --force` replaced 22,286 chunks with the topic plane's
+    703, sealed consistent, exit 0. `load_store` (`store.py`) only ever read an absent file
+    as `{}`; this loader now agrees, and any other `OSError` propagates — the CLI prints it
+    as `Error: …` with exit 1, and the index on disk is not touched.
+    """
+    if path is None:
+        return None, 0, 0
+    try:
+        handle = path.open("rb")
+    except FileNotFoundError:
+        return None, 0, 0
+    with handle:
+        stat = os.fstat(handle.fileno())
+        data = handle.read()
+    return data.decode("utf-8"), stat.st_mtime_ns, stat.st_size
+
+
+@dataclass(frozen=True)
+class IndexOptions:
+    """Everything a build needs that is not the corpus itself.
+
+    The configured transcribe/vision commands no longer travel here (F7-7, round 08): they
+    were stamped on the ASR/VLM surfaces as `producer`, a provenance claim the store cannot
+    back, and the emitter no longer takes them. See `surfaces.item_surfaces`.
+    """
+
+    params: ChunkerParams = DEFAULT_CHUNKER_PARAMS
+    vault_dir: Path | None = None
+
+
+@dataclass(frozen=True)
+class Manifest:
+    """The index's self-description. Written last, so its presence means the build finished."""
+
+    schema_version: str
+    built_at: datetime
+    store_fingerprint: str
+    store_signal: StoreSignal
+    vocab_fingerprint: str
+    topics_fingerprint: str
+    surface_version: str
+    chunker_version: str
+    chunker_params: dict[str, int]
+    tokenize: str
+    connective: str
+    counts: dict[str, int]
+    skipped: dict[str, int]
+    failed: list[dict[str, str]] = field(default_factory=list)
+    # The hole Plan 03 fills with `{model, dimension, normalized, command_version}`. Declared
+    # now so its arrival is not a manifest migration in the next plan.
+    embeddings: dict[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "built_at": self.built_at.isoformat(),
+            "store_fingerprint": self.store_fingerprint,
+            "store_signal": self.store_signal.to_dict(),
+            "vocab_fingerprint": self.vocab_fingerprint,
+            "topics_fingerprint": self.topics_fingerprint,
+            "surface_version": self.surface_version,
+            "chunker_version": self.chunker_version,
+            "chunker_params": dict(self.chunker_params),
+            "tokenize": self.tokenize,
+            "connective": self.connective,
+            "embeddings": self.embeddings,
+            "counts": dict(self.counts),
+            "skipped": dict(self.skipped),
+            "failed": list(self.failed),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object]) -> Manifest:
+        """The document, TOTALLY validated — every nested key, every value's type (B1).
+
+        The first version checked the top-level key set and cast what sat under it, so a
+        manifest whose `counts` was `{}` loaded as compatible, and `manifest_mismatch`,
+        iterating whatever `counts` offered, compared nothing: `status` called an amputated
+        base healthy, `search` answered zero results over it with `no_embeddings` and nothing
+        else, and `update` sealed the state as sound (the round-06 gate, reproduced). Spec
+        §9.3: an incompatible manifest is never queried partially — and a manifest that
+        declares less than the schema is incompatible, not lenient. Closed as well as total:
+        an undeclared plane or cause is refused, because nothing could compare it.
+        """
+        missing = MANIFEST_FIELDS - set(raw)
+        if missing:
+            raise IndexIncompatibleError(
+                f"El manifest no declara {sorted(missing)}. {REBUILD_ADVICE}"
+            )
+        return cls(
+            schema_version=str(raw["schema_version"]),
+            built_at=_instant(raw["built_at"]),
+            store_fingerprint=str(raw["store_fingerprint"]),
+            store_signal=StoreSignal.from_dict(raw["store_signal"]),
+            vocab_fingerprint=str(raw["vocab_fingerprint"]),
+            topics_fingerprint=str(raw["topics_fingerprint"]),
+            surface_version=str(raw["surface_version"]),
+            chunker_version=str(raw["chunker_version"]),
+            chunker_params=_closed_int_mapping(
+                raw["chunker_params"], "chunker_params", CHUNKER_PARAM_NAMES
+            ),
+            tokenize=str(raw["tokenize"]),
+            connective=str(raw["connective"]),
+            embeddings=_optional_mapping(raw["embeddings"], "embeddings"),
+            counts=_closed_int_mapping(raw["counts"], "counts", COUNT_PLANES),
+            skipped=_closed_int_mapping(raw["skipped"], "skipped", SKIPPED_CAUSES),
+            failed=_failures(raw["failed"]),
+        )
+
+
+def _malformed(field_name: str, detail: str) -> IndexIncompatibleError:
+    """One actionable sentence for every malformed field, naming the field and the reason.
+
+    A hand-edited manifest is exactly the input this reader has to survive, and spec §9.3
+    asks for a stable error rather than a traceback from inside a query.
+    """
+    return IndexIncompatibleError(
+        f"El manifest tiene el campo {field_name!r} malformado: {detail}. {REBUILD_ADVICE}"
+    )
+
+
+def _closed_int_mapping(
+    value: object,
+    field_name: str,
+    required: frozenset[str],
+    optional: frozenset[str] = frozenset(),
+) -> dict[str, int]:
+    """A mapping with EXACTLY the declared keys, each a non-negative integer.
+
+    `type(count) is int` rather than `isinstance`: `True` is an `int` to `isinstance`, and a
+    JSON `true` where a count belongs is a malformed document, not a count of one. A string
+    `"56"` is refused for the same reason — `int("56")` accepted it silently before.
+    """
+    if not isinstance(value, dict):
+        raise _malformed(field_name, "no es un objeto")
+    keys = set(value)
+    if absent := sorted(required - keys):
+        raise _malformed(field_name, f"faltan {absent}")
+    if unknown := sorted(keys - required - optional):
+        raise _malformed(field_name, f"claves no declaradas {unknown}")
+    for key, count in value.items():
+        if type(count) is not int or count < 0:
+            raise _malformed(field_name, f"{key!r} debe ser un entero no negativo, es {count!r}")
+    return {str(key): int(count) for key, count in value.items()}
+
+
+def _signal_keys() -> tuple[frozenset[str], frozenset[str]]:
+    """`(required, optional)` entries of `store_signal`, read off `StoreSignal` itself."""
+    required = frozenset(f.name for f in dataclass_fields(StoreSignal) if f.default is MISSING)
+    optional = frozenset(f.name for f in dataclass_fields(StoreSignal)) - required
+    return required, optional
+
+
+def _optional_mapping(value: object, field_name: str) -> dict[str, object] | None:
+    """`null` or an object — the `embeddings` slot Plan 03 fills — never anything else."""
+    if value is None:
+        return None
+    if not isinstance(value, dict):
+        raise _malformed(field_name, "no es null ni un objeto")
+    return {str(key): item for key, item in value.items()}
+
+
+def _failures(value: object) -> list[dict[str, str]]:
+    """The `failed` list: every entry a mapping of strings, or the document is refused."""
+    if not isinstance(value, list) or not all(
+        isinstance(entry, dict) and all(isinstance(v, str) for v in entry.values())
+        for entry in value
+    ):
+        raise _malformed("failed", "no es una lista de objetos de texto")
+    return [{str(k): str(v) for k, v in entry.items()} for entry in value]
+
+
+def _instant(value: object) -> datetime:
+    """`built_at` as an instant, or the malformed-field sentence instead of a `ValueError`."""
+    try:
+        return datetime.fromisoformat(str(value))
+    except ValueError as error:
+        raise _malformed("built_at", f"{value!r} no es un instante ISO") from error
+
+
+def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
+    """sha256 over everything about this item that the INDEX holds.
+
+    Two halves, and both are needed. The SURFACE ROWS answer *did what the index holds about
+    each surface change?* — `surface_row` is the exact tuple `_write_surfaces` inserts, so
+    it covers the surface fingerprint (emitter version, type, origin, body) AND the
+    attribution, title, url, locator and language the index stores and `search` serves on
+    every match (A-1). The filterable METADATA of the item (source, author, date, topics,
+    content kinds) answers the other half: a changed author changes what `--author` returns
+    even though not one character of text moved.
+
+    THE ROW, NOT THE SURFACE FINGERPRINT ALONE (G-5). `surface_fingerprint` is
+    `(version, type, origin, text)` by design and must stay so; but hashing only that here
+    meant a `refresh-quoted` that filled in the author of a quoted post without touching
+    its body left `update` reporting `0 cambiados` and `search` serving the old attribution
+    — the evidence repaired, the derivative standing (CLAUDE.md rule 6), on the attribution
+    rule this repo paid for in blood. Sharing the writer's projection is what makes "every
+    stored column is hashed" structural rather than a list kept in step by hand.
+
+    What is NOT hashed, and why: `producer`. The index has no producer column, and the
+    producers the store records (`enriched.executor`, `description_version`) travel with
+    the surface `get` re-emits; the ASR/VLM surfaces carry none since round 08 (F7-7),
+    because the store records no transcriber and a configured command is not evidence.
+
+    Deliberately NOT `(item_id, content.fetched_at, enriched.enriched_at)`: see the module
+    docstring for why a timestamp proxy both misses hand edits and cannot reach the 40 % of
+    the corpus with no `content` at all.
+    """
+    options = options or IndexOptions()
+    surfaces = item_surfaces(item)
+    parts = [
+        SURFACE_VERSION,
+        item.id,
+        item.source,
+        item.url,
+        item.author.handle,
+        item.author.name,
+        item.created_at.isoformat(),
+        item.captured_at.isoformat(),
+        item.bookmark_folder or "",
+        *item_topics(item),
+        *sorted(
+            source.kind
+            for _index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
+        ),
+        *(json.dumps(surface_row(surface), ensure_ascii=False) for surface in surfaces),
+    ]
+    return _sha256("\0".join(parts))
+
+
+# The column order of `surfaces`, as ONE tuple type shared by the writer and the fingerprint.
+SurfaceRow = tuple[
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    int,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str,
+    str | None,
+    str,
+    int,
+]
+
+
+def surface_row(surface: KnowledgeSurface) -> SurfaceRow:
+    """What the index STORES about a surface — the row `_write_surfaces` inserts, verbatim.
+
+    One projection, two readers: the writer binds it to the `INSERT`, `item_fingerprint`
+    hashes it. A column added to `surfaces` therefore cannot be stored without being hashed,
+    and `test_the_fingerprint_hashes_the_same_row_the_writer_inserts` reads the rows back to
+    prove the two never drifted. The last column is a LENGTH, never the body (spec §10.8);
+    the body is covered by `fingerprint`, which hashes it.
+    """
+    return (
+        surface.surface_id,
+        surface.owner_type,
+        surface.owner_id,
+        surface.surface_type,
+        surface.origin,
+        surface.trust_class,
+        int(surface.derived),
+        surface.attribution.handle if surface.attribution else None,
+        surface.attribution.name if surface.attribution else None,
+        surface.title,
+        surface.locator.url,
+        surface.locator.model_dump_json(),
+        surface.language,
+        surface.fingerprint,
+        len(surface.text),
+    )
+
+
+# The column order of `topics`, as ONE tuple type shared by the writer and the comparator (H1).
+TopicRow = tuple[
+    str,
+    str,
+    str | None,
+    str,
+    str | None,
+    int | None,
+    int,
+    str,
+    str,
+    str,
+    str | None,
+]
+
+
+def topic_row(record: TopicRecord) -> TopicRow:
+    """What the index STORES about a topic — the row `_write_topic_row` inserts, verbatim.
+
+    The same pattern as `surface_row` (G-5), for the same reason: one projection, two
+    readers. The writer binds it to the `INSERT`; `topic_rows_behind` compares it against
+    what the base holds. A membership-derived column — `primary_item_ids_json`,
+    `secondary_item_ids_json`, `stale` — therefore cannot be stored without being compared,
+    which is exactly what H1 lacked: `update` decided the whole topic plane from the
+    vocabulary and page fingerprints and never asked whether the members it had written were
+    still the members the store implies, so a topic move done by `enrich` rewrote
+    `item_topics` and left `topics` holding the old members under a healthy manifest.
+    """
+    return (
+        record.slug,
+        record.description.text,
+        record.overview.text if record.overview else None,
+        json.dumps([note.text for note in record.notes], ensure_ascii=False),
+        record.synthesized_at.isoformat() if record.synthesized_at else None,
+        record.post_count_at_synth,
+        int(record.stale),
+        json.dumps(list(record.primary_item_ids)),
+        json.dumps(list(record.secondary_item_ids)),
+        record.vocab_fingerprint,
+        record.synthesis_fingerprint,
+    )
+
+
+def store_fingerprint(store: Mapping[str, Item], *, options: IndexOptions | None = None) -> str:
+    """The DEEP store signal: one sha256 over every item's fingerprint, in id order.
+
+    Order-independent by construction — the ids are sorted — because a dict's iteration order
+    is a property of how the store was loaded, not of what it contains.
+    """
+    parts = [
+        f"{item_id}={item_fingerprint(store[item_id], options=options)}"
+        for item_id in sorted(store)
+    ]
+    return _sha256("\0".join(parts))
+
+
+def vocab_fingerprint(vocab: Sequence[Topic]) -> str:
+    """sha256 over the vocabulary's slugs AND descriptions.
+
+    The descriptions are in because they enter every assigned item's PROFILE (spec §5.1.A):
+    editing one changes indexed text on the item plane, not only on the topic plane.
+    """
+    parts = [f"{topic.slug}={topic.description}" for topic in sorted(vocab, key=lambda t: t.slug)]
+    return _sha256("\0".join(parts))
+
+
+def topics_fingerprint(pages: Mapping[str, TopicPage]) -> str:
+    """sha256 over each topic page's overview and notes — the synthesised text."""
+    parts = []
+    for slug in sorted(pages):
+        page = pages[slug]
+        parts.append(surface_fingerprint("topic_overview", "llm", page.overview))
+        parts += [surface_fingerprint("topic_note", "llm", note) for note in page.notes]
+        parts.append(slug)
+    return _sha256("\0".join(parts))
+
+
+def _sha256(blob: str) -> str:
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# the writer — ONE definition, used by build, update and the evaluation harness
+# ---------------------------------------------------------------------------
+
+
+def _params_dict(params: ChunkerParams) -> dict[str, int]:
+    return {
+        "target": params.target,
+        "max_chars": params.max_chars,
+        "overlap": params.overlap,
+        "min_chars": params.min_chars,
+    }
+
+
+def write_manifest(index_dir: Path, manifest: Manifest) -> None:
+    """Write the manifest LAST. Its presence is what says a build completed.
+
+    THE WRITER ROUND-TRIPS THROUGH THE READER (B1). The document is serialised, parsed and
+    validated by `Manifest.from_dict` before one byte lands, so a build or an update cannot
+    seal a manifest every later door would refuse — and, the other direction, a writer whose
+    shape drifted from the reader's schema fails HERE, loudly, instead of producing a
+    document the reader happens to accept while comparing less than it should.
+    """
+    document = json.dumps(manifest.to_dict(), ensure_ascii=False, indent=2)
+    Manifest.from_dict(json.loads(document))
+    index_dir.mkdir(parents=True, exist_ok=True)
+    manifest_path(index_dir).write_text(document, encoding="utf-8")
+
+
+def load_manifest(index_dir: Path) -> Manifest:
+    """Read the manifest, turning any malformed document into an ACTIONABLE error.
+
+    A `JSONDecodeError` from inside a query is a traceback; spec §9.3 asks for an error that
+    names the command that fixes it. Nothing is repaired here — Plan 02 §11: a corrupt base
+    is rebuilt, never patched.
+    """
+    path = manifest_path(index_dir)
+    if not path.exists():
+        raise IndexMissingError(
+            f"No hay manifest en {path}: el índice no está construido o quedó incompleto. "
+            "Constrúyelo con `xbrain index build`."
+        )
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise IndexIncompatibleError(
+            f"El manifest está corrupto ({error}). {REBUILD_ADVICE}"
+        ) from error
+    return Manifest.from_dict(raw)
+
+
+def load_compatible_manifest(index_dir: Path, *, params: ChunkerParams | None = None) -> Manifest:
+    """The manifest, REFUSED unless every version the code depends on matches (step 29).
+
+    Spec §9.3: *manifest incompatible: no se consulta parcialmente.* Six checks, not three.
+    The plan names the schema, the emitter and the chunker; the fourth is the chunker
+    PARAMETERS, because Plan 02 §7 sweeps `target x overlap` and a sweep that lands on new
+    parameters without bumping `CHUNKER_VERSION` produces chunks cut differently under
+    IDENTICAL ids — the worst case, since the id resolves and the text behind it is not what
+    it was. The fifth and sixth are the TOKENIZER and the CONNECTIVE (F7-8, round 07): the
+    manifest recorded them «because they decide every recall number» and no door compared
+    them — `tokenize: porter` / `connective: AND` were accepted by all three on the real
+    index. The tokenizer is baked into the FTS DDL, so a base built under one and queried
+    under another is the M-1 shape with no guard; the connective moved recall@10 from
+    0.1429 to 0.8099 in Plan 01 M3.
+    """
+    manifest = load_manifest(index_dir)
+    mismatches = []
+    # `!r` on every manifest string (T-1, round 08): the manifest is hand-editable, and the
+    # three version strings were interpolated raw, so a newline in `schema_version` stood at
+    # column 0 of `index status` as a forged header and an ESC reached the TTY through the
+    # sentence `search` and `update` raise. A repr carries neither.
+    if manifest.schema_version != SCHEMA_VERSION:
+        mismatches.append(f"schema_version {manifest.schema_version!r} != {SCHEMA_VERSION!r}")
+    if manifest.surface_version != SURFACE_VERSION:
+        mismatches.append(f"surface_version {manifest.surface_version!r} != {SURFACE_VERSION!r}")
+    if manifest.chunker_version != CHUNKER_VERSION:
+        mismatches.append(f"chunker_version {manifest.chunker_version!r} != {CHUNKER_VERSION!r}")
+    if params is not None and manifest.chunker_params != _params_dict(params):
+        mismatches.append(f"chunker_params {manifest.chunker_params} != {_params_dict(params)}")
+    if manifest.tokenize != FTS_TOKENIZE:
+        mismatches.append(f"tokenize {manifest.tokenize!r} != {FTS_TOKENIZE!r}")
+    if manifest.connective != FTS_CONNECTIVE:
+        mismatches.append(f"connective {manifest.connective!r} != {FTS_CONNECTIVE!r}")
+    if mismatches:
+        raise IndexIncompatibleError(
+            "El índice fue construido con otra versión: "
+            + "; ".join(mismatches)
+            + f". {REBUILD_ADVICE}"
+        )
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+# One literal per table. The f-string version was safe — the names came from a tuple in this
+# module — but it made `bandit` report B608 and needed a suppression, and a suppression is a
+# request to stop looking.

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -356,7 +356,7 @@ class Manifest:
         }
 
     @classmethod
-    def from_dict(cls, raw: Mapping[str, object]) -> Manifest:
+    def from_dict(cls, raw: object) -> Manifest:
         """The document, TOTALLY validated — every nested key, every value's type (B1).
 
         The first version checked the top-level key set and cast what sat under it, so a
@@ -367,7 +367,24 @@ class Manifest:
         §9.3: an incompatible manifest is never queried partially — and a manifest that
         declares less than the schema is incompatible, not lenient. Closed as well as total:
         an undeclared plane or cause is refused, because nothing could compare it.
+
+        THE DOCUMENT IS A JSON OBJECT BEFORE IT IS ANYTHING ELSE. The totality check was
+        `MANIFEST_FIELDS - set(raw)`, and `set()` of a non-mapping is not an error — it is
+        the ELEMENTS. A hand-edited `manifest.json` holding the JSON LIST
+        `["schema_version", "built_at", …]` therefore passed the guard with `missing`
+        empty, because a list of the field NAMES has exactly the field names as its
+        elements, and the first subscript below raised `TypeError: list indices must be
+        integers` — out of `load_manifest`, out of `load_compatible_manifest`, out of every
+        door, as a traceback. Spec §9.3 asks for an actionable error; a `TypeError` from
+        inside a query is the shape this reader exists to remove. A top-level `3`, `null`
+        or `true` was worse still: `set()` of them raises `TypeError: not iterable` from
+        the guard LINE ITSELF, before one field was read. The type is checked first, so
+        every non-object document leaves by the same door as every other malformed one.
         """
+        if not isinstance(raw, Mapping):
+            raise IndexIncompatibleError(
+                f"El manifest no es un objeto JSON, es {type(raw).__name__}. {REBUILD_ADVICE}"
+            )
         missing = MANIFEST_FIELDS - set(raw)
         if missing:
             raise IndexIncompatibleError(

--- a/src/xbrain/rubrics.py
+++ b/src/xbrain/rubrics.py
@@ -150,7 +150,12 @@ def load_vocab(path: Path) -> list[Topic]:
     """Load the topic vocabulary; an empty list if the file does not exist."""
     if not path.exists():
         return []
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return parse_vocab(path.read_text(encoding="utf-8"))
+
+
+def parse_vocab(text: str) -> list[Topic]:
+    """The vocabulary from its YAML text — the ONE parser (see `store.parse_store`)."""
+    data = yaml.safe_load(text) or {}
     return [Topic(**entry) for entry in data.get("topics", [])]
 
 

--- a/src/xbrain/store.py
+++ b/src/xbrain/store.py
@@ -14,7 +14,17 @@ def load_store(path: Path) -> dict[str, Item]:
     """Load the item store; an empty dict if the file does not exist."""
     if not path.exists():
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    return parse_store(path.read_text(encoding="utf-8"))
+
+
+def parse_store(text: str) -> dict[str, Item]:
+    """The item store from its JSON text — the ONE parser, shared with the index loader.
+
+    Split from `load_store` so a reader that must bind what it parsed to the exact bytes it
+    read (`knowledge.index_build.load_index_inputs`) can read through its own file handle and
+    still parse through this function, instead of a second copy of these two lines.
+    """
+    raw = json.loads(text)
     return {item_id: Item.model_validate(data) for item_id, data in raw.items()}
 
 
@@ -40,7 +50,12 @@ def load_topic_pages(path: Path) -> dict[str, TopicPage]:
     """Load the topic-page store; an empty dict if the file does not exist."""
     if not path.exists():
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    return parse_topic_pages(path.read_text(encoding="utf-8"))
+
+
+def parse_topic_pages(text: str) -> dict[str, TopicPage]:
+    """The topic-page store from its JSON text — the ONE parser (see `parse_store`)."""
+    raw = json.loads(text)
     return {slug: TopicPage.model_validate(data) for slug, data in raw.items()}
 
 

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -1,0 +1,294 @@
+# tests/test_knowledge_index_build.py
+"""`index build` and its manifest (Plan 02 §2, §3, steps 3, 4, 7c, 9, 10c).
+
+THE MANIFEST IS THE CONTRACT BETWEEN A BUILD AND EVERY LATER QUERY. Spec §5.6 enumerates
+what it must record, and the enumeration is asserted as a SET rather than field by field, so
+a field dropped from the writer goes red instead of quietly disappearing from a JSON document
+nobody reads until a query answers under the wrong chunker.
+
+TWO SIGNALS, TWO COSTS, TWO PLACES (B3). `store_signal` is an `os.stat` — mtime and size of
+`data/items.json` — and it is what a QUERY can afford on every call. `store_fingerprint` is a
+sha256 per item and costs loading the store, so it is paid only by `build`, `update` and
+`status`. The cheap one says *the store moved*; the expensive one says *which items changed,
+and how many*. A false positive on the cheap one costs one warning; a false negative costs
+serving stale evidence as fresh, so it fails towards the warning.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from xbrain.knowledge import index_build
+from xbrain.knowledge.index_schema import (
+    IndexIncompatibleError,
+    db_path,
+    manifest_path,
+    open_index,
+)
+from xbrain.models import Item, Topic, TopicPage
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture()
+def corpus() -> tuple[dict[str, Item], list[Topic], dict[str, TopicPage]]:
+    raw = json.loads((FIXTURES / "knowledge_corpus.json").read_text(encoding="utf-8"))
+    store = {k: Item.model_validate(v) for k, v in raw["items"].items()}
+    vocab = [Topic.model_validate(v) for v in raw["vocab"].values()]
+    pages = {k: TopicPage.model_validate(v) for k, v in raw["topics"].items()}
+    return store, vocab, pages
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path, corpus) -> Path:
+    """A data/ directory holding the fixture store, so `store_signal` has a real file."""
+    store, _vocab, _pages = corpus
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "items.json").write_text(
+        json.dumps({k: v.model_dump(mode="json") for k, v in store.items()}), encoding="utf-8"
+    )
+    return data
+
+
+def test_a_corrupt_manifest_is_an_actionable_error_not_a_json_traceback(workspace) -> None:
+    """Plan 02 §11: a corrupt base or manifest names `index build --force`; nothing is repaired."""
+    (workspace / "index").mkdir(parents=True)
+    manifest_path(workspace / "index").write_text("{not json", encoding="utf-8")
+    with pytest.raises(IndexIncompatibleError, match="index build --force"):
+        index_build.load_compatible_manifest(workspace / "index")
+
+
+# ---------------------------------------------------------------------------
+# The fingerprint, and the population it has to reach (rule 6)
+# ---------------------------------------------------------------------------
+
+
+def test_the_item_fingerprint_changes_when_indexable_text_changes(corpus) -> None:
+    """It hashes the SURFACES, not `(fetched_at, enriched_at)` as Plan 01 §10 sketched.
+
+    Two reasons, and CLAUDE.md rule 6 is both of them. First, `content.fetched_at` cannot
+    reach an item whose `content` is `None` — 960 of 2,404 in the real store (measured
+    2026-09-01 on sha256 `f76341a3…`) — because there
+    is nothing to stamp. Second, a timestamp is a PROXY: a summary edited by hand, or any
+    repair that rewrites text without touching a clock, changes the indexable corpus and
+    leaves the proxy unmoved, so the index would keep serving the old body under a
+    fingerprint that says it is current.
+
+    Hashing the emitted surface fingerprints answers the question directly — *did the text
+    this index holds change?* — and it reaches every item, with or without `content`.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    before = index_build.item_fingerprint(item)
+    edited = item.model_copy(
+        update={"enriched": item.enriched.model_copy(update={"summary": "otro resumen"})}
+    )
+    assert index_build.item_fingerprint(edited) != before
+    assert index_build.item_fingerprint(item) == before, "and it is stable"
+
+
+def test_the_item_fingerprint_reaches_an_item_with_no_content(corpus) -> None:
+    """Step 6 / rule 6: the invalidation signal must reach the population it has to reach.
+
+    `k02` carries no `content` at all, so a fingerprint over `content.fetched_at` would be
+    constant for it forever. Seen red by hashing only the timestamps.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    assert item.content is None, "this test is only meaningful on an item with no content"
+    edited = item.model_copy(
+        update={"enriched": item.enriched.model_copy(update={"summary": "otro resumen"})}
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
+
+
+def test_the_item_fingerprint_also_covers_the_filterable_metadata(corpus) -> None:
+    """The index stores more than text: a changed author or topic changes what a filter returns.
+
+    Ignoring them would leave `--author` answering from an author the store no longer records.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    moved = item.model_copy(update={"source": "own_tweet"})
+    assert index_build.item_fingerprint(moved) != index_build.item_fingerprint(item)
+
+
+def test_the_store_fingerprint_is_order_independent(corpus) -> None:
+    """Two loads of the same store must agree, whatever order the dict happens to iterate in."""
+    store, _vocab, _pages = corpus
+    reversed_store = dict(reversed(list(store.items())))
+    assert index_build.store_fingerprint(reversed_store) == index_build.store_fingerprint(store)
+
+
+def test_load_index_inputs_binds_the_signal_to_the_bytes_it_read(workspace, corpus) -> None:
+    """The mechanism behind P1b, at the loader: the signal is `fstat` of the handle the
+    text came from, taken BEFORE the read — so a replacement that lands during the read
+    leaves the objects and the signal describing the same snapshot (the handle keeps the
+    inode it opened; the store's writers replace atomically), and leaves the path pointing
+    at a newer inode the query-time `StoreSignal.of` reports as different.
+
+    Staged INSIDE the read: the handle `load_index_inputs` opens replaces the file on disk
+    the moment it is read from, which is the only place a stat of the path and a stat of
+    the handle can disagree. Seen red under the mutation `stat = path.stat()` taken after
+    the read: the signal then described the replacement, not the bytes parsed.
+    """
+    from xbrain.store import save_store
+
+    store, _vocab, _pages = corpus
+    items = workspace / "items.json"
+    before = index_build.StoreSignal.of(items)
+    newer = {**store, "k01": store["k01"].model_copy(update={"text": "replaced during the load"})}
+
+    class RacingHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def fileno(self):
+            return self._handle.fileno()
+
+        def read(self):
+            save_store(newer, items)  # the race: a save lands while the loader is reading
+            return self._handle.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return self._handle.__exit__(*exc)
+
+    class RacingPath(type(items)):
+        def open(self, *args, **kwargs):
+            return RacingHandle(super().open(*args, **kwargs))
+
+    loaded = index_build.load_index_inputs(RacingPath(items))
+
+    assert loaded.store["k01"].text == store["k01"].text, "the parse saw the bytes it read"
+    assert loaded.signal == before, "the signal describes the snapshot that was parsed"
+    assert index_build.StoreSignal.of(items) != loaded.signal, "the path now points elsewhere"
+
+
+def test_the_store_signal_is_one_stat_and_nothing_else(workspace) -> None:
+    """The cheap signal must stay cheap, or it is the expensive one with a different name."""
+    signal = index_build.StoreSignal.of(workspace / "items.json")
+    stat = (workspace / "items.json").stat()
+    assert signal.items_json_mtime_ns == stat.st_mtime_ns
+    assert signal.items_json_size == stat.st_size
+
+
+def test_the_store_signal_of_a_missing_store_is_zeroed_not_an_exception(tmp_path: Path) -> None:
+    """A query must still be able to say "the index is behind" when the store is gone.
+
+    Raising here would turn a missing store into a crash inside `search`, which is the wrong
+    place to learn it: the response declares the degradation instead.
+    """
+    signal = index_build.StoreSignal.of(tmp_path / "nope.json")
+    assert signal == index_build.StoreSignal(items_json_mtime_ns=0, items_json_size=0)
+
+
+def _obstruct(path: Path, obstacle: str) -> None:
+    """Make `path` UNREADABLE without removing it — the two shapes an operator meets."""
+    if obstacle == "chmod000":
+        path.chmod(0)
+    else:
+        path.unlink()
+        path.mkdir()
+
+
+@pytest.mark.parametrize(
+    ("obstacle", "error"), [("chmod000", PermissionError), ("directory", IsADirectoryError)]
+)
+def test_an_unreadable_store_is_an_error_never_an_empty_store(
+    workspace: Path, obstacle: str, error: type[OSError]
+) -> None:
+    """A-2 (gate Fable §5.2, round 08 — the DIFF subagent's A-1, reproduced by the gate in
+    two variants): `_read_bound` caught EVERY `OSError` and answered `(None, 0, 0)`, the
+    reading reserved for a file that is ABSENT — so an `items.json` with `chmod 000`, or a
+    directory standing where the file was, loaded as an EMPTY store. On the real index:
+    `status` healthy with `items_removed 2404`, `search` «0 resultados» exit 0 with nothing
+    declared, `update` planning `-2404 items`, and `build --force` replacing 22,286 chunks
+    with the 703 of the topic plane, sealed consistent, exit 0. The loader is the route
+    BEFORE seam (a), the one no door asks, and through it the whole fail-open family came
+    back with a destruction on top.
+
+    `load_store` (`store.py`) reads only an ABSENT file as `{}`; every other `OSError`
+    propagates. The loader now agrees: only `FileNotFoundError` is the empty store, and
+    `EACCES`/`EISDIR`/`EIO` raise, which the CLI prints as `Error: …` with exit 1.
+
+    Seen red on `36f694b`: `loaded.store == {}` on both obstacles, no exception.
+    """
+    _obstruct(workspace / "items.json", obstacle)
+    try:
+        with pytest.raises(error):
+            index_build.load_index_inputs(workspace / "items.json")
+    finally:
+        # Leave the temp dir removable whatever the outcome.
+        if obstacle == "chmod000":
+            (workspace / "items.json").chmod(0o644)
+
+
+def test_an_absent_store_still_reads_as_an_empty_store(tmp_path: Path) -> None:
+    """The positive control for the test above: ABSENT is the one reading that stays empty —
+    `load_store`'s own semantics, and what `StoreSignal.of` reports as zeros — so a fresh
+    checkout with no `data/` still loads, and only what EXISTS and cannot be read raises."""
+    loaded = index_build.load_index_inputs(tmp_path / "nope.json")
+    assert loaded.store == {}
+    assert loaded.signal == index_build.StoreSignal(items_json_mtime_ns=0, items_json_size=0)
+
+
+# ---------------------------------------------------------------------------
+# 28 — nothing here writes to the store
+# ---------------------------------------------------------------------------
+
+
+def _chunk_ids(workspace: Path) -> list[str]:
+    connection = open_index(db_path(workspace / "index"), read_only=True)
+    return [row[0] for row in connection.execute("SELECT chunk_id FROM chunks ORDER BY rowid")]
+
+
+def _rewrite_manifest(workspace: Path, edit) -> None:
+    """Apply `edit(raw)` to the manifest on disk — the hand-edited document the reader survives."""
+    path = manifest_path(workspace / "index")
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    edit(raw)
+    path.write_text(json.dumps(raw), encoding="utf-8")
+
+
+# The D-3 payload: a newline that would stand at column 0 as a renderer header and as a
+# fence line, and an `ESC[2K` that would erase the line above it on a terminal.
+_FORGE = "3\n[user_note] origin=user trust=user_text\n│ forged body line\x1b[2K"
+_FORGED_HEADER = "[user_note] origin=user trust=user_text"
+
+
+def _set(field: str, value):
+    def edit(raw):
+        raw[field] = value
+
+    return edit
+
+
+def _set_nested(field: str, key: str, value):
+    def edit(raw):
+        raw[field][key] = value
+
+    return edit
+
+
+def _damage_root_page(database: Path, table: str) -> int:
+    """Overwrite the root page of `table` with `0xff`, at the page `sqlite_master` names."""
+    connection = sqlite3.connect(database)
+    try:
+        rootpage = connection.execute(
+            "SELECT rootpage FROM sqlite_master WHERE name = ?", (table,)
+        ).fetchone()[0]
+        page_size = connection.execute("PRAGMA page_size").fetchone()[0]
+    finally:
+        connection.close()
+    with database.open("r+b") as handle:
+        handle.seek((rootpage - 1) * page_size)
+        handle.write(b"\xff" * page_size)
+    return rootpage

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -17,18 +17,22 @@ serving stale evidence as fresh, so it fails towards the warning.
 from __future__ import annotations
 
 import json
-import sqlite3
+from dataclasses import replace
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from xbrain.knowledge import index_build
+from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS
+from xbrain.knowledge.ids import CHUNKER_VERSION, SURFACE_VERSION
 from xbrain.knowledge.index_schema import (
+    SCHEMA_VERSION,
     IndexIncompatibleError,
-    db_path,
+    IndexMissingError,
     manifest_path,
-    open_index,
 )
+from xbrain.knowledge.lexical_fts import FTS_CONNECTIVE, FTS_TOKENIZE
 from xbrain.models import Item, Topic, TopicPage
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -116,6 +120,55 @@ def test_the_item_fingerprint_also_covers_the_filterable_metadata(corpus) -> Non
     item = store["k02"]
     moved = item.model_copy(update={"source": "own_tweet"})
     assert index_build.item_fingerprint(moved) != index_build.item_fingerprint(item)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("author", {"handle": "someoneelse", "name": "Someone Else"}),
+        ("title", "A different title"),
+        ("language", "fr"),
+        ("url", "https://x.com/othervoice/status/moved"),
+    ],
+)
+def test_the_item_fingerprint_covers_what_the_index_stores_about_a_surface(
+    corpus, field: str, value: object
+) -> None:
+    """G-5: every column the index STORES about a surface moves the fingerprint.
+
+    `surface_fingerprint` is `(version, type, origin, text)` by design — two surfaces with
+    the same text under different provenance must differ, and nothing more. But the index
+    persists more than that in `surfaces`: attribution, title, url, locator and language,
+    which `search` serves on every match (A-1) and `--has-surface` filters on. A change to
+    any of them with the text untouched left `update` seeing nothing to do — the evidence
+    repaired and the derivative standing (rule 6), on the attribution rule this repo paid
+    for in blood.
+
+    Four axes, one parametrised test, each changing ONE field of k07's quoted post and
+    nothing else. The url moves the locator too (`locator.url`), which is the point: the
+    locator is what the consumer resolves the evidence through. `producer` is deliberately
+    NOT here — the index has no producer column, and since round 08 (F7-7) the ASR/VLM
+    surfaces carry none at all, because the store records no transcriber; the producers
+    that ARE recorded (`enriched.executor`, `description_version`) travel with the surface
+    and are not stored columns either.
+
+    Seen red before the fix on all four: the fingerprint did not move. Seen red again here
+    under the mutant `surface_row` → `(None, None, None, …)`, which the file passed 90/90
+    before this test was restored: `surface_row` is the projection `item_fingerprint`
+    hashes, so a column dropped from it is a column the index stores and never re-hashes.
+    """
+    from xbrain.models import Author
+
+    store, _vocab, _pages = corpus
+    item = store["k07"]
+    position = next(i for i, s in enumerate(item.content.sources) if s.kind == "quoted_tweet")
+    sources = list(item.content.sources)
+    patch = {field: Author(**value) if field == "author" else value}
+    sources[position] = sources[position].model_copy(update=patch)
+    edited = item.model_copy(
+        update={"content": item.content.model_copy(update={"sources": sources})}
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), field
 
 
 def test_the_store_fingerprint_is_order_independent(corpus) -> None:
@@ -241,13 +294,15 @@ def test_an_absent_store_still_reads_as_an_empty_store(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# 28 — nothing here writes to the store
+# The manifest: sealed by this child's writer, read by this child's reader
+#
+# THE SEED IS `write_manifest`, NOT `build`. Every assertion below is the snapshot's, on the
+# same doors (`Manifest.from_dict`, `write_manifest`, `load_manifest`,
+# `load_compatible_manifest`); only the way a manifest gets onto disk changes, because
+# `index_build.build` arrives with 02.7 and this child already ships the seal and the read.
+# Nothing is invented: the seeded document is what `to_dict` emits, validated by the same
+# reader every door uses.
 # ---------------------------------------------------------------------------
-
-
-def _chunk_ids(workspace: Path) -> list[str]:
-    connection = open_index(db_path(workspace / "index"), read_only=True)
-    return [row[0] for row in connection.execute("SELECT chunk_id FROM chunks ORDER BY rowid")]
 
 
 def _rewrite_manifest(workspace: Path, edit) -> None:
@@ -278,17 +333,458 @@ def _set_nested(field: str, key: str, value):
     return edit
 
 
-def _damage_root_page(database: Path, table: str) -> int:
-    """Overwrite the root page of `table` with `0xff`, at the page `sqlite_master` names."""
-    connection = sqlite3.connect(database)
-    try:
-        rootpage = connection.execute(
-            "SELECT rootpage FROM sqlite_master WHERE name = ?", (table,)
-        ).fetchone()[0]
-        page_size = connection.execute("PRAGMA page_size").fetchone()[0]
-    finally:
-        connection.close()
-    with database.open("r+b") as handle:
-        handle.seek((rootpage - 1) * page_size)
-        handle.write(b"\xff" * page_size)
-    return rootpage
+def _manifest(**overrides) -> index_build.Manifest:
+    """A VALID manifest, every version read off the module the code reads it off (rule 5).
+
+    Not a literal document: two literals that must agree are two definitions, and the
+    snapshot's own test went red once for a `"2"` that stopped being foreign the day the
+    schema became "2". Sealed through `write_manifest`, so what lands on disk is what the
+    writer emits — the only seed this child can produce, and the honest one.
+    """
+    defaults = dict(
+        schema_version=SCHEMA_VERSION,
+        built_at=datetime.now(timezone.utc),
+        store_fingerprint="a" * 64,
+        store_signal=index_build.StoreSignal(
+            items_json_mtime_ns=1,
+            items_json_size=2,
+            vocab_yaml_mtime_ns=3,
+            vocab_yaml_size=4,
+            topics_json_mtime_ns=5,
+            topics_json_size=6,
+        ),
+        vocab_fingerprint="b" * 64,
+        topics_fingerprint="c" * 64,
+        surface_version=SURFACE_VERSION,
+        chunker_version=CHUNKER_VERSION,
+        chunker_params=index_build._params_dict(DEFAULT_CHUNKER_PARAMS),
+        tokenize=FTS_TOKENIZE,
+        connective=FTS_CONNECTIVE,
+        counts=dict.fromkeys(sorted(index_build.COUNT_PLANES), 0),
+        skipped=dict.fromkeys(sorted(index_build.SKIPPED_CAUSES), 0),
+    )
+    return index_build.Manifest(**{**defaults, **overrides})
+
+
+def _seal(workspace: Path, **overrides) -> index_build.Manifest:
+    """Seal a valid manifest into `workspace/index` and hand it back."""
+    manifest = _manifest(**overrides)
+    index_build.write_manifest(workspace / "index", manifest)
+    return manifest
+
+
+def _raw(workspace: Path) -> dict:
+    return json.loads(manifest_path(workspace / "index").read_text(encoding="utf-8"))
+
+
+# --- what the writer seals ------------------------------------------------
+
+
+def test_write_manifest_seals_exactly_the_fields_the_contract_declares(workspace) -> None:
+    """Step 3, at the WRITER this child ships: asserted as a SET against `MANIFEST_FIELDS`,
+    not one `in` per key.
+
+    A key-by-key list is a second copy of the schema that drifts; the set assertion makes
+    "the writer emits exactly what the contract declares" a single fact, in BOTH directions
+    — a field dropped from `to_dict` and a field dropped from the declared set are the same
+    red. Seen red under the mutant `manifest_fields_set` (`"counts"` removed from
+    `MANIFEST_FIELDS`), which the suite passed 11/11 before this test existed.
+
+    The half that belongs to `build` — that `counts["items"]` equals the corpus it indexed —
+    arrives with 02.7, which owns the producer of those numbers. This pins the seam.
+    """
+    _seal(workspace)
+    raw = _raw(workspace)
+    assert set(raw) == index_build.MANIFEST_FIELDS
+    assert raw["schema_version"] == SCHEMA_VERSION
+    assert raw["surface_version"] == SURFACE_VERSION and raw["chunker_version"] == CHUNKER_VERSION
+    # The MEASURED parameters (Plan 02 §7's sweep), read from the module rather than written
+    # here a second time: two literals that must agree are two definitions (rule 5).
+    assert raw["chunker_params"] == {
+        "target": DEFAULT_CHUNKER_PARAMS.target,
+        "max_chars": DEFAULT_CHUNKER_PARAMS.max_chars,
+        "overlap": DEFAULT_CHUNKER_PARAMS.overlap,
+        "min_chars": DEFAULT_CHUNKER_PARAMS.min_chars,
+    }
+    assert set(raw["counts"]) == index_build.COUNT_PLANES
+    assert set(raw["skipped"]) == index_build.SKIPPED_CAUSES
+    # The hole Plan 03 fills. Declared now so its arrival is not a manifest migration.
+    assert raw["embeddings"] is None
+
+
+def test_the_manifest_records_the_tokenizer_and_the_connective(workspace) -> None:
+    """Beyond spec §5.6, and deliberately so: these two DECIDE every recall number.
+
+    The connective change of Plan 01 M3 moved mean `recall@10` from 0.1429 to 0.8099 without
+    touching one line of the chunker. A manifest that records the chunker version but not the
+    query semantics would let two incomparable baselines look like the same measurement.
+    """
+    _seal(workspace)
+    raw = _raw(workspace)
+    assert raw["tokenize"] == "unicode61 remove_diacritics 2"
+    assert raw["connective"] == "OR"
+
+
+def test_a_sealed_manifest_reads_back_as_the_manifest_that_was_sealed(workspace) -> None:
+    """The round trip, end to end: `to_dict` → JSON → `from_dict` loses nothing.
+
+    Equality is on the DATACLASS, so a field the writer emits and the reader drops (or reads
+    into the wrong slot) is red — `built_at` through an ISO string and `store_signal` through
+    its own nested document are the two that could silently degrade. Seen red by writing
+    `built_at` with `.date().isoformat()`: the instant came back at midnight.
+    """
+    sealed = _seal(workspace)
+    assert index_build.load_compatible_manifest(workspace / "index") == sealed
+    assert index_build.load_manifest(workspace / "index") == sealed
+
+
+def test_the_embeddings_slot_round_trips_the_object_plan_03_will_put_in_it(workspace) -> None:
+    """`embeddings` is `null` or an OBJECT, and the object half has to survive the trip.
+
+    The slot is declared now so Plan 03's `{model, dimension, normalized, command_version}`
+    is not a manifest migration — which is only true if a manifest carrying one reads back
+    carrying it. `_optional_mapping`'s success path is the one line of the reader that a
+    manifest sealed today never exercises, and «declared for later» is exactly the kind of
+    promise that is discovered to be false later.
+    """
+    declared = {"model": "all-MiniLM-L6-v2", "dimension": 384, "normalized": True}
+    _seal(workspace, embeddings=declared)
+    assert _raw(workspace)["embeddings"] == declared
+    assert index_build.load_compatible_manifest(workspace / "index").embeddings == declared
+
+
+def test_the_manifest_built_at_is_an_instant_not_a_date(workspace) -> None:
+    """A rebuild the same day must be distinguishable from the previous one."""
+    _seal(workspace)
+    built = datetime.fromisoformat(_raw(workspace)["built_at"])
+    assert built.tzinfo is not None, "an instant with no timezone is a local guess"
+    assert abs((datetime.now(timezone.utc) - built).total_seconds()) < 120
+
+
+# --- totality: the document is an object, and it declares every field --------
+
+
+@pytest.mark.parametrize(
+    "label, document",
+    [
+        # THE ONE THAT PASSED THE GUARD. A JSON list whose elements are exactly the field
+        # NAMES: `MANIFEST_FIELDS - set(raw)` is empty, because `set()` of a list is its
+        # ELEMENTS — so the totality check agreed the document declared everything, and the
+        # first subscript raised `TypeError: list indices must be integers` out of every
+        # door as a traceback.
+        ("a list of the field names", "MANIFEST_FIELDS_AS_LIST"),
+        ("an empty list", []),
+        # These never reached a subscript: `set()` of them raises `TypeError: not iterable`
+        # from the guard LINE ITSELF, before one field was read.
+        ("a number", 3),
+        ("null", None),
+        ("a boolean", True),
+        # A string is iterable, so it reached the guard and was refused for the wrong
+        # reason (its CHARACTERS are not the field names). Now refused for the right one.
+        ("a string", "schema_version"),
+    ],
+)
+def test_a_manifest_that_is_not_a_json_object_is_refused_naming_the_rebuild(
+    workspace, label: str, document
+) -> None:
+    """Spec §9.3: an incompatible manifest is refused with an ACTIONABLE sentence — never a
+    traceback from inside a query, which is the one thing this reader exists to remove.
+
+    `manifest.json` is hand-editable by design (B1 measured what an operator can hold), and
+    the totality guard was `MANIFEST_FIELDS - set(raw)` with no type check in front of it.
+    `set()` of a non-mapping is not an error, so the guard answered about the wrong thing.
+
+    Seen red on `99731e9` for all six: `TypeError: list indices must be integers or slices,
+    not str` (the list) and `TypeError: 'int'/'NoneType'/'bool' object is not iterable`, out
+    of `load_manifest` AND `load_compatible_manifest`; the string was refused, but by the
+    field-name check, so a document that happened to be the field name of a one-field schema
+    would have walked through.
+    """
+    if document == "MANIFEST_FIELDS_AS_LIST":
+        document = sorted(index_build.MANIFEST_FIELDS)
+    (workspace / "index").mkdir(parents=True, exist_ok=True)
+    manifest_path(workspace / "index").write_text(json.dumps(document), encoding="utf-8")
+
+    with pytest.raises(IndexIncompatibleError, match="index build --force"):
+        index_build.load_manifest(workspace / "index")
+    with pytest.raises(IndexIncompatibleError, match="index build --force"):
+        index_build.load_compatible_manifest(workspace / "index")
+
+
+@pytest.mark.parametrize("field", sorted(index_build.MANIFEST_FIELDS))
+def test_a_manifest_missing_a_top_level_field_is_refused_naming_the_rebuild(
+    workspace, field: str
+) -> None:
+    """The totality guard itself, one parametrisation per declared field.
+
+    `MANIFEST_FIELDS` is the enumeration of spec §5.6 in one place, and the guard that
+    enforces it had NO test: mutating `missing = MANIFEST_FIELDS - set(raw)` to
+    `frozenset()` — deleting the required-field check entirely — left the WHOLE suite green
+    at 2,243 passed, on `99731e9` and on the snapshot it was ported from. Rule 1: a guard
+    nothing can make fail is not guarded.
+
+    Derived from the constant, so a field added to the contract is required of the reader
+    without anybody remembering — and a field removed from the constant cannot go unnoticed,
+    because `test_write_manifest_seals_exactly_the_fields_the_contract_declares` compares
+    the same set against what the writer emits.
+    """
+    _seal(workspace)
+    _rewrite_manifest(workspace, lambda raw: raw.pop(field))
+
+    with pytest.raises(IndexIncompatibleError, match="index build --force") as caught:
+        index_build.load_compatible_manifest(workspace / "index")
+    assert field in str(caught.value), "names the field the document does not declare"
+
+
+_NESTED_KEYS = [
+    *(("counts", plane) for plane in sorted(index_build.COUNT_PLANES)),
+    *(("skipped", cause) for cause in sorted(index_build.SKIPPED_CAUSES)),
+    *(("chunker_params", name) for name in sorted(index_build.CHUNKER_PARAM_NAMES)),
+    ("store_signal", "items_json_mtime_ns"),
+    ("store_signal", "items_json_size"),
+]
+
+
+@pytest.mark.parametrize("field, key", _NESTED_KEYS)
+def test_a_manifest_missing_a_nested_key_is_refused_naming_the_rebuild(
+    workspace, field: str, key: str
+) -> None:
+    """B1: `Manifest.from_dict` checked the TOP-LEVEL key set and cast everything under it,
+    so a manifest whose `counts` was `{}` loaded as compatible — and the consistency check,
+    which iterated whatever `counts` offered, then compared NOTHING: `status` said healthy,
+    `search` answered zero results over a base with its chunks and profiles deleted, and
+    `update` sealed that state as sound. Spec §9.3: an incompatible manifest is never
+    queried partially.
+
+    Every nested key is REQUIRED, one parametrisation per key, derived from the same
+    constants the writer uses — so a plane, a cause or a chunker parameter added to the
+    writer is required of the reader without anybody remembering. Seen red under the mutant
+    `nested_required` on all 15 parametrisations: `load_compatible_manifest` returned a
+    `Manifest`.
+    """
+    _seal(workspace)
+    _rewrite_manifest(workspace, lambda raw: raw[field].pop(key))
+
+    with pytest.raises(IndexIncompatibleError, match="index build --force") as caught:
+        index_build.load_compatible_manifest(workspace / "index")
+    assert field in str(caught.value), "names the malformed field"
+
+
+@pytest.mark.parametrize(
+    "label, edit",
+    [
+        ("counts empty", _set("counts", {})),
+        ("counts not a mapping", _set("counts", "12")),
+        ("counts a list", _set("counts", [])),
+        ("a count that is a string", _set_nested("counts", "chunks", "56")),
+        ("a negative count", _set_nested("counts", "chunks", -1)),
+        ("a boolean count", _set_nested("counts", "chunks", True)),
+        ("a float count", _set_nested("counts", "chunks", 1.0)),
+        ("an undeclared plane", _set_nested("counts", "vectors", 0)),
+        ("skipped not a mapping", _set("skipped", [])),
+        ("an undeclared cause", _set_nested("skipped", "vanished", 0)),
+        ("a chunker parameter that is a string", _set_nested("chunker_params", "target", "800")),
+        ("an undeclared chunker parameter", _set_nested("chunker_params", "stride", 4)),
+        ("store_signal not a mapping", _set("store_signal", 5)),
+        ("a signal entry that is a string", _set_nested("store_signal", "items_json_size", "17")),
+        ("an undeclared signal entry", _set_nested("store_signal", "media_dir_size", 0)),
+        ("embeddings neither null nor a mapping", _set("embeddings", ["all-MiniLM"])),
+        ("failed not a list", _set("failed", {"k01": "boom"})),
+        # The two shapes the `isinstance(value, list)` guard alone is load-bearing for: an
+        # EMPTY object makes `all(… for entry in value)` vacuously true (accepted, fail-open)
+        # and a number makes the same generator raise `TypeError: not iterable` (a traceback
+        # from inside a query). Every other malformed `failed` is refused by the per-entry
+        # clause, so without these two the guard is unguarded — mutant `failed_shape`.
+        ("failed an empty object", _set("failed", {})),
+        ("failed a number", _set("failed", 5)),
+        ("a failure that is not a mapping of strings", _set("failed", [{"item_id": 1}])),
+        ("a failure that is not a mapping", _set("failed", ["boom"])),
+        ("built_at not an instant", _set("built_at", "yesterday")),
+        ("built_at null", _set("built_at", None)),
+    ],
+)
+def test_a_malformed_nested_value_is_refused_naming_the_rebuild(
+    workspace, label: str, edit
+) -> None:
+    """B1, the values: a key that is present with the wrong shape is as vacuous as one that
+    is missing. `int("56")` silently accepted a string count; `True` is an `int` to
+    `isinstance`; an undeclared plane would be compared against a `COUNT(*)` that does not
+    exist. Closed as well as total: exactly the declared keys, each a non-negative integer.
+
+    Seen red under `nested_closed`, `nested_int`, `optional_mapping`, `failed_shape` and
+    `instant` — five mutants the suite passed 11/11 before this test existed.
+    """
+    _seal(workspace)
+    _rewrite_manifest(workspace, edit)
+
+    with pytest.raises(IndexIncompatibleError, match="index build --force"):
+        index_build.load_compatible_manifest(workspace / "index")
+
+
+# --- the writer round-trips through the reader ------------------------------
+
+
+def test_write_manifest_refuses_a_document_the_reader_would_refuse(workspace) -> None:
+    """The WRITER side of the seam: `write_manifest` round-trips the document through the
+    same reader every door uses, so a build or an update cannot seal a manifest that the
+    next `search` would then refuse — or, worse, one the reader would have accepted while
+    the writer's shape drifted.
+
+    `counts={}` is buildable in Python (`counts: dict[str, int]` constrains the value type,
+    not the key set), and it is exactly the amputation B1 measured. Seen red under the
+    mutant `roundtrip_guard`: the file was overwritten with a document no door would read.
+    """
+    _seal(workspace)
+    before = manifest_path(workspace / "index").read_bytes()
+
+    with pytest.raises(IndexIncompatibleError, match="counts"):
+        index_build.write_manifest(workspace / "index", _manifest(counts={}))
+
+    assert manifest_path(workspace / "index").read_bytes() == before, "and it wrote nothing"
+
+
+def test_write_manifest_leaves_no_manifest_behind_when_the_document_is_refused(
+    tmp_path: Path,
+) -> None:
+    """The same guard where there is nothing to preserve: a FIRST seal that is refused must
+    leave no file at all, or its presence — which is what says a build completed — would be
+    a lie about a document no door can read."""
+    index_dir = tmp_path / "index"
+    with pytest.raises(IndexIncompatibleError):
+        index_build.write_manifest(index_dir, _manifest(skipped={}))
+    assert not manifest_path(index_dir).exists()
+
+
+# --- compatibility: refused unless every version the code depends on matches --
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        # DERIVED from the constant, not a literal: the literal `"2"` stopped being foreign
+        # the day the schema was bumped to "2", and the test went red for a reason that had
+        # nothing to do with what it pins.
+        ("schema_version", f"{SCHEMA_VERSION}-foreign"),
+        ("surface_version", "xbrain-knowledge-surface/v9"),
+        ("chunker_version", "xbrain-knowledge-chunker/v9"),
+        # The fifth and sixth checks (F7-8, round 07). The manifest recorded them «because
+        # they decide every recall number» and no door compared them: `tokenize: porter` /
+        # `connective: AND` were accepted on the real index. The tokenizer is baked into the
+        # FTS DDL, so a base built under one and queried under another is the M-1 shape with
+        # no guard; the connective moved recall@10 from 0.1429 to 0.8099.
+        ("tokenize", "porter unicode61"),
+        ("connective", "AND"),
+    ],
+)
+def test_an_incompatible_manifest_refuses_the_query_entirely(
+    workspace, field: str, value: str
+) -> None:
+    """Step 29 / spec §9.3: *manifest incompatible: no se consulta parcialmente.*
+
+    Each of these invalidates a different thing, and any one of them makes the stored rows
+    mean something other than what the code would compute. Seen red by logging a warning and
+    answering anyway — and, here, under the mutants `compat_schema`, `compat_tokenize` and
+    `compat_connective`, which the suite passed 11/11 before this test existed.
+    """
+    _seal(workspace)
+    _rewrite_manifest(workspace, _set(field, value))
+    with pytest.raises(IndexIncompatibleError, match="index build --force") as caught:
+        index_build.load_compatible_manifest(workspace / "index")
+    assert field in str(caught.value), "names which version disagrees"
+
+
+def test_chunker_parameters_are_compared_when_the_caller_declares_them(workspace) -> None:
+    """The FOURTH check, and the one no version string carries: Plan 02 §7 sweeps
+    `target x overlap`, and a sweep that lands on new parameters without bumping
+    `CHUNKER_VERSION` produces chunks cut differently under IDENTICAL ids — the worst case,
+    because the id resolves and the text behind it is not what it was.
+
+    Compared only when the caller declares its parameters, which is what `params=None`
+    means; both directions are pinned, or the mutant `compat_params` (`if False and …`)
+    survives on the half nobody exercised.
+    """
+    _seal(workspace)
+    swept = replace(DEFAULT_CHUNKER_PARAMS, target=DEFAULT_CHUNKER_PARAMS.target + 1)
+
+    with pytest.raises(IndexIncompatibleError, match="chunker_params"):
+        index_build.load_compatible_manifest(workspace / "index", params=swept)
+    assert index_build.load_compatible_manifest(workspace / "index", params=DEFAULT_CHUNKER_PARAMS)
+    assert index_build.load_compatible_manifest(workspace / "index"), "undeclared is not compared"
+
+
+@pytest.mark.parametrize(
+    "field", ["schema_version", "surface_version", "chunker_version", "tokenize", "connective"]
+)
+def test_a_forged_manifest_string_reaches_no_terminal_raw_through_this_child_s_door(
+    workspace, field: str
+) -> None:
+    """T-1: the manifest is a file an operator edits by hand, and the incompatibility
+    sentence interpolated `schema_version`, `surface_version` and `chunker_version` RAW — so
+    a forged line stood at column 0 and an `ESC[2K` reached a TTY through the sentence every
+    door raises. The fix is `!r` on every manifest string, and it lives HERE, in
+    `load_compatible_manifest`.
+
+    This child has one door, so this pins the sentence at its SOURCE. The three-door version
+    — `status`'s rendered report, `search` through `open_for_query`, `update` — arrives with
+    02.8/02.9, which own those doors; it asserts the same bytes never reach a terminal, one
+    level further out.
+    """
+    _seal(workspace)
+    _rewrite_manifest(workspace, _set(field, _FORGE))
+
+    with pytest.raises(IndexIncompatibleError) as caught:
+        index_build.load_compatible_manifest(workspace / "index")
+
+    sentence = str(caught.value)
+    assert "\x1b" not in sentence
+    assert _FORGED_HEADER not in sentence.splitlines(), sentence
+    assert not any(line.startswith("│ forged") for line in sentence.splitlines()), sentence
+    assert "xbrain index build --force" in sentence
+
+
+def test_a_manifest_from_before_round_05_reads_its_absent_signal_entries_as_zeros(
+    workspace,
+) -> None:
+    """The compatibility promise P1a is documented in three places and no test exercised it:
+    a manifest sealed before round 05 carries no `vocab.yaml`/`topics.json` entries, and
+    they must read back as ZEROS — which compare unequal to the live files, so the index is
+    declared behind until one `index update` re-seals it. The direction this signal is meant
+    to fail in, and it costs one `update`.
+
+    Required and optional are read off `StoreSignal` itself (`_signal_keys`), so this pins
+    that split: make the four round-05 entries required and a pre-round-05 manifest becomes
+    unreadable instead of behind; make the two `items.json` entries optional and an
+    amputated signal reads as a store that never moved.
+
+    The other half — that `search` then declares `index_behind_store` and `status` reports
+    `behind` — arrives with 02.8/02.9, which own those doors.
+    """
+    _seal(workspace)
+
+    def pre_round_05(raw):
+        for key in (
+            "vocab_yaml_mtime_ns",
+            "vocab_yaml_size",
+            "topics_json_mtime_ns",
+            "topics_json_size",
+        ):
+            del raw["store_signal"][key]
+
+    _rewrite_manifest(workspace, pre_round_05)
+    assert set(_raw(workspace)["store_signal"]) == {"items_json_mtime_ns", "items_json_size"}
+
+    signal = index_build.load_compatible_manifest(workspace / "index").store_signal
+    assert signal == index_build.StoreSignal(items_json_mtime_ns=1, items_json_size=2)
+    assert signal != index_build.StoreSignal.of(
+        workspace / "items.json", workspace / "vocab.yaml", workspace / "topics.json"
+    ), "so the index is declared behind, which is what the zeros are for"
+
+
+def test_a_missing_manifest_names_the_build_command_not_the_rebuild(tmp_path: Path) -> None:
+    """An index that was never built is not an incompatible one, and the two errors name
+    different commands: `IndexMissingError` says `xbrain index build`, and only a document
+    that EXISTS and disagrees says `--force`. Conflating them sends an operator to a
+    destructive command to fix an empty directory."""
+    with pytest.raises(IndexMissingError, match="xbrain index build") as caught:
+        index_build.load_compatible_manifest(tmp_path / "index")
+    assert "--force" not in str(caught.value)


### PR DESCRIPTION
**Plan 02, child 02.6 — sealed inputs.** Base: `VGonPa/umbrella-knowledge-index-lexical` @ `2c0a631` (unmoved; `origin/develop` @ `0bd9527` is an ancestor of the umbrella, so **no sync child is due**). Ported from immutable snapshot `1d30554` (anchored by `refs/heads/VGonPa/knowledge-lexical-snapshot-fix-09`, tree `85a5ccf`).

> ### ⚠️ Corrected at `0e1b4a0` — read this section first
>
> The first cut, `99731e9`, is superseded. Two blocking findings from the formal review, plus one the review did not name that the same cut produced, are fixed below. **The sections after this one describe `99731e9` and are kept for the record; where they disagree with this section, this section is right** — in particular adaptation **5** was wrong, and its error is the root cause of finding B.

## Correction — the exact diff at `0e1b4a0`

```
 src/xbrain/knowledge/index_build.py |  19 +-      (+18 −1)
 tests/test_knowledge_index_build.py | 542 ++++++   (+518 −24)
 2 files changed, 537 insertions(+), 24 deletions(-)
```

Only 02.6’s own files. Tree clean, nothing untracked, no `zz-support-files/`.

### Full corrected child size vs umbrella

The complete child at `0e1b4a0` is **+1,576 / -3 = 1,579 touched lines** across four files. That is 79 touched lines above the 800-1,500 review band. The excess is justified by restoration of executable tests for the same sealed-input/manifest boundary after formal review proved the original split had dropped them (2/15 mutants caught before; 19/19 now). It does not add `build`, `update`, `status`, `search`, CLI, embeddings, graph, MCP, recap, or automation.

### A — the manifest reader reached an unhandled `TypeError` (Codex, blocking)

`Manifest.from_dict`'s totality guard was `MANIFEST_FIELDS - set(raw)` with **no type check in front of it**, and `set()` of a non-mapping is not an error — on a `dict` it is the KEYS, on a `list` the ELEMENTS. A hand-edited `manifest.json` holding the JSON **list of the field names** therefore passed the guard with `missing` empty, and the first subscript raised a traceback:

```
$ python … load_manifest(index_dir)      # manifest.json = ["built_at", "chunker_params", …]
  File "src/xbrain/knowledge/index_build.py", line 377, in from_dict
    schema_version=str(raw["schema_version"]),
TypeError: list indices must be integers or slices, not str
```

Out of `load_manifest` **and** `load_compatible_manifest`. Spec §9.3 asks for an actionable sentence, and a `TypeError` from inside a query is the one thing this reader exists to remove.

**It is wider than the reported case.** A top-level `3`, `null` or `true` never reached a field at all — `set()` of them raises from the guard *line itself*:

| document | before | after |
|---|---|---|
| `["schema_version", …]` (the field names) | `TypeError: list indices must be integers` | `IndexIncompatibleError` |
| `[]` | `IndexIncompatibleError` (right answer, wrong reason) | `IndexIncompatibleError` |
| `3` / `null` / `true` | `TypeError: … object is not iterable` | `IndexIncompatibleError` |
| `"schema_version"` | refused — but by the *field-name* check | `IndexIncompatibleError` |

Fix: `if not isinstance(raw, Mapping): raise IndexIncompatibleError(…)` **before** the totality guard, and the signature is now the honest `raw: object`. Red-first evidence: `red/findingA_before.txt`. Test: `test_a_manifest_that_is_not_a_json_object_is_refused_naming_the_rebuild`, 6 parametrisations, both doors each.

### B — the manifest seal/read half shipped untested (Claude, blocking), and why

**The measurement, not the assertion.** 15 mutations of `index_build.py` against the 11-test cut:

| | before (`99731e9`) | after (`0e1b4a0`) |
|---|---:|---:|
| mutants caught | **2 of 15** | **19 of 19** |
| tests in the file | 11 | **94** |
| `index_build.py` coverage, its own test file | **64 %** | **94 %** |
| `index_build.py` coverage, whole suite | 65 % | **94 %** |

The two caught were exactly the two the PR claimed (`_read_bound`'s `FileNotFoundError`, the handle-`fstat`). Everything else survived — including `missing = frozenset()`, the required-field guard **deleted outright**, which left the **whole suite green at 2,243 passed**. Rule 1, in the file that ships the guard.

**Root cause, and it is adaptation 5.** The re-cut was made decorator-aware for *parsing* (it had to be — the published classifier produced a `SyntaxError`), but ownership was still decided by call-graph attribution from the `def` line. Two consequences, and the PR body recorded both as facts about the snapshot rather than as artefacts of the splitter:

1. The manifest tests *seed* through `_build(...)` while every one of them *asserts* on `Manifest.from_dict` / `write_manifest` / `load_compatible_manifest` — doors this child already ships. Attributed to 02.7 on the seed.
2. **`_set_nested` was reported as having "no caller anywhere in the 1.383-line snapshot file".** It has **seven**, at snapshot lines 1164-1172 — all inside a `@pytest.mark.parametrize` argument list. The helpers looked orphaned for the same reason the tests looked like 02.7's: a call site inside a decorator argument is not where a `def`-anchored scan looks. That claim is retracted.

**The port.** The seed becomes `write_manifest(_manifest(...))` instead of `_build(...)`; nothing else changes. No behaviour is invented — the seeded document is what `to_dict` emits, validated by the same reader every door uses.

| restored from `1d30554` | snapshot | params |
|---|---|---:|
| the manifest field **set** (writer half) | 96-124 | — |
| tokenizer and connective recorded | 126-137 | — |
| `built_at` is an instant, not a date | 1039-1046 | — |
| a nested key missing → refused, named | 1112-1143 | 15 |
| a malformed nested value → refused | 1145-1192 | 21 |
| `write_manifest` refuses what the reader would | 1217-1233 | — |
| an incompatible manifest refuses the query | 652-679 | 6 |
| a forged string reaches no terminal raw | 1067-1110 | 5 |
| the pre-round-05 signal reads back as zeros | 1340-1383 | — |
| **`…fingerprint_covers_what_the_index_stores_about_a_surface`** | 744-786 | 4 |

| new — the snapshot has no original | why |
|---|---|
| top-level required-field totality, 15 params | the `MANIFEST_FIELDS` guard is untested **in the snapshot too**; `missing = frozenset()` is green there as well |
| the document is not a JSON object, 6 params | finding A |
| the `embeddings` slot round-trips an object | «declared for Plan 03» is only true if a manifest carrying one reads back carrying it |
| `failed` as `{}` and as `5` | the two shapes only the `isinstance(value, list)` guard catches — every other malformed `failed` is refused by the per-entry clause |

Two ported tests are **reduced to this child's single door** and say so in their docstrings: the forged-string test asserts on `load_compatible_manifest`'s sentence (its `status` / `search` / `update` version arrives with 02.8/02.9, which own those doors), and the pre-round-05 test asserts the reader's zeros (its `index_behind_store` half likewise). Neither duplicates what the later children restore.

### C — a third test the same split dropped, not named by either reviewer

`test_the_item_fingerprint_covers_what_the_index_stores_about_a_surface` (snapshot 744-786) needs only `item_fingerprint`, which ships here. **Verified unguarded before porting:** dropping the attribution and title columns from `surface_row` — the projection `item_fingerprint` hashes — left the file **green at 90/90**. That is G-5 exactly: a `refresh-quoted` that fills in a quoted post's author without touching its body, `update` reporting `0 cambiados`, `search` serving the old attribution. The attribution rule this repo paid for in blood.

### The mutation table

19 mutants, `tests/test_knowledge_index_build.py` as the oracle. `nonmapping` reverts finding A's fix; `oserror` and `pathstat` are the two the first cut claimed, re-run to prove they are preserved.

| mutant | what it amputates | `99731e9` | `0e1b4a0` |
|---|---|---|---|
| `oserror` | `_read_bound` catches `OSError` (A-2) | CAUGHT | **CAUGHT** |
| `pathstat` | `path.stat()` after the read (P1b) | CAUGHT | **CAUGHT** |
| `nonmapping` | the `isinstance(raw, Mapping)` guard | n/a — the bug | **CAUGHT** |
| `missing_fields` | `missing = frozenset()` | SURVIVED | **CAUGHT** |
| `manifest_fields_set` | `"counts"` dropped from `MANIFEST_FIELDS` | SURVIVED | **CAUGHT** |
| `nested_required` | nested required-key check | SURVIVED | **CAUGHT** |
| `nested_closed` | nested undeclared-key check | SURVIVED | **CAUGHT** |
| `nested_int` | non-negative-`int` strictness | SURVIVED | **CAUGHT** |
| `optional_mapping` | `embeddings` type check | SURVIVED\* | **CAUGHT** |
| `failed_shape` | `failed` is-a-list check | SURVIVED | **CAUGHT** |
| `instant` | `built_at` swallows `ValueError` | SURVIVED | **CAUGHT** |
| `roundtrip_guard` | `write_manifest`'s re-read | SURVIVED | **CAUGHT** |
| `compat_schema` / `compat_tokenize` / `compat_connective` / `compat_params` | the version checks | SURVIVED ×4 | **CAUGHT** ×4 |
| `compat_repr` | `!r` on the mismatch sentence (T-1) | SURVIVED | **CAUGHT** |
| `signal_keys_required` | `_signal_keys` required/optional split | SURVIVED | **CAUGHT** |
| `surface_row` | attribution + title columns (G-5) | SURVIVED | **CAUGHT** |

\* **`optional_mapping` first reported SURVIVED and had not run.** CPython validates a `.pyc` against *(source mtime truncated to whole seconds, source size)*, and two mutants applied inside the same second can produce equal-sized files, so pytest re-executed **stale bytecode** for a mutant that never loaded. `PYTHONDONTWRITEBYTECODE=1` flipped it to CAUGHT. Rule 9 one level down — name the surface you read, and falsify a green before quoting it. Every row above is from the hardened run.

### The gate at `0e1b4a0`

```
ALL CRITICAL CHECKS PASSED        (exit 0)
Tests            PASS - 2326 tests      (+ 1 xfailed)     was 2243
Coverage                94%
Coverage (knowledge/)  PASS - 94%       (floor 90)        was 91%
Ruff / Format / Mypy / Bandit / Vulture / Interrogate / Detect-secrets / Deptry   PASS
Radon            WARN - grade C  (pre-existing, warn-only)
```

The umbrella has not moved (`2c0a631`), so the merge tree is still this tree.

### The residue, stated as residue

`index_build.py` holds **13 uncovered lines**, and each has a named consumer in a later child, not a missing test here:

| lines | symbol | its consumer |
|---|---|---|
| 273-275 | `_bound_signal` | **no caller in this child at all** — `build` / `update` call it (02.7 / 02.8) |
| 610 | `topic_row`'s return | `topic_rows_behind` (02.8) |
| 644-656 | `vocab_fingerprint`, `topics_fingerprint` | exercised through `build` (02.7) |

**The two fingerprints have no direct test anywhere in the 1,383-line snapshot suite** — only transitive coverage through `build` / `update` / `status`. Writing one here would be new behaviour-pinning outside the correction's scope, and a smoke test asserting a hash is truthy is rule-1 bait. Flagged for 02.7, which owns their caller.

**One consequence for the next children.** The nested/malformed/compatibility tests now live in 02.6 and must **not** be restored again by 02.7 — that child restores the `build`-specific halves only (`counts["items"] == len(corpus)`, the dry run, the interrupted build). Its `+469` shrinks accordingly. The declared `334` line budget for this file was itself produced by the attribution that caused finding B, so it is a symptom, not the authority; the file is now **790** lines.

### Independent audit of the read path — what was measured and deliberately NOT changed

A second bounded agent swept the manifest reader for the whole malformed-input family, executing every case rather than reading for it. All 9 non-object top-level shapes, all 11 `built_at` shapes, all 9 `counts` value types, 14 file-level shapes and the `write_manifest` guard now behave. **Six residues remain. None is fail-open; each is recorded rather than fixed, because fixing it is behaviour the snapshot does not contain and this is a correction, not a redesign.** Reviewers should rule on 5 and 6.

| # | observed | direction | judgement |
|---|---|---|---|
| 1 | `manifest.json` is a **directory** / `chmod 000` → `IsADirectoryError` / `PermissionError` escapes `load_manifest`; the CLI prints `Error: …` exit 1 | **fail-closed** | consistent with **A-2**, which ruled exactly this for `_read_bound`: an unreadable file raises, it is not an empty one. Leave. |
| 2 | JSON nested 100 000 deep → `RecursionError`, CLI exit 1 | **fail-closed** | leave |
| 3 | duplicate JSON keys → last wins silently | inert | `json.loads` semantics; no `object_pairs_hook` in the snapshot. Leave. |
| 4 | a `Manifest` built in Python with a non-serialisable `embeddings` → `TypeError` from `json.dumps`; `built_at` as a `str` → `AttributeError` | programmer error, not a document | and the property that matters **holds and was verified**: a serialisation failure leaves the standing manifest **intact**, because `json.dumps` runs before `write_text` |
| 5 | the **top level is OPEN** to unknown extra keys (nested levels are closed) | inert today | asymmetric on purpose or by omission? An extra *nested* key would be compared against a `COUNT(*)` that does not exist, which is why nested is closed; an extra top-level key has no consumer. **Open question for the reviewers**, not a defect I will decide alone. |
| 6 | `schema_version: 3` (a JSON **number**) is accepted as `"3"`; `store_fingerprint: null` is accepted as the string `"None"` — `str()` coerces both | **fails towards the warning** | `"None"` can never equal a real sha256, so `status`/`update` (02.8) report *changed*, never *fresh*. Sloppy, not unsafe. Tightening it to a `hex64` shape check is new behaviour → **flagged for whoever lands 02.8**, which owns the comparison. |
| 7 | a count of an arbitrarily large `int` is accepted | inert | correct type, non-negative; a mismatch just reads as changed |


---

<sub>Everything below describes the superseded `99731e9`.</sub>


## One thing

The three source files are read **once**, the change signal is bound to **the bytes that were read**, those bytes are fingerprinted, and the manifest is sealed and re-read.

`load_index_inputs` opens `items.json`, `vocab.yaml` and `topics.json` each through **its own handle** and takes `os.fstat` of that handle **before** the read. The signal therefore describes exactly what was parsed, by construction. `item_fingerprint` / `store_fingerprint` / `vocab_fingerprint` / `topics_fingerprint` hash them; `write_manifest` / `load_manifest` / `load_compatible_manifest` seal and re-read the document that binds a build to every later query.

Nothing here writes. `items.json`, `vocab.yaml` and `topics.json` are read and never touched.

## Red first — both named gates seen failing before the implementation existed

| Stage | What was in the tree | Result |
|---|---|---|
| **R1** | test file present, `index_build.py` **absent** | `ImportError: cannot import name 'index_build'` — collection error, both gates red |
| **R2a** | implementation present, `_read_bound` mutated to `except OSError:` | **2 failed** — `DID NOT RAISE PermissionError` / `DID NOT RAISE IsADirectoryError` |
| **R2b** | implementation present, `_read_bound` mutated to `stat = path.stat()` **after** the read | **1 failed** — `AssertionError: the signal describes the snapshot that was parsed`, `items_json_mtime_ns` differing |

R2a is **A-2** (round 08), reproduced against this branch as §7.2 requires: the correction travelled with the code. The pre-correction `except OSError` read a `chmod 000` `items.json`, and a directory standing in its place, as the **empty store** reserved for an absent one — which is how `build --force` replaced 22,286 chunks with 703 and sealed it consistent with exit 0. `_read_bound` now catches `FileNotFoundError` and nothing wider.

R2b is **P1b**: the signal is a property of the snapshot, not of the path. Both mutations were reverted; the file on disk re-hashes to the un-mutated port (sha256 `0734023b…`).

Evidence transcripts are in the session scratchpad (`red/R1-…`, `red/R2a-…`, `red/R2b-…`); each is the verbatim `pytest` output.

## What was ported

| File | How | Lines |
|---|---|---|
| `src/xbrain/knowledge/index_build.py` | snapshot ranges `1-485`, `548-731`, `1232-1240`, `1280-1366` | 765 raw → **746** after the import prune |
| `tests/test_knowledge_index_build.py` | the 02.6 bucket of the appendix-A split, re-cut decorator-aware | 334 declared → **294** on disk |
| `src/xbrain/store.py` | whole-file checkout, **audited hunk by hunk** | +17 / −2 |
| `src/xbrain/rubrics.py` | whole-file checkout, **audited hunk by hunk** | +6 / −1 |

`store.py` / `rubrics.py` add `parse_store`, `parse_topic_pages` and `parse_vocab` — **one parser each**, so a reader that must bind what it parsed to the exact bytes it read can use its own handle instead of a second copy of the two lines. Symbol-level audit of the checkout: **nothing removed, nothing re-signed**; `load_store` / `load_topic_pages` / `load_vocab` delegate. The result is byte-identical to the snapshot for both files (`git diff 1d30554 -- …` empty).

## Boundary adaptations (plan §4.0 class B — declared, F3 / F4)

1. **19 import lines pruned from `index_build.py`.** `ruff` reported exactly **22 F401** on the raw concatenation; `ruff check --fix` removed them. This is F3 as written (*«El bloque `import` es también un subconjunto en cada estado (si no, `ruff F401`)»*). Restored by 02.7 / 02.8 with the code that uses them.
2. **5 import lines + 2 trailing blank lines pruned from the test slice** (7 F401 names used only by deferred tests; `ruff format` dropped the blanks).
3. **The published appendix-A classifier mis-attributes decorator lines.** It reproduces its declared buckets exactly (246 / 334 / 469, header 42) — but it starts each span at the `def` line, so a decorated def's `@pytest.mark.parametrize(...)` lines fall into the **previous** span. Slicing by it produces a file that **does not parse**: `SyntaxError` at line 334, `@pytest.mark.parametrize("table", ["items", "chunks"])`. Re-cut decorator-aware with `ast` (span = first decorator line … next def's first decorator line − 1). New split **02.6 = 301 · 02.7 = 501 · 02.8 = 324 · 02.9 = 257 · header 41**, summing to **1383 = the whole file**. The −33 against the declared 334 is entirely these decorator blocks, and it moves the later children's counts by the same construction.
4. **Two orphan comment blocks sit at the range seams**, kept **verbatim** rather than retyped: the `# the writer …` banner (snapshot 727-729) now precedes `_params_dict`, and the `# update` banner plus the `_COUNT_STATEMENTS` comment (1359-1366) end the file. Both land back on their own code in 02.7 / 02.8; trimming them would mean typing bytes twice (§4.0).
5. **Five test helpers are pre-positioned here** by the published classifier although **none of them has a single call site in this PR** — measured, not assumed: `grep` finds only their own `def` line. Their callers, by name and by child:

   | helper | called by |
   |---|---|
   | `_chunk_ids` | `test_build_is_deterministic` (02.7) |
   | `_rewrite_manifest` | two 02.7 tests + two 02.9 tests |
   | `_damage_root_page` | `test_a_damaged_root_page_is_declared_by_status_and_refused_by_update_naming_the_rebuild` (02.8) |
   | `_set` | `test_a_forged_manifest_string_reaches_no_terminal_raw_through_any_door` (02.9) |
   | `_set_nested` | **no caller anywhere in the 1.383-line snapshot file** |

   Kept where the declared reparto puts them; no gate flags them (`vulture` scans `src/` only). **`_set_nested` is dead in the snapshot itself**, not made dead by this cut — a backlog finding for whoever lands 02.9, not a blocker here.

## Size — re-derived from the real umbrella, not inherited

| | additions | touched |
|---|---:|---:|
| Declared (matrix row 02.6) | 1.122 | 1.125 |
| **Measured on this branch** | **1.063** | **1.066** |

The −59 is fully accounted for: **−19** import lines (adaptation 1), **−33** decorator lines (adaptation 3), **−5** test import lines and **−2** trailing blanks (adaptation 2). No content was dropped.

**One arithmetic note on the matrix itself:** the three declared range sets sum to **1.935** of `index_build.py`'s **1.936** lines — line **547** (a blank separator between `StatusReport` and the `# fingerprints` banner) is in no child's range. It does not affect 02.6, whose four ranges measure 765 exactly; it is the 02.7 column that reads +598 where its own ranges give 597.

## The gate

`bash scripts/check.sh` on this tree — and the merge tree **is** this tree, since the umbrella has not moved (`merge-tree(umbrella, HEAD) == HEAD^{tree}`, the §4.2b shortcut with its authorising equality):

```
ALL CRITICAL CHECKS PASSED        (exit 0)
Tests            PASS - 2243 tests      (+ 1 xfailed)
Coverage                94%
Coverage (knowledge/)  PASS - 91%       (floor 90)
Ruff / Format / Mypy / Bandit / Detect-secrets   PASS
Radon            WARN - grade C  (pre-existing, warn-only)
```

**§7.2 flagged 02.6 as one of two candidates to fall through the 90 % package floor. It clears at 91 %, by one point.** `index_build.py` itself is at **65 %**: the ported ranges contain branches whose tests live in the deferred children (`Manifest.from_dict`'s malformed-field paths, `surface_row` / `topic_row`, the vocab and topics fingerprints). That is the honest reading — the floor is a package floor, and this module reaches its own numbers when 02.7 / 02.8 land.

## Deliberately out of scope

`build`, `update`, `status`, `search`, `index_store`, `search_service`, `get_service`, `render`, the CLI commands and the `[index]` config. Children 02.7 onwards.

## Band

1.066 touched, inside the 800–1.500 band §6 asks to justify in the PR description: **one module's input/fingerprint/manifest half plus its own test file**, and the two shared parser seams that half needs to exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br9vE5wbpJBScSCRffCavK

