### PR TITLE
feat(knowledge): the three inputs read once, the signal bound to those bytes (Plan 02, child 02.6a)

### DIFF
--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -252,12 +252,26 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
     docstring for why a timestamp proxy both misses hand edits and cannot reach the 40 % of
     the corpus with no `content` at all.
 
+    EACH VARIADIC REGION DECLARES ITS LENGTH. `topics`, `kinds` and `rows` are three
+    variable-length regions inside one flat `\0`-joined list, and with no count in front of
+    each the join is NOT injective: `topics=("thread",)` with no sources serialised exactly
+    like no topics with one blank `thread` source, so two different item states hashed the
+    same and `update` called the item unchanged — rule 6, failing OPEN. The framing is what
+    makes the stream decodable. It deliberately replaces an earlier argument from
+    `Topic.slug`'s pattern, which governs the VOCABULARY and not `Enrichment.topics` — the
+    unrestricted `list[str]` this actually hashes.
+
     `options` IS NOT READ HERE. It is accepted so the signature 02.7 consumes is already the
     ported one, and discarded — see `IndexOptions`. Nothing in this fingerprint depends on the
     chunker's parameters or on the vault, and a caller must not assume it does.
     """
     options = options or IndexOptions()
-    surfaces = item_surfaces(item)
+    topics = item_topics(item)
+    kinds = sorted(
+        source.kind
+        for _index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
+    )
+    rows = [json.dumps(surface_row(surface), ensure_ascii=False) for surface in item_surfaces(item)]
     parts = [
         SURFACE_VERSION,
         item.id,
@@ -268,12 +282,12 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
         item.created_at.isoformat(),
         item.captured_at.isoformat(),
         item.bookmark_folder or "",
-        *item_topics(item),
-        *sorted(
-            source.kind
-            for _index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
-        ),
-        *(json.dumps(surface_row(surface), ensure_ascii=False) for surface in surfaces),
+        f"topics:{len(topics)}",
+        *topics,
+        f"kinds:{len(kinds)}",
+        *kinds,
+        f"rows:{len(rows)}",
+        *rows,
     ]
     return _sha256("\0".join(parts))
 

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -3,29 +3,25 @@
 
 TWO SIGNALS, TWO COSTS, TWO PLACES (B3). Indexing is MANUAL BY DECISION (spec §9.2), so the
 failure that actually happens is not corruption — it is *you ran `enrich` and did not
-reindex*. Two different instruments answer two different questions:
-
-| `StoreSignal` — mtime + size of the THREE inputs | three `os.stat` | EVERY query | "an input moved" |
-| `store_fingerprint` — sha256 per item | loads the store | build/update/status | "WHICH items changed, and how many" |
-
+reindex*. `StoreSignal` is mtime + size of the THREE inputs: three `os.stat`, cheap enough
+for EVERY query, and it answers *an input moved*. `store_fingerprint` is a sha256 per item:
+it loads the store, is paid only by build/update/status, and answers *WHICH items changed*.
 The cheap one can give false positives (a `touch` with no edit) and that is accepted: a false
 positive costs one warning, a false negative costs serving stale evidence as fresh. It fails
 towards the warning, the same direction `origin: unknown -> llm_synthesis` fails.
 
 THE PER-ITEM FINGERPRINT IS OVER THE SURFACES, NOT OVER `(fetched_at, enriched_at)` as Plan
 01 §10 sketched, and CLAUDE.md rule 6 is both reasons. First, `content.fetched_at` cannot
-reach an item whose `content` is `None` — 960 of 2,404 in the real store, measured
-2026-09-01 on sha256 `f76341a3…` — because there is
-nothing to stamp. Second, a timestamp is a PROXY: a summary edited by hand, or any repair
-that rewrites text without touching a clock, changes the indexable corpus and leaves the
-proxy unmoved, so the index would keep serving the old body under a fingerprint asserting it
-is current. Hashing the emitted surface fingerprints asks the question directly — *did the
-text this index holds change?* — and it reaches every item. The cost is one emitter pass over
-the store per `update`/`status`, which is measured and published in the execution report.
+reach an item whose `content` is `None` — 960 of 2,404 in the real store, measured 2026-09-01
+on sha256 `f76341a3…` — because there is nothing to stamp. Second, a timestamp is a PROXY: a
+summary edited by hand, or any repair that rewrites text without touching a clock, changes
+the indexable corpus and leaves the proxy unmoved, so the index would keep serving the old
+body under a fingerprint asserting it is current. Hashing the emitted surface fingerprints
+asks the question directly and reaches every item, for one emitter pass per `update`/`status`.
 
-NOTHING HERE WRITES TO THE STORE. `items.json`, `vocab.yaml` and `topics.json` are read and
-never touched, and no command of this plan takes a snapshot, because none of them is
-destructive: `data/index/` is derived and reconstructible by definition (spec §5.6).
+NOTHING HERE WRITES TO THE STORE. The three inputs are read and never touched, and no command
+of this plan snapshots, because none is destructive: `data/index/` is derived and
+reconstructible by definition (spec §5.6).
 """
 
 from __future__ import annotations
@@ -56,24 +52,19 @@ class StoreSignal:
     """The CHEAP change signal: `mtime_ns` and size of the THREE inputs (spec §5.6, P1a).
 
     Three `os.stat`, so a query can afford it on every call. A missing file yields zeros
-    rather than raising: a query must still be able to say *the index is behind* when the
-    store has been moved away, and raising from inside `search` is the wrong place to learn
-    it.
+    rather than raising: a query must still say *the index is behind* when the store has been
+    moved away, and `search` is the wrong place to learn it by exception.
 
-    THREE FILES, NOT ONE (P1a, gate Codex round 05). Spec §5.6 names `data/items.json` as
-    the file the cheap signal watches, and that is what the first version stat'ed — but the
-    index derives from `vocab.yaml` and `topics.json` too: a topic description enters every
-    assigned item's PROFILE (spec §5.1.A), and overviews and notes are chunks the index
-    serves. The manifest already recorded their deep fingerprints; the query door never
-    compared them, so `xbrain topics` — which writes `topics.json` and never `items.json` —
-    left every later `search` answering over the old topic plane with nothing declared, the
-    silent staleness spec §9.3 forbids, on two of the three inputs. One signal over the
-    three files, one comparison, three `stat` calls.
-
-    A manifest written before round 05 carries no vocab/topics entries: they read back as
-    zeros, compare unequal to the live files, and the index is declared behind until the
-    next `update` re-seals the manifest. That is the direction this signal is meant to
-    fail in — towards the warning — and it costs one `index update`.
+    THREE FILES, NOT ONE (P1a, gate Codex round 05). Spec §5.6 names `data/items.json`, and
+    that is what the first version stat'ed — but the index derives from `vocab.yaml` and
+    `topics.json` too: a topic description enters every assigned item's PROFILE (spec §5.1.A),
+    and overviews and notes are chunks the index serves. The manifest already recorded their
+    deep fingerprints; the query door never compared them, so `xbrain topics` — which writes
+    `topics.json` and never `items.json` — left every later `search` answering over the old
+    topic plane with nothing declared, the silent staleness spec §9.3 forbids, on two of the
+    three inputs. A manifest written before round 05 carries no vocab/topics entries: they
+    read back as zeros, compare unequal, and the index is declared behind until the next
+    `update` re-seals it — the direction this signal is meant to fail in, at one `update`.
     """
 
     items_json_mtime_ns: int
@@ -116,9 +107,9 @@ def _stat_signal(path: Path | None) -> tuple[int, int]:
 class IndexInputs:
     """The three inputs of the index AND the cheap signal of the snapshot they were read from.
 
-    The signal travels WITH the objects because it describes them (P1b): a signal taken from
-    the path at any other moment describes whatever file is there at that moment, which is
-    what let the manifest certify an `items.json` the base had never seen.
+    The signal travels WITH the objects because it describes them (P1b): taken from the path
+    at any other moment it describes whatever file is there then, which is what let the
+    manifest certify an `items.json` the base had never seen.
     """
 
     store: dict[str, Item]
@@ -135,23 +126,20 @@ def load_index_inputs(
     THE SIGNAL IS BOUND TO THE SNAPSHOT, NOT TO THE PATH (P1b, gate Codex round 05). `build`
     and `update` used to seal the manifest with `StoreSignal.of(items_path)` taken AFTER the
     rows were committed — a `stat` of whatever file the path pointed at by then. The caller
-    had loaded the store minutes earlier (the CLI loads it before calling in), so a save that
-    landed in that window put the base under the OLD objects and the manifest under the NEW
-    file's mtime and size: `search` then compared equal signals and answered over stale rows
-    with nothing declared, while `status` — which loads the store — saw the changed item.
-    The gate's probe A: `raceonlytoken` in the file, not in the base, `degraded:
-    ("no_embeddings",)`, `items_changed=1`, `behind=False`.
+    had loaded the store minutes earlier, so a save landing in that window put the base under
+    the OLD objects and the manifest under the NEW file's mtime and size: `search` compared
+    equal signals and answered over stale rows with nothing declared, while `status` — which
+    loads the store — saw the changed item. The gate's probe A: `raceonlytoken` in the file,
+    not in the base, `degraded: ("no_embeddings",)`, `items_changed=1`, `behind=False`.
 
     Every file is read through ITS OWN HANDLE and the signal is `os.fstat` of that handle,
     taken BEFORE the read. The store's writers replace files atomically (`os.replace`), so an
     open handle keeps the inode it opened and the bytes parsed are the bytes that inode holds:
-    the signal describes exactly what was parsed, by construction, and a replacement that
-    lands during the read leaves the path pointing at a NEWER inode, which the query-time
-    `StoreSignal.of` then reports as different — the index declares itself behind. For a
-    writer that rewrites in place instead (`save_vocab` uses `write_text`), taking the stat
-    before the read means a write that lands mid-read produces an older signal than the
-    content, so the index is again declared behind rather than certified fresh: the same
-    direction, the warning.
+    the signal describes exactly what was parsed, by construction, and a replacement landing
+    during the read leaves the path on a NEWER inode, which query-time `StoreSignal.of`
+    reports as different — the index declares itself behind. For a writer that rewrites in
+    place instead (`save_vocab` uses `write_text`), stat-before-read yields an older signal
+    than the content, so the index is again declared behind: the same direction, the warning.
 
     A MISSING file reads as its empty value and a zero signal, exactly as `load_store`,
     `load_vocab`, `load_topic_pages` and `StoreSignal.of` treat it. A file that exists and
@@ -181,14 +169,13 @@ def _read_bound(path: Path | None) -> tuple[str | None, int, int]:
 
     `(None, 0, 0)` for an ABSENT or unnamed file — and for nothing else (A-2, round 08).
     The first version caught every `OSError`, so a file that EXISTS and cannot be read — a
-    `chmod 000`, a directory standing in its place, an `EIO` from a failing mount — loaded
-    as the empty store reserved for a missing one: the cheap signal still stat'ed fine, so
-    no door saw anything wrong, and on the real index `status` reported `items_removed
-    2404` as healthy, `search` answered zero results with exit 0, `update` planned the
-    deletion of every item and `build --force` replaced 22,286 chunks with the topic plane's
-    703, sealed consistent, exit 0. `load_store` (`store.py`) only ever read an absent file
-    as `{}`; this loader now agrees, and any other `OSError` propagates — the CLI prints it
-    as `Error: …` with exit 1, and the index on disk is not touched.
+    `chmod 000`, a directory standing in its place, an `EIO` from a failing mount — loaded as
+    the empty store reserved for a missing one: the cheap signal still stat'ed fine, so no
+    door saw anything wrong, and on the real index `status` reported `items_removed 2404` as
+    healthy, `search` answered zero results with exit 0, `update` planned the deletion of
+    every item and `build --force` replaced 22,286 chunks with the topic plane's 703, sealed
+    consistent, exit 0. `load_store` only ever read an ABSENT file as `{}`; this loader now
+    agrees, and any other `OSError` propagates to `Error: …` with exit 1, index untouched.
     """
     if path is None:
         return None, 0, 0
@@ -211,12 +198,10 @@ class IndexOptions:
     back, and the emitter no longer takes them. See `surfaces.item_surfaces`.
 
     CARRIED INERT IN THIS CHILD, AND SAYING SO IS THE POINT. Neither `params` nor `vault_dir`
-    is read anywhere in this tree: `options` is a NO-OP today, so `item_fingerprint(item,
-    options=X)` silently discards `X`, and a caller who passes the chunker's parameters
-    expecting the fingerprint to cover them would be wrong. The dataclass travels here so the
-    ported signature stays stable and 02.7 — its first consumer, the builder that actually
-    reads `params` and `vault_dir` — does not have to re-type it, never because anything
-    already reads it.
+    is read anywhere in this tree, so `item_fingerprint(item, options=X)` silently discards
+    `X` and a caller who passes the chunker's parameters expecting the fingerprint to cover
+    them would be wrong. The dataclass travels here so the ported signature stays stable for
+    02.7 — its first consumer — never because anything already reads it.
     """
 
     params: ChunkerParams = DEFAULT_CHUNKER_PARAMS
@@ -226,44 +211,34 @@ class IndexOptions:
 def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
     """sha256 over everything about this item that the INDEX holds.
 
-    Two halves, and both are needed. The SURFACE ROWS answer *did what the index holds about
-    each surface change?* — `surface_row` is the projection of every column the `surfaces`
-    table holds, so it covers the surface fingerprint (emitter version, type, origin, body)
-    AND the attribution, title, url, locator and language the index stores and `search`
-    serves on every match (A-1). The filterable METADATA of the item (source, author, date,
-    topics, content kinds) answers the other half: a changed author changes what `--author`
-    returns even though not one character of text moved.
+    Two halves, both needed. The SURFACE ROWS answer *did what the index holds about each
+    surface change?* — `surface_row` is the projection of every column `surfaces` holds, so it
+    covers the surface fingerprint (emitter version, type, origin, body) AND the attribution,
+    title, url, locator and language `search` serves on every match (A-1). The filterable
+    METADATA (source, author, date, topics, content kinds) answers the other half: a changed
+    author changes what `--author` returns with no text moved.
 
     THE ROW, NOT THE SURFACE FINGERPRINT ALONE (G-5). `surface_fingerprint` is
     `(version, type, origin, text)` by design and must stay so; but hashing only that here
-    meant a `refresh-quoted` that filled in the author of a quoted post without touching
-    its body left `update` reporting `0 cambiados` and `search` serving the old attribution
-    — the evidence repaired, the derivative standing (CLAUDE.md rule 6), on the attribution
-    rule this repo paid for in blood. Hashing the projection itself is what keeps "every
-    stored column is hashed" ONE list instead of two — see `surface_row` for what still
-    binds that list to the persisted schema by hand today, and what 02.7 owes it.
+    meant a `refresh-quoted` that filled in the author of a quoted post without touching its
+    body left `update` reporting `0 cambiados` and `search` serving the old attribution — the
+    evidence repaired, the derivative standing (rule 6), on the attribution rule this repo
+    paid for in blood. Hashing the projection keeps "every stored column is hashed" ONE list
+    instead of two — see `surface_row` for what binds it to the schema by hand, and what 02.7
+    owes it. `producer` is NOT hashed: the index has no producer column, and the producers
+    the store records travel with the surface `get` re-emits (F7-7). Deliberately NOT
+    `(item_id, content.fetched_at, enriched.enriched_at)` — see the module docstring.
 
-    What is NOT hashed, and why: `producer`. The index has no producer column, and the
-    producers the store records (`enriched.executor`, `description_version`) travel with
-    the surface `get` re-emits; the ASR/VLM surfaces carry none since round 08 (F7-7),
-    because the store records no transcriber and a configured command is not evidence.
-
-    Deliberately NOT `(item_id, content.fetched_at, enriched.enriched_at)`: see the module
-    docstring for why a timestamp proxy both misses hand edits and cannot reach the 40 % of
-    the corpus with no `content` at all.
-
-    EACH VARIADIC REGION DECLARES ITS LENGTH. `topics`, `kinds` and `rows` are three
-    variable-length regions inside one flat `\0`-joined list, and with no count in front of
-    each the join is NOT injective: `topics=("thread",)` with no sources serialised exactly
-    like no topics with one blank `thread` source, so two different item states hashed the
-    same and `update` called the item unchanged — rule 6, failing OPEN. The framing is what
-    makes the stream decodable. It deliberately replaces an earlier argument from
-    `Topic.slug`'s pattern, which governs the VOCABULARY and not `Enrichment.topics` — the
-    unrestricted `list[str]` this actually hashes.
+    THE THREE VARIADIC REGIONS ARE NESTED, NEVER SPLICED. Flattening `topics`, `kinds` and
+    `rows` into one delimited list is NOT injective: `topics=("thread",)` with no sources
+    serialised exactly like no topics with one blank `thread` source, so two item states
+    hashed alike and `update` called the item unchanged — rule 6, failing OPEN. Each is its
+    own JSON array, so the boundary is STRUCTURAL, and `_canonical` makes the atoms inside
+    them unforgeable too. Both retire an older argument from `Topic.slug`'s pattern, which
+    governs the VOCABULARY and not the `Enrichment.topics` this hashes.
 
     `options` IS NOT READ HERE. It is accepted so the signature 02.7 consumes is already the
-    ported one, and discarded — see `IndexOptions`. Nothing in this fingerprint depends on the
-    chunker's parameters or on the vault, and a caller must not assume it does.
+    ported one, and discarded — see `IndexOptions`.
     """
     options = options or IndexOptions()
     topics = item_topics(item)
@@ -271,25 +246,25 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
         source.kind
         for _index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
     )
-    rows = [json.dumps(surface_row(surface), ensure_ascii=False) for surface in item_surfaces(item)]
-    parts = [
-        SURFACE_VERSION,
-        item.id,
-        item.source,
-        item.url,
-        item.author.handle,
-        item.author.name,
-        item.created_at.isoformat(),
-        item.captured_at.isoformat(),
-        item.bookmark_folder or "",
-        f"topics:{len(topics)}",
-        *topics,
-        f"kinds:{len(kinds)}",
-        *kinds,
-        f"rows:{len(rows)}",
-        *rows,
-    ]
-    return _sha256("\0".join(parts))
+    return _sha256(
+        _canonical(
+            "item",
+            [
+                SURFACE_VERSION,
+                item.id,
+                item.source,
+                item.url,
+                item.author.handle,
+                item.author.name,
+                item.created_at.isoformat(),
+                item.captured_at.isoformat(),
+                item.bookmark_folder,
+                topics,
+                kinds,
+                [surface_row(surface) for surface in item_surfaces(item)],
+            ],
+        )
+    )
 
 
 # The column order of `surfaces`, as ONE tuple type: hashed here, and bound to the `INSERT`
@@ -316,17 +291,14 @@ SurfaceRow = tuple[
 def surface_row(surface: KnowledgeSurface) -> SurfaceRow:
     """What the index STORES about a surface — the projection of one `surfaces` row.
 
-    ONE PROJECTION, AND 02.7's WRITER HAS TO CONSUME IT. `item_fingerprint` hashes this
-    tuple today; the writer that binds it to the `INSERT` into `surfaces` lands in 02.7 and
-    does not exist in this tree. Until it does, the correspondence with the persisted DDL
-    (`index_schema`: fifteen columns, this tuple's order and types) is kept BY HAND —
-    nothing here forces a column added to `surfaces` to be hashed, and this docstring is the
-    contract, not the guard.
-
-    Making it structural is 02.7's job, in two parts: its writer binds THIS function instead
-    of assembling a second tuple, and it writes the readback test — red first — that proves
-    the stored row and the hashed row cannot drift. Read any claim of that guard here as a
-    statement of 02.7's obligation, never as one already discharged.
+    ONE PROJECTION, AND 02.7's WRITER HAS TO CONSUME IT. `item_fingerprint` hashes this tuple
+    today; the writer that binds it to the `INSERT` into `surfaces` lands in 02.7. Until it
+    does, the correspondence with the persisted DDL (`index_schema`: fifteen columns, this
+    tuple's order and types) is kept BY HAND — nothing forces a column added to `surfaces` to
+    be hashed, and this docstring is the contract, not the guard. Making it structural is
+    02.7's job: its writer binds THIS function instead of assembling a second tuple, and it
+    writes the readback test — red first — proving the stored and hashed rows cannot drift.
+    Read any claim of that guard here as 02.7's obligation, never as one discharged.
 
     The last column is a LENGTH, never the body (spec §10.8); the body is covered by
     `fingerprint`, which hashes it.
@@ -354,13 +326,14 @@ def store_fingerprint(store: Mapping[str, Item], *, options: IndexOptions | None
     """The DEEP store signal: one sha256 over every item's fingerprint, in id order.
 
     Order-independent by construction — the ids are sorted — because a dict's iteration order
-    is a property of how the store was loaded, not of what it contains.
+    is a property of how the store was loaded, not of what it contains. Each `(id, hash)` is
+    its own array, so an id cannot run into the hash beside it.
     """
-    parts = [
-        f"{item_id}={item_fingerprint(store[item_id], options=options)}"
-        for item_id in sorted(store)
-    ]
-    return _sha256("\0".join(parts))
+    return _sha256(
+        _canonical(
+            "store", [[k, item_fingerprint(store[k], options=options)] for k in sorted(store)]
+        )
+    )
 
 
 def vocab_fingerprint(vocab: Sequence[Topic]) -> str:
@@ -369,19 +342,44 @@ def vocab_fingerprint(vocab: Sequence[Topic]) -> str:
     The descriptions are in because they enter every assigned item's PROFILE (spec §5.1.A):
     editing one changes indexed text on the item plane, not only on the topic plane.
     """
-    parts = [f"{topic.slug}={topic.description}" for topic in sorted(vocab, key=lambda t: t.slug)]
-    return _sha256("\0".join(parts))
+    ordered = sorted(vocab, key=lambda topic: topic.slug)
+    return _sha256(_canonical("vocab", [[t.slug, t.description] for t in ordered]))
 
 
 def topics_fingerprint(pages: Mapping[str, TopicPage]) -> str:
     """sha256 over each topic page's overview and notes — the synthesised text."""
-    parts = []
-    for slug in sorted(pages):
-        page = pages[slug]
-        parts.append(surface_fingerprint("topic_overview", "llm", page.overview))
-        parts += [surface_fingerprint("topic_note", "llm", note) for note in page.notes]
-        parts.append(slug)
-    return _sha256("\0".join(parts))
+    plane = [
+        [
+            slug,
+            surface_fingerprint("topic_overview", "llm", pages[slug].overview),
+            [surface_fingerprint("topic_note", "llm", note) for note in pages[slug].notes],
+        ]
+        for slug in sorted(pages)
+    ]
+    return _sha256(_canonical("topics", plane))
+
+
+def _canonical(domain: str, value: object) -> str:
+    """The ONE serialisation every fingerprint here hashes, and the only one (rule 5).
+
+    INJECTIVE BY ROUND TRIP, which the NUL-join it replaces was not. That join framed nothing
+    below the region, and both writers persist a NUL, so a stored value could re-split the
+    stream and move every later boundary — including the count tags meant to fix them.
+    Measured before the change: two topic lists, two vocabularies and two topic planes, each
+    pair distinct after `save`/`load` and each pair hashing alike. `json.loads` recovers the
+    exact structure, so two different structures cannot encode alike and no argument about
+    which strings can appear is left. (Said in words, not escapes: written as an escape in a
+    non-raw docstring it puts a real NUL in `__doc__` — three of them, in the first version.)
+
+    `ensure_ascii=False` IS THE INJECTIVE SETTING, a correctness choice: with `True` a lone
+    surrogate PAIR and the astral character it spells serialise to the same escape, which is
+    a collision; with `False` they differ and a lone surrogate raises at `.encode("utf-8")`.
+    `domain` is hashed IN so two planes cannot serialise alike — `store_fingerprint({"a": i})`
+    and a one-entry vocabulary with slug `a` and description `i`'s fingerprint are both
+    `[["a", <64 hex>]]`, measured EQUAL before the tag. Not consequential while the manifest
+    keeps the planes in separate columns, and closed anyway: it costs one argument.
+    """
+    return json.dumps([domain, value], ensure_ascii=False)
 
 
 def _sha256(blob: str) -> str:

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -5,7 +5,7 @@ TWO SIGNALS, TWO COSTS, TWO PLACES (B3). Indexing is MANUAL BY DECISION (spec §
 failure that actually happens is not corruption — it is *you ran `enrich` and did not
 reindex*. Two different instruments answer two different questions:
 
-| `StoreSignal` — mtime + size | one `os.stat` | EVERY query | "the store moved" |
+| `StoreSignal` — mtime + size of the THREE inputs | three `os.stat` | EVERY query | "an input moved" |
 | `store_fingerprint` — sha256 per item | loads the store | build/update/status | "WHICH items changed, and how many" |
 
 The cheap one can give false positives (a `touch` with no edit) and that is accepted: a false
@@ -209,6 +209,14 @@ class IndexOptions:
     The configured transcribe/vision commands no longer travel here (F7-7, round 08): they
     were stamped on the ASR/VLM surfaces as `producer`, a provenance claim the store cannot
     back, and the emitter no longer takes them. See `surfaces.item_surfaces`.
+
+    CARRIED INERT IN THIS CHILD, AND SAYING SO IS THE POINT. Neither `params` nor `vault_dir`
+    is read anywhere in this tree: `options` is a NO-OP today, so `item_fingerprint(item,
+    options=X)` silently discards `X`, and a caller who passes the chunker's parameters
+    expecting the fingerprint to cover them would be wrong. The dataclass travels here so the
+    ported signature stays stable and 02.7 — its first consumer, the builder that actually
+    reads `params` and `vault_dir` — does not have to re-type it, never because anything
+    already reads it.
     """
 
     params: ChunkerParams = DEFAULT_CHUNKER_PARAMS
@@ -243,6 +251,10 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
     Deliberately NOT `(item_id, content.fetched_at, enriched.enriched_at)`: see the module
     docstring for why a timestamp proxy both misses hand edits and cannot reach the 40 % of
     the corpus with no `content` at all.
+
+    `options` IS NOT READ HERE. It is accepted so the signature 02.7 consumes is already the
+    ported one, and discarded — see `IndexOptions`. Nothing in this fingerprint depends on the
+    chunker's parameters or on the vault, and a caller must not assume it does.
     """
     options = options or IndexOptions()
     surfaces = item_surfaces(item)

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -1,0 +1,351 @@
+"""The three inputs of the index, the signal bound to them, and their fingerprints
+(Plan 02 §2, §3).
+
+TWO SIGNALS, TWO COSTS, TWO PLACES (B3). Indexing is MANUAL BY DECISION (spec §9.2), so the
+failure that actually happens is not corruption — it is *you ran `enrich` and did not
+reindex*. Two different instruments answer two different questions:
+
+| `StoreSignal` — mtime + size | one `os.stat` | EVERY query | "the store moved" |
+| `store_fingerprint` — sha256 per item | loads the store | build/update/status | "WHICH items changed, and how many" |
+
+The cheap one can give false positives (a `touch` with no edit) and that is accepted: a false
+positive costs one warning, a false negative costs serving stale evidence as fresh. It fails
+towards the warning, the same direction `origin: unknown -> llm_synthesis` fails.
+
+THE PER-ITEM FINGERPRINT IS OVER THE SURFACES, NOT OVER `(fetched_at, enriched_at)` as Plan
+01 §10 sketched, and CLAUDE.md rule 6 is both reasons. First, `content.fetched_at` cannot
+reach an item whose `content` is `None` — 960 of 2,404 in the real store, measured
+2026-09-01 on sha256 `f76341a3…` — because there is
+nothing to stamp. Second, a timestamp is a PROXY: a summary edited by hand, or any repair
+that rewrites text without touching a clock, changes the indexable corpus and leaves the
+proxy unmoved, so the index would keep serving the old body under a fingerprint asserting it
+is current. Hashing the emitted surface fingerprints asks the question directly — *did the
+text this index holds change?* — and it reaches every item. The cost is one emitter pass over
+the store per `update`/`status`, which is measured and published in the execution report.
+
+NOTHING HERE WRITES TO THE STORE. `items.json`, `vocab.yaml` and `topics.json` are read and
+never touched, and no command of this plan takes a snapshot, because none of them is
+destructive: `data/index/` is derived and reconstructible by definition (spec §5.6).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from xbrain.executors.api import iter_content_sources
+from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams
+from xbrain.knowledge.ids import SURFACE_VERSION, surface_fingerprint
+from xbrain.knowledge.models import KnowledgeSurface
+from xbrain.knowledge.surfaces import (
+    CONTENT_KIND_TO_SURFACE_TYPES,
+    item_surfaces,
+    item_topics,
+)
+from xbrain.models import Item, Topic, TopicPage
+from xbrain.rubrics import parse_vocab
+from xbrain.store import parse_store, parse_topic_pages
+
+
+@dataclass(frozen=True)
+class StoreSignal:
+    """The CHEAP change signal: `mtime_ns` and size of the THREE inputs (spec §5.6, P1a).
+
+    Three `os.stat`, so a query can afford it on every call. A missing file yields zeros
+    rather than raising: a query must still be able to say *the index is behind* when the
+    store has been moved away, and raising from inside `search` is the wrong place to learn
+    it.
+
+    THREE FILES, NOT ONE (P1a, gate Codex round 05). Spec §5.6 names `data/items.json` as
+    the file the cheap signal watches, and that is what the first version stat'ed — but the
+    index derives from `vocab.yaml` and `topics.json` too: a topic description enters every
+    assigned item's PROFILE (spec §5.1.A), and overviews and notes are chunks the index
+    serves. The manifest already recorded their deep fingerprints; the query door never
+    compared them, so `xbrain topics` — which writes `topics.json` and never `items.json` —
+    left every later `search` answering over the old topic plane with nothing declared, the
+    silent staleness spec §9.3 forbids, on two of the three inputs. One signal over the
+    three files, one comparison, three `stat` calls.
+
+    A manifest written before round 05 carries no vocab/topics entries: they read back as
+    zeros, compare unequal to the live files, and the index is declared behind until the
+    next `update` re-seals the manifest. That is the direction this signal is meant to
+    fail in — towards the warning — and it costs one `index update`.
+    """
+
+    items_json_mtime_ns: int
+    items_json_size: int
+    vocab_yaml_mtime_ns: int = 0
+    vocab_yaml_size: int = 0
+    topics_json_mtime_ns: int = 0
+    topics_json_size: int = 0
+
+    @classmethod
+    def of(
+        cls, items_path: Path, vocab_path: Path | None = None, topics_path: Path | None = None
+    ) -> StoreSignal:
+        """The signal of the three inputs AS THEY ARE ON DISK NOW — the query-time side."""
+        items_mtime, items_size = _stat_signal(items_path)
+        vocab_mtime, vocab_size = _stat_signal(vocab_path)
+        topics_mtime, topics_size = _stat_signal(topics_path)
+        return cls(
+            items_json_mtime_ns=items_mtime,
+            items_json_size=items_size,
+            vocab_yaml_mtime_ns=vocab_mtime,
+            vocab_yaml_size=vocab_size,
+            topics_json_mtime_ns=topics_mtime,
+            topics_json_size=topics_size,
+        )
+
+
+def _stat_signal(path: Path | None) -> tuple[int, int]:
+    """`(mtime_ns, size)` of one input file, or `(0, 0)` when it is absent or not given."""
+    if path is None:
+        return 0, 0
+    try:
+        stat = path.stat()
+    except OSError:
+        return 0, 0
+    return stat.st_mtime_ns, stat.st_size
+
+
+@dataclass(frozen=True)
+class IndexInputs:
+    """The three inputs of the index AND the cheap signal of the snapshot they were read from.
+
+    The signal travels WITH the objects because it describes them (P1b): a signal taken from
+    the path at any other moment describes whatever file is there at that moment, which is
+    what let the manifest certify an `items.json` the base had never seen.
+    """
+
+    store: dict[str, Item]
+    vocab: list[Topic]
+    topic_pages: dict[str, TopicPage]
+    signal: StoreSignal
+
+
+def load_index_inputs(
+    items_path: Path, vocab_path: Path | None = None, topics_path: Path | None = None
+) -> IndexInputs:
+    """Read the three inputs and return them WITH the signal of the bytes that were read.
+
+    THE SIGNAL IS BOUND TO THE SNAPSHOT, NOT TO THE PATH (P1b, gate Codex round 05). `build`
+    and `update` used to seal the manifest with `StoreSignal.of(items_path)` taken AFTER the
+    rows were committed — a `stat` of whatever file the path pointed at by then. The caller
+    had loaded the store minutes earlier (the CLI loads it before calling in), so a save that
+    landed in that window put the base under the OLD objects and the manifest under the NEW
+    file's mtime and size: `search` then compared equal signals and answered over stale rows
+    with nothing declared, while `status` — which loads the store — saw the changed item.
+    The gate's probe A: `raceonlytoken` in the file, not in the base, `degraded:
+    ("no_embeddings",)`, `items_changed=1`, `behind=False`.
+
+    Every file is read through ITS OWN HANDLE and the signal is `os.fstat` of that handle,
+    taken BEFORE the read. The store's writers replace files atomically (`os.replace`), so an
+    open handle keeps the inode it opened and the bytes parsed are the bytes that inode holds:
+    the signal describes exactly what was parsed, by construction, and a replacement that
+    lands during the read leaves the path pointing at a NEWER inode, which the query-time
+    `StoreSignal.of` then reports as different — the index declares itself behind. For a
+    writer that rewrites in place instead (`save_vocab` uses `write_text`), taking the stat
+    before the read means a write that lands mid-read produces an older signal than the
+    content, so the index is again declared behind rather than certified fresh: the same
+    direction, the warning.
+
+    A MISSING file reads as its empty value and a zero signal, exactly as `load_store`,
+    `load_vocab`, `load_topic_pages` and `StoreSignal.of` treat it. A file that exists and
+    cannot be read RAISES (A-2): an unreadable store is not an empty one, and every door
+    that loads through here closes on the error instead of answering over nothing.
+    """
+    items_text, items_mtime, items_size = _read_bound(items_path)
+    vocab_text, vocab_mtime, vocab_size = _read_bound(vocab_path)
+    topics_text, topics_mtime, topics_size = _read_bound(topics_path)
+    return IndexInputs(
+        store=parse_store(items_text) if items_text is not None else {},
+        vocab=parse_vocab(vocab_text) if vocab_text is not None else [],
+        topic_pages=parse_topic_pages(topics_text) if topics_text is not None else {},
+        signal=StoreSignal(
+            items_json_mtime_ns=items_mtime,
+            items_json_size=items_size,
+            vocab_yaml_mtime_ns=vocab_mtime,
+            vocab_yaml_size=vocab_size,
+            topics_json_mtime_ns=topics_mtime,
+            topics_json_size=topics_size,
+        ),
+    )
+
+
+def _read_bound(path: Path | None) -> tuple[str | None, int, int]:
+    """`(text, mtime_ns, size)` of one input, the stat taken on the handle the text came from.
+
+    `(None, 0, 0)` for an ABSENT or unnamed file — and for nothing else (A-2, round 08).
+    The first version caught every `OSError`, so a file that EXISTS and cannot be read — a
+    `chmod 000`, a directory standing in its place, an `EIO` from a failing mount — loaded
+    as the empty store reserved for a missing one: the cheap signal still stat'ed fine, so
+    no door saw anything wrong, and on the real index `status` reported `items_removed
+    2404` as healthy, `search` answered zero results with exit 0, `update` planned the
+    deletion of every item and `build --force` replaced 22,286 chunks with the topic plane's
+    703, sealed consistent, exit 0. `load_store` (`store.py`) only ever read an absent file
+    as `{}`; this loader now agrees, and any other `OSError` propagates — the CLI prints it
+    as `Error: …` with exit 1, and the index on disk is not touched.
+    """
+    if path is None:
+        return None, 0, 0
+    try:
+        handle = path.open("rb")
+    except FileNotFoundError:
+        return None, 0, 0
+    with handle:
+        stat = os.fstat(handle.fileno())
+        data = handle.read()
+    return data.decode("utf-8"), stat.st_mtime_ns, stat.st_size
+
+
+@dataclass(frozen=True)
+class IndexOptions:
+    """Everything a build needs that is not the corpus itself.
+
+    The configured transcribe/vision commands no longer travel here (F7-7, round 08): they
+    were stamped on the ASR/VLM surfaces as `producer`, a provenance claim the store cannot
+    back, and the emitter no longer takes them. See `surfaces.item_surfaces`.
+    """
+
+    params: ChunkerParams = DEFAULT_CHUNKER_PARAMS
+    vault_dir: Path | None = None
+
+
+def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
+    """sha256 over everything about this item that the INDEX holds.
+
+    Two halves, and both are needed. The SURFACE ROWS answer *did what the index holds about
+    each surface change?* — `surface_row` is the exact tuple `_write_surfaces` inserts, so
+    it covers the surface fingerprint (emitter version, type, origin, body) AND the
+    attribution, title, url, locator and language the index stores and `search` serves on
+    every match (A-1). The filterable METADATA of the item (source, author, date, topics,
+    content kinds) answers the other half: a changed author changes what `--author` returns
+    even though not one character of text moved.
+
+    THE ROW, NOT THE SURFACE FINGERPRINT ALONE (G-5). `surface_fingerprint` is
+    `(version, type, origin, text)` by design and must stay so; but hashing only that here
+    meant a `refresh-quoted` that filled in the author of a quoted post without touching
+    its body left `update` reporting `0 cambiados` and `search` serving the old attribution
+    — the evidence repaired, the derivative standing (CLAUDE.md rule 6), on the attribution
+    rule this repo paid for in blood. Sharing the writer's projection is what makes "every
+    stored column is hashed" structural rather than a list kept in step by hand.
+
+    What is NOT hashed, and why: `producer`. The index has no producer column, and the
+    producers the store records (`enriched.executor`, `description_version`) travel with
+    the surface `get` re-emits; the ASR/VLM surfaces carry none since round 08 (F7-7),
+    because the store records no transcriber and a configured command is not evidence.
+
+    Deliberately NOT `(item_id, content.fetched_at, enriched.enriched_at)`: see the module
+    docstring for why a timestamp proxy both misses hand edits and cannot reach the 40 % of
+    the corpus with no `content` at all.
+    """
+    options = options or IndexOptions()
+    surfaces = item_surfaces(item)
+    parts = [
+        SURFACE_VERSION,
+        item.id,
+        item.source,
+        item.url,
+        item.author.handle,
+        item.author.name,
+        item.created_at.isoformat(),
+        item.captured_at.isoformat(),
+        item.bookmark_folder or "",
+        *item_topics(item),
+        *sorted(
+            source.kind
+            for _index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
+        ),
+        *(json.dumps(surface_row(surface), ensure_ascii=False) for surface in surfaces),
+    ]
+    return _sha256("\0".join(parts))
+
+
+# The column order of `surfaces`, as ONE tuple type shared by the writer and the fingerprint.
+SurfaceRow = tuple[
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    int,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str,
+    str | None,
+    str,
+    int,
+]
+
+
+def surface_row(surface: KnowledgeSurface) -> SurfaceRow:
+    """What the index STORES about a surface — the row `_write_surfaces` inserts, verbatim.
+
+    One projection, two readers: the writer binds it to the `INSERT`, `item_fingerprint`
+    hashes it. A column added to `surfaces` therefore cannot be stored without being hashed,
+    and `test_the_fingerprint_hashes_the_same_row_the_writer_inserts` reads the rows back to
+    prove the two never drifted. The last column is a LENGTH, never the body (spec §10.8);
+    the body is covered by `fingerprint`, which hashes it.
+    """
+    return (
+        surface.surface_id,
+        surface.owner_type,
+        surface.owner_id,
+        surface.surface_type,
+        surface.origin,
+        surface.trust_class,
+        int(surface.derived),
+        surface.attribution.handle if surface.attribution else None,
+        surface.attribution.name if surface.attribution else None,
+        surface.title,
+        surface.locator.url,
+        surface.locator.model_dump_json(),
+        surface.language,
+        surface.fingerprint,
+        len(surface.text),
+    )
+
+
+def store_fingerprint(store: Mapping[str, Item], *, options: IndexOptions | None = None) -> str:
+    """The DEEP store signal: one sha256 over every item's fingerprint, in id order.
+
+    Order-independent by construction — the ids are sorted — because a dict's iteration order
+    is a property of how the store was loaded, not of what it contains.
+    """
+    parts = [
+        f"{item_id}={item_fingerprint(store[item_id], options=options)}"
+        for item_id in sorted(store)
+    ]
+    return _sha256("\0".join(parts))
+
+
+def vocab_fingerprint(vocab: Sequence[Topic]) -> str:
+    """sha256 over the vocabulary's slugs AND descriptions.
+
+    The descriptions are in because they enter every assigned item's PROFILE (spec §5.1.A):
+    editing one changes indexed text on the item plane, not only on the topic plane.
+    """
+    parts = [f"{topic.slug}={topic.description}" for topic in sorted(vocab, key=lambda t: t.slug)]
+    return _sha256("\0".join(parts))
+
+
+def topics_fingerprint(pages: Mapping[str, TopicPage]) -> str:
+    """sha256 over each topic page's overview and notes — the synthesised text."""
+    parts = []
+    for slug in sorted(pages):
+        page = pages[slug]
+        parts.append(surface_fingerprint("topic_overview", "llm", page.overview))
+        parts += [surface_fingerprint("topic_note", "llm", note) for note in page.notes]
+        parts.append(slug)
+    return _sha256("\0".join(parts))
+
+
+def _sha256(blob: str) -> str:
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -368,16 +368,15 @@ def _canonical(domain: str, value: object) -> str:
     Measured before the change: two topic lists, two vocabularies and two topic planes, each
     pair distinct after `save`/`load` and each pair hashing alike. `json.loads` recovers the
     exact structure, so two different structures cannot encode alike and no argument about
-    which strings can appear is left. (Said in words, not escapes: written as an escape in a
-    non-raw docstring it puts a real NUL in `__doc__` — three of them, in the first version.)
+    which strings can appear is left. (NUL is spelled in words here: as an escape in a non-raw
+    docstring it puts a real one in `__doc__` — three, in the first version of this text.)
 
     `ensure_ascii=False` IS THE INJECTIVE SETTING, a correctness choice: with `True` a lone
-    surrogate PAIR and the astral character it spells serialise to the same escape, which is
-    a collision; with `False` they differ and a lone surrogate raises at `.encode("utf-8")`.
+    surrogate PAIR and the astral character it spells serialise to the same escape, which is a
+    collision; with `False` they differ and a lone surrogate raises at `.encode("utf-8")`.
     `domain` is hashed IN so two planes cannot serialise alike — `store_fingerprint({"a": i})`
-    and a one-entry vocabulary with slug `a` and description `i`'s fingerprint are both
-    `[["a", <64 hex>]]`, measured EQUAL before the tag. Not consequential while the manifest
-    keeps the planes in separate columns, and closed anyway: it costs one argument.
+    and a one-entry vocabulary with slug `a` and description `i`'s fingerprint were both
+    `[["a", <64 hex>]]`, measured EQUAL. Closed because it costs one argument.
     """
     return json.dumps([domain, value], ensure_ascii=False)
 

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -219,20 +219,21 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
     """sha256 over everything about this item that the INDEX holds.
 
     Two halves, and both are needed. The SURFACE ROWS answer *did what the index holds about
-    each surface change?* — `surface_row` is the exact tuple `_write_surfaces` inserts, so
-    it covers the surface fingerprint (emitter version, type, origin, body) AND the
-    attribution, title, url, locator and language the index stores and `search` serves on
-    every match (A-1). The filterable METADATA of the item (source, author, date, topics,
-    content kinds) answers the other half: a changed author changes what `--author` returns
-    even though not one character of text moved.
+    each surface change?* — `surface_row` is the projection of every column the `surfaces`
+    table holds, so it covers the surface fingerprint (emitter version, type, origin, body)
+    AND the attribution, title, url, locator and language the index stores and `search`
+    serves on every match (A-1). The filterable METADATA of the item (source, author, date,
+    topics, content kinds) answers the other half: a changed author changes what `--author`
+    returns even though not one character of text moved.
 
     THE ROW, NOT THE SURFACE FINGERPRINT ALONE (G-5). `surface_fingerprint` is
     `(version, type, origin, text)` by design and must stay so; but hashing only that here
     meant a `refresh-quoted` that filled in the author of a quoted post without touching
     its body left `update` reporting `0 cambiados` and `search` serving the old attribution
     — the evidence repaired, the derivative standing (CLAUDE.md rule 6), on the attribution
-    rule this repo paid for in blood. Sharing the writer's projection is what makes "every
-    stored column is hashed" structural rather than a list kept in step by hand.
+    rule this repo paid for in blood. Hashing the projection itself is what keeps "every
+    stored column is hashed" ONE list instead of two — see `surface_row` for what still
+    binds that list to the persisted schema by hand today, and what 02.7 owes it.
 
     What is NOT hashed, and why: `producer`. The index has no producer column, and the
     producers the store records (`enriched.executor`, `description_version`) travel with
@@ -265,7 +266,8 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
     return _sha256("\0".join(parts))
 
 
-# The column order of `surfaces`, as ONE tuple type shared by the writer and the fingerprint.
+# The column order of `surfaces`, as ONE tuple type: hashed here, and bound to the `INSERT`
+# by the writer 02.7 lands.
 SurfaceRow = tuple[
     str,
     str,
@@ -286,13 +288,22 @@ SurfaceRow = tuple[
 
 
 def surface_row(surface: KnowledgeSurface) -> SurfaceRow:
-    """What the index STORES about a surface — the row `_write_surfaces` inserts, verbatim.
+    """What the index STORES about a surface — the projection of one `surfaces` row.
 
-    One projection, two readers: the writer binds it to the `INSERT`, `item_fingerprint`
-    hashes it. A column added to `surfaces` therefore cannot be stored without being hashed,
-    and `test_the_fingerprint_hashes_the_same_row_the_writer_inserts` reads the rows back to
-    prove the two never drifted. The last column is a LENGTH, never the body (spec §10.8);
-    the body is covered by `fingerprint`, which hashes it.
+    ONE PROJECTION, AND 02.7's WRITER HAS TO CONSUME IT. `item_fingerprint` hashes this
+    tuple today; the writer that binds it to the `INSERT` into `surfaces` lands in 02.7 and
+    does not exist in this tree. Until it does, the correspondence with the persisted DDL
+    (`index_schema`: fifteen columns, this tuple's order and types) is kept BY HAND —
+    nothing here forces a column added to `surfaces` to be hashed, and this docstring is the
+    contract, not the guard.
+
+    Making it structural is 02.7's job, in two parts: its writer binds THIS function instead
+    of assembling a second tuple, and it writes the readback test — red first — that proves
+    the stored row and the hashed row cannot drift. Read any claim of that guard here as a
+    statement of 02.7's obligation, never as one already discharged.
+
+    The last column is a LENGTH, never the body (spec §10.8); the body is covered by
+    `fingerprint`, which hashes it.
     """
     return (
         surface.surface_id,

--- a/src/xbrain/rubrics.py
+++ b/src/xbrain/rubrics.py
@@ -150,7 +150,12 @@ def load_vocab(path: Path) -> list[Topic]:
     """Load the topic vocabulary; an empty list if the file does not exist."""
     if not path.exists():
         return []
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return parse_vocab(path.read_text(encoding="utf-8"))
+
+
+def parse_vocab(text: str) -> list[Topic]:
+    """The vocabulary from its YAML text — the ONE parser (see `store.parse_store`)."""
+    data = yaml.safe_load(text) or {}
     return [Topic(**entry) for entry in data.get("topics", [])]
 
 

--- a/src/xbrain/store.py
+++ b/src/xbrain/store.py
@@ -14,7 +14,17 @@ def load_store(path: Path) -> dict[str, Item]:
     """Load the item store; an empty dict if the file does not exist."""
     if not path.exists():
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    return parse_store(path.read_text(encoding="utf-8"))
+
+
+def parse_store(text: str) -> dict[str, Item]:
+    """The item store from its JSON text — the ONE parser, shared with the index loader.
+
+    Split from `load_store` so a reader that must bind what it parsed to the exact bytes it
+    read (`knowledge.index_build.load_index_inputs`) can read through its own file handle and
+    still parse through this function, instead of a second copy of these two lines.
+    """
+    raw = json.loads(text)
     return {item_id: Item.model_validate(data) for item_id, data in raw.items()}
 
 
@@ -40,7 +50,12 @@ def load_topic_pages(path: Path) -> dict[str, TopicPage]:
     """Load the topic-page store; an empty dict if the file does not exist."""
     if not path.exists():
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    return parse_topic_pages(path.read_text(encoding="utf-8"))
+
+
+def parse_topic_pages(text: str) -> dict[str, TopicPage]:
+    """The topic-page store from its JSON text — the ONE parser (see `parse_store`)."""
+    raw = json.loads(text)
     return {slug: TopicPage.model_validate(data) for slug, data in raw.items()}
 
 

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -501,6 +501,106 @@ def test_the_item_fingerprint_covers_a_content_kind_that_emits_no_surface(corpus
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
 
 
+def test_two_different_items_cannot_share_one_serialisation_across_the_variadic_regions(
+    corpus,
+) -> None:
+    """The topics region and the kinds region are ADJACENT, and nothing said where one ends.
+
+    `parts` splices three variable-length regions — `item_topics`, the sorted content kinds
+    and the surface rows — into one flat list joined by `\0`. With no length in front of each,
+    that join is NOT injective: two different item states serialise to the very same bytes.
+
+    Constructed here, and neither side is exotic — both are states the store can hold:
+    `primary_topic="thread"` with `topics=["thread"]` and no content at all, against no topics
+    and one `ContentSourceSuccess(kind="thread", text="")`. `thread` is both a `ContentKind`
+    and a legal topic string — `Enrichment.topics` is `list[str]` with no pattern, so nothing
+    in the TYPE forbids it — and a non-video source whose text is blank emits NO surface, so
+    the surface region is byte-identical on both sides and cannot break the tie.
+
+    IT FAILS OPEN, which is what makes it worth a test in a module whose every other staleness
+    path fails towards the warning: the two states hash the same, `update` reports the item
+    unchanged, and the persisted `item_topics` / `item_content_kinds` planes go on serving a
+    state the store no longer holds (rule 6). The reading this replaces measured how hard the
+    collision was to REACH and argued it from `Topic.slug`'s pattern — but `Topic.slug` is not
+    what is hashed, and "hard to reach" is not the same fact as "impossible to express".
+
+    MEASURED, AND STATED AS MEASURED. Seen RED at `bfbaf87`, both sides hashing
+    `bafd6ed7…`; red again under removal of the WHOLE framing (1 failed, 40 passed —
+    diagonal). Removing any ONE length tag alone leaves this file GREEN, because either
+    surviving tag still separates the two regions. So what this test pins is THE FRAMING,
+    never each tag independently, and no claim of per-tag protection is made for it.
+
+    The last assertion is the guard; the three before it prove the two states really do differ
+    on the axes they name, or an equal-hash assertion could pass on two identical items.
+    """
+    from xbrain.models import Content, ContentSourceSuccess
+
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    assert item.content is None, "the base item must start with no content source at all"
+
+    topic_side = item.model_copy(
+        update={
+            "enriched": item.enriched.model_copy(
+                update={"primary_topic": "thread", "topics": ["thread"]}
+            )
+        }
+    )
+    kind_side = item.model_copy(
+        update={
+            "enriched": item.enriched.model_copy(update={"primary_topic": None, "topics": []}),
+            "content": Content(
+                fetched_at=item.captured_at,
+                sources=[
+                    ContentSourceSuccess(kind="thread", url="https://x.com/i/status/2", text="")
+                ],
+            ),
+        }
+    )
+
+    assert item_topics(topic_side) == ("thread",), "one state carries `thread` as a TOPIC"
+    assert item_topics(kind_side) == (), "and the other carries no topic at all"
+    assert [index_build.surface_row(s) for s in item_surfaces(topic_side)] == [
+        index_build.surface_row(s) for s in item_surfaces(kind_side)
+    ], "the blank thread source emits no surface, so the surface region cannot break the tie"
+
+    assert index_build.item_fingerprint(topic_side) != index_build.item_fingerprint(kind_side), (
+        "a topic named like a content kind must not serialise as that content kind"
+    )
+
+
+def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this(corpus) -> None:
+    """`options` is accepted and DISCARDED, and until now only prose said so.
+
+    `item_fingerprint` binds `options = options or IndexOptions()` and then reads neither
+    `params` nor `vault_dir`, so `item_fingerprint(i, options=A) == item_fingerprint(i)` for
+    every A. Two docstrings say it and nothing executable saw it — `grep -n options` over this
+    file returned nothing, and `vulture` does not flag a parameter that is bound.
+
+    THIS IS A CHARACTERIZATION TEST: green before and after, repairing no defect, and no
+    mutation motivated it. What it buys is the other direction. 02.7's builder is the first
+    consumer that will genuinely read `params` and `vault_dir`, and the commit that makes the
+    fingerprint depend on them MUST turn this red. Reading the parameters while it stayed
+    green would mean the dependency never entered the hash — rule 6 armed: a re-chunk under
+    new parameters that `update` reports as `0 cambiados`.
+
+    So in 02.7 DELETE it, never weaken it.
+    """
+    from xbrain.knowledge.chunking import ChunkerParams
+
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    bare = index_build.item_fingerprint(item)
+
+    swept = index_build.IndexOptions(params=ChunkerParams(target=1, max_chars=2, min_chars=1))
+    vaulted = index_build.IndexOptions(vault_dir=Path("/nowhere"))
+    assert index_build.item_fingerprint(item, options=swept) == bare, "params are not read"
+    assert index_build.item_fingerprint(item, options=vaulted) == bare, "nor is the vault"
+    assert index_build.store_fingerprint(store, options=swept) == index_build.store_fingerprint(
+        store
+    ), "and `store_fingerprint` hands them to the same discard"
+
+
 def test_the_leading_surface_version_is_the_belt_for_an_item_with_no_surfaces(
     corpus, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -582,12 +682,45 @@ def test_load_index_inputs_binds_the_signal_to_the_bytes_it_read(workspace, corp
     assert index_build.StoreSignal.of(items) != loaded.signal, "the path now points elsewhere"
 
 
-def test_the_store_signal_is_one_stat_and_nothing_else(workspace) -> None:
-    """The cheap signal must stay cheap, or it is the expensive one with a different name."""
-    signal = index_build.StoreSignal.of(workspace / "items.json")
-    stat = (workspace / "items.json").stat()
-    assert signal.items_json_mtime_ns == stat.st_mtime_ns
-    assert signal.items_json_size == stat.st_size
+def test_the_store_signal_is_one_stat_per_named_input_and_nothing_else(
+    three_inputs: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cheap signal must stay cheap, or it is the expensive one with a different name.
+
+    THE NAME THIS REPLACES SAID «one stat» WHILE THE CODE DOES THREE. Round 10 corrected both
+    docstrings that carried the stale claim and left the test's own name, which is the most
+    widely read prose in a test file because it is what pytest prints. And the body asserted
+    nothing the name claimed — it compared the `items` entry against `path.stat()` and stayed
+    green under five stats, or none.
+
+    What is pinned instead is the contract as it actually is, and it is NOT «three»
+    unconditionally: `_stat_signal` answers `(0, 0)` for an unnamed path WITHOUT touching the
+    filesystem, so the cost is one stat PER NAMED INPUT. Both halves are asserted because a
+    signal that grew a second stat per file and a signal that stat'ed an unnamed path are
+    different regressions, and each moves a different number here.
+    """
+    real_stat = Path.stat
+    calls: list[Path] = []
+
+    def counted(self, *args, **kwargs):
+        calls.append(self)
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", counted)
+    items = three_inputs / "items.json"
+
+    signal = index_build.StoreSignal.of(
+        items, three_inputs / "vocab.yaml", three_inputs / "topics.json"
+    )
+    assert len(calls) == 3, f"one stat per named input, and nothing else: {calls}"
+
+    calls.clear()
+    partial = index_build.StoreSignal.of(items)
+    assert len(calls) == 1, "an unnamed input costs no stat at all"
+    assert (partial.vocab_yaml_size, partial.topics_json_size) == (0, 0)
+
+    assert signal.items_json_mtime_ns == real_stat(items).st_mtime_ns
+    assert signal.items_json_size == real_stat(items).st_size
 
 
 def test_the_store_signal_of_a_missing_store_is_zeroed_not_an_exception(tmp_path: Path) -> None:

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -1,0 +1,519 @@
+# tests/test_knowledge_index_build.py
+"""The three inputs of the index, the signal bound to them, and their fingerprints
+(Plan 02 §2, §3, steps 3, 4, 9).
+
+TWO SIGNALS, TWO COSTS, TWO PLACES (B3). `store_signal` is an `os.stat` — mtime and size of
+`data/items.json` — and it is what a QUERY can afford on every call. `store_fingerprint` is a
+sha256 per item and costs loading the store, so it is paid only by `build`, `update` and
+`status`. The cheap one says *the store moved*; the expensive one says *which items changed,
+and how many*. A false positive on the cheap one costs one warning; a false negative costs
+serving stale evidence as fresh, so it fails towards the warning.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xbrain.knowledge import index_build
+from xbrain.models import Item, Topic, TopicPage
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture()
+def corpus() -> tuple[dict[str, Item], list[Topic], dict[str, TopicPage]]:
+    raw = json.loads((FIXTURES / "knowledge_corpus.json").read_text(encoding="utf-8"))
+    store = {k: Item.model_validate(v) for k, v in raw["items"].items()}
+    vocab = [Topic.model_validate(v) for v in raw["vocab"].values()]
+    pages = {k: TopicPage.model_validate(v) for k, v in raw["topics"].items()}
+    return store, vocab, pages
+
+
+@pytest.fixture()
+def workspace(tmp_path: Path, corpus) -> Path:
+    """A data/ directory holding the fixture store, so `store_signal` has a real file."""
+    store, _vocab, _pages = corpus
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "items.json").write_text(
+        json.dumps({k: v.model_dump(mode="json") for k, v in store.items()}), encoding="utf-8"
+    )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# The fingerprint, and the population it has to reach (rule 6)
+# ---------------------------------------------------------------------------
+
+
+def test_the_item_fingerprint_changes_when_indexable_text_changes(corpus) -> None:
+    """It hashes the SURFACES, not `(fetched_at, enriched_at)` as Plan 01 §10 sketched.
+
+    Two reasons, and CLAUDE.md rule 6 is both of them. First, `content.fetched_at` cannot
+    reach an item whose `content` is `None` — 960 of 2,404 in the real store (measured
+    2026-09-01 on sha256 `f76341a3…`) — because there
+    is nothing to stamp. Second, a timestamp is a PROXY: a summary edited by hand, or any
+    repair that rewrites text without touching a clock, changes the indexable corpus and
+    leaves the proxy unmoved, so the index would keep serving the old body under a
+    fingerprint that says it is current.
+
+    Hashing the emitted surface fingerprints answers the question directly — *did the text
+    this index holds change?* — and it reaches every item, with or without `content`.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    before = index_build.item_fingerprint(item)
+    edited = item.model_copy(
+        update={"enriched": item.enriched.model_copy(update={"summary": "otro resumen"})}
+    )
+    assert index_build.item_fingerprint(edited) != before
+    assert index_build.item_fingerprint(item) == before, "and it is stable"
+
+
+def test_the_item_fingerprint_reaches_an_item_with_no_content(corpus) -> None:
+    """Step 6 / rule 6: the invalidation signal must reach the population it has to reach.
+
+    `k02` carries no `content` at all, so a fingerprint over `content.fetched_at` would be
+    constant for it forever. Seen red by hashing only the timestamps.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    assert item.content is None, "this test is only meaningful on an item with no content"
+    edited = item.model_copy(
+        update={"enriched": item.enriched.model_copy(update={"summary": "otro resumen"})}
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
+
+
+def test_the_item_fingerprint_also_covers_the_filterable_metadata(corpus) -> None:
+    """The index stores more than text: a changed author or topic changes what a filter returns.
+
+    Ignoring them would leave `--author` answering from an author the store no longer records.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    moved = item.model_copy(update={"source": "own_tweet"})
+    assert index_build.item_fingerprint(moved) != index_build.item_fingerprint(item)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("author", {"handle": "someoneelse", "name": "Someone Else"}),
+        ("title", "A different title"),
+        ("language", "fr"),
+        ("url", "https://x.com/othervoice/status/moved"),
+    ],
+)
+def test_the_item_fingerprint_covers_what_the_index_stores_about_a_surface(
+    corpus, field: str, value: object
+) -> None:
+    """G-5: every column the index STORES about a surface moves the fingerprint.
+
+    `surface_fingerprint` is `(version, type, origin, text)` by design — two surfaces with
+    the same text under different provenance must differ, and nothing more. But the index
+    persists more than that in `surfaces`: attribution, title, url, locator and language,
+    which `search` serves on every match (A-1) and `--has-surface` filters on. A change to
+    any of them with the text untouched left `update` seeing nothing to do — the evidence
+    repaired and the derivative standing (rule 6), on the attribution rule this repo paid
+    for in blood.
+
+    Four axes, one parametrised test, each changing ONE field of k07's quoted post and
+    nothing else. The url moves the locator too (`locator.url`), which is the point: the
+    locator is what the consumer resolves the evidence through. `producer` is deliberately
+    NOT here — the index has no producer column, and since round 08 (F7-7) the ASR/VLM
+    surfaces carry none at all, because the store records no transcriber; the producers
+    that ARE recorded (`enriched.executor`, `description_version`) travel with the surface
+    and are not stored columns either.
+
+    Seen red before the fix on all four: the fingerprint did not move. Seen red again here
+    under the mutant `surface_row` → `(None, None, None, …)`, which the file passed 90/90
+    before this test was restored: `surface_row` is the projection `item_fingerprint`
+    hashes, so a column dropped from it is a column the index stores and never re-hashes.
+    """
+    from xbrain.models import Author
+
+    store, _vocab, _pages = corpus
+    item = store["k07"]
+    position = next(i for i, s in enumerate(item.content.sources) if s.kind == "quoted_tweet")
+    sources = list(item.content.sources)
+    patch = {field: Author(**value) if field == "author" else value}
+    sources[position] = sources[position].model_copy(update=patch)
+    edited = item.model_copy(
+        update={"content": item.content.model_copy(update={"sources": sources})}
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), field
+
+
+def test_the_store_fingerprint_is_order_independent(corpus) -> None:
+    """Two loads of the same store must agree, whatever order the dict happens to iterate in."""
+    store, _vocab, _pages = corpus
+    reversed_store = dict(reversed(list(store.items())))
+    assert index_build.store_fingerprint(reversed_store) == index_build.store_fingerprint(store)
+
+
+def test_load_index_inputs_binds_the_signal_to_the_bytes_it_read(workspace, corpus) -> None:
+    """The mechanism behind P1b, at the loader: the signal is `fstat` of the handle the
+    text came from, taken BEFORE the read — so a replacement that lands during the read
+    leaves the objects and the signal describing the same snapshot (the handle keeps the
+    inode it opened; the store's writers replace atomically), and leaves the path pointing
+    at a newer inode the query-time `StoreSignal.of` reports as different.
+
+    Staged INSIDE the read: the handle `load_index_inputs` opens replaces the file on disk
+    the moment it is read from, which is the only place a stat of the path and a stat of
+    the handle can disagree. Seen red under the mutation `stat = path.stat()` taken after
+    the read: the signal then described the replacement, not the bytes parsed.
+    """
+    from xbrain.store import save_store
+
+    store, _vocab, _pages = corpus
+    items = workspace / "items.json"
+    before = index_build.StoreSignal.of(items)
+    newer = {**store, "k01": store["k01"].model_copy(update={"text": "replaced during the load"})}
+
+    class RacingHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def fileno(self):
+            return self._handle.fileno()
+
+        def read(self):
+            save_store(newer, items)  # the race: a save lands while the loader is reading
+            return self._handle.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return self._handle.__exit__(*exc)
+
+    class RacingPath(type(items)):
+        def open(self, *args, **kwargs):
+            return RacingHandle(super().open(*args, **kwargs))
+
+    loaded = index_build.load_index_inputs(RacingPath(items))
+
+    assert loaded.store["k01"].text == store["k01"].text, "the parse saw the bytes it read"
+    assert loaded.signal == before, "the signal describes the snapshot that was parsed"
+    assert index_build.StoreSignal.of(items) != loaded.signal, "the path now points elsewhere"
+
+
+def test_the_store_signal_is_one_stat_and_nothing_else(workspace) -> None:
+    """The cheap signal must stay cheap, or it is the expensive one with a different name."""
+    signal = index_build.StoreSignal.of(workspace / "items.json")
+    stat = (workspace / "items.json").stat()
+    assert signal.items_json_mtime_ns == stat.st_mtime_ns
+    assert signal.items_json_size == stat.st_size
+
+
+def test_the_store_signal_of_a_missing_store_is_zeroed_not_an_exception(tmp_path: Path) -> None:
+    """A query must still be able to say "the index is behind" when the store is gone.
+
+    Raising here would turn a missing store into a crash inside `search`, which is the wrong
+    place to learn it: the response declares the degradation instead.
+    """
+    signal = index_build.StoreSignal.of(tmp_path / "nope.json")
+    assert signal == index_build.StoreSignal(items_json_mtime_ns=0, items_json_size=0)
+
+
+def _obstruct(path: Path, obstacle: str) -> None:
+    """Make `path` UNREADABLE without removing it — the two shapes an operator meets."""
+    if obstacle == "chmod000":
+        path.chmod(0)
+    else:
+        path.unlink()
+        path.mkdir()
+
+
+@pytest.mark.parametrize(
+    ("obstacle", "error"), [("chmod000", PermissionError), ("directory", IsADirectoryError)]
+)
+def test_an_unreadable_store_is_an_error_never_an_empty_store(
+    workspace: Path, obstacle: str, error: type[OSError]
+) -> None:
+    """A-2 (gate Fable §5.2, round 08 — the DIFF subagent's A-1, reproduced by the gate in
+    two variants): `_read_bound` caught EVERY `OSError` and answered `(None, 0, 0)`, the
+    reading reserved for a file that is ABSENT — so an `items.json` with `chmod 000`, or a
+    directory standing where the file was, loaded as an EMPTY store. On the real index:
+    `status` healthy with `items_removed 2404`, `search` «0 resultados» exit 0 with nothing
+    declared, `update` planning `-2404 items`, and `build --force` replacing 22,286 chunks
+    with the 703 of the topic plane, sealed consistent, exit 0. The loader is the route
+    BEFORE seam (a), the one no door asks, and through it the whole fail-open family came
+    back with a destruction on top.
+
+    `load_store` (`store.py`) reads only an ABSENT file as `{}`; every other `OSError`
+    propagates. The loader now agrees: only `FileNotFoundError` is the empty store, and
+    `EACCES`/`EISDIR`/`EIO` raise, which the CLI prints as `Error: …` with exit 1.
+
+    Seen red on `36f694b`: `loaded.store == {}` on both obstacles, no exception.
+    """
+    _obstruct(workspace / "items.json", obstacle)
+    try:
+        with pytest.raises(error):
+            index_build.load_index_inputs(workspace / "items.json")
+    finally:
+        # Leave the temp dir removable whatever the outcome.
+        if obstacle == "chmod000":
+            (workspace / "items.json").chmod(0o644)
+
+
+def test_an_absent_store_still_reads_as_an_empty_store(tmp_path: Path) -> None:
+    """The positive control for the test above: ABSENT is the one reading that stays empty —
+    `load_store`'s own semantics, and what `StoreSignal.of` reports as zeros — so a fresh
+    checkout with no `data/` still loads, and only what EXISTS and cannot be read raises."""
+    loaded = index_build.load_index_inputs(tmp_path / "nope.json")
+    assert loaded.store == {}
+    assert loaded.signal == index_build.StoreSignal(items_json_mtime_ns=0, items_json_size=0)
+
+
+# ---------------------------------------------------------------------------
+# THREE INPUTS, NOT ONE — and the two fingerprints over the other two
+#
+# The snapshot's suite reached `items.json` on every door and reached `vocab.yaml` /
+# `topics.json` on none: `vocab_fingerprint` and `topics_fingerprint` had no direct test
+# anywhere in it, and no test loaded a workspace that contained the other two files at all.
+# Measured before writing these: the file was green at 14/14 with `load_index_inputs`
+# reduced to `vocab=[], topic_pages={}` and the four vocab/topics signal entries left at
+# zero — which is exactly the pre-round-05 defect P1a records, back with nothing to catch
+# it. This child owns the three-input read and the three fingerprints over it, so the tests
+# come with them (rule 1: each was seen red under the mutation named in its docstring).
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def three_inputs(tmp_path: Path, corpus) -> Path:
+    """A data/ directory holding ALL THREE inputs, written by the store's own writers."""
+    from xbrain.rubrics import save_vocab
+    from xbrain.store import save_store, save_topic_pages
+
+    store, vocab, pages = corpus
+    data = tmp_path / "data"
+    save_store(store, data / "items.json")
+    save_vocab(vocab, data / "vocab.yaml")
+    save_topic_pages(pages, data / "topics.json")
+    return data
+
+
+def test_load_index_inputs_reads_the_vocabulary_and_the_topic_pages_too(
+    three_inputs: Path, corpus
+) -> None:
+    """P1a at the loader: the index derives from THREE files, so the loader reads three.
+
+    A topic description enters every assigned item's PROFILE (spec §5.1.A) and the overviews
+    and notes are chunks the index serves, so a loader that reads `items.json` and defaults
+    the other two to empty builds an index missing the whole topic plane while every signal
+    it seals says the inputs were read. All six signal entries are the stat of the file that
+    was actually parsed.
+
+    Seen red under the mutation `vocab=[], topic_pages={}` with the four vocab/topics signal
+    entries left at zero — the pre-round-05 shape: `AssertionError` on the vocabulary, and
+    on `vocab_yaml_mtime_ns` once the parse was restored.
+    """
+    _store, vocab, pages = corpus
+    loaded = index_build.load_index_inputs(
+        three_inputs / "items.json", three_inputs / "vocab.yaml", three_inputs / "topics.json"
+    )
+
+    assert [t.slug for t in loaded.vocab] == [t.slug for t in vocab], "the vocabulary was read"
+    assert {t.slug: t.description for t in loaded.vocab} == {
+        t.slug: t.description for t in vocab
+    }, "descriptions included: they enter every assigned item's profile"
+    assert set(loaded.topic_pages) == set(pages), "the topic pages were read"
+    assert loaded.topic_pages["agent-evaluation"].overview == pages["agent-evaluation"].overview
+
+    for name, mtime_field, size_field in [
+        ("items.json", "items_json_mtime_ns", "items_json_size"),
+        ("vocab.yaml", "vocab_yaml_mtime_ns", "vocab_yaml_size"),
+        ("topics.json", "topics_json_mtime_ns", "topics_json_size"),
+    ]:
+        stat = (three_inputs / name).stat()
+        assert getattr(loaded.signal, mtime_field) == stat.st_mtime_ns, name
+        assert getattr(loaded.signal, size_field) == stat.st_size, name
+
+
+def test_an_unnamed_vocab_or_topics_path_reads_as_empty_with_a_zero_signal(
+    three_inputs: Path,
+) -> None:
+    """The two optional inputs default to absent, and absent is empty — never an error.
+
+    `load_index_inputs(items_path)` is the one-argument call every pre-round-05 caller made
+    and the CLI still makes for a corpus with no vocabulary yet. It must load, not raise.
+
+    Seen red under the mutation `_read_bound` without its `if path is None` guard:
+    `AttributeError: 'NoneType' object has no attribute 'open'`.
+    """
+    loaded = index_build.load_index_inputs(three_inputs / "items.json")
+    assert loaded.vocab == []
+    assert loaded.topic_pages == {}
+    assert (loaded.signal.vocab_yaml_mtime_ns, loaded.signal.vocab_yaml_size) == (0, 0)
+    assert (loaded.signal.topics_json_mtime_ns, loaded.signal.topics_json_size) == (0, 0)
+
+
+@pytest.mark.parametrize(
+    "obstacle, error", [("chmod000", PermissionError), ("directory", IsADirectoryError)]
+)
+@pytest.mark.parametrize("filename", ["vocab.yaml", "topics.json"])
+def test_an_unreadable_vocab_or_topics_is_an_error_never_an_empty_one(
+    three_inputs: Path, filename: str, obstacle: str, error: type[OSError]
+) -> None:
+    """A-2 reaches all three inputs, not only the one the gate happened to probe.
+
+    The fail-open family the gate found on `items.json` — an unreadable file read as the
+    empty value reserved for an absent one — is a property of `_read_bound`, and the loader
+    routes all three inputs through it. On `vocab.yaml` the same defect is quieter and no
+    less destructive: a `chmod 000` vocabulary loads as «no topics», so every profile is
+    built without its topic descriptions, `topic_rows_behind` sees an empty vocabulary and
+    `update` plans the deletion of the whole topic plane — sealed consistent, exit 0.
+
+    Seen red under the mutation `except OSError` in `_read_bound` (the pre-A-2 shape):
+    `DID NOT RAISE` on all four parametrisations.
+    """
+    _obstruct(three_inputs / filename, obstacle)
+    try:
+        with pytest.raises(error):
+            index_build.load_index_inputs(
+                three_inputs / "items.json",
+                three_inputs / "vocab.yaml",
+                three_inputs / "topics.json",
+            )
+    finally:
+        if obstacle == "chmod000":
+            (three_inputs / filename).chmod(0o644)
+
+
+def test_the_vocab_fingerprint_covers_the_descriptions_not_only_the_slugs(corpus) -> None:
+    """The descriptions are hashed because they are INDEXED TEXT, not metadata (spec §5.1.A).
+
+    A topic description enters the profile of every item assigned to it, so editing one
+    changes indexable text on the ITEM plane, not only on the topic plane. A fingerprint
+    over the slugs alone would leave `update` reporting nothing to do while every profile
+    the index serves quotes the old description — rule 6, on the plane the vocabulary owns.
+
+    And it is order-independent for the same reason `store_fingerprint` is: the order a
+    vocabulary happens to be loaded in is a property of the load, not of what it contains.
+
+    Seen red under three mutations: `f"{topic.slug}"` (the description dropped) on the
+    first assertion, `f"{topic.description}"` (the slug dropped) on the second, and
+    `sorted(...)` → `vocab` on the third. The rename PRESERVES SORT POSITION
+    (`agent-evaluationz` sorts where `agent-evaluation` did) so that the second assertion
+    cannot pass merely by reordering the concatenation — the way its first version did on
+    the topics fingerprint below.
+    """
+    _store, vocab, _pages = corpus
+    before = index_build.vocab_fingerprint(vocab)
+
+    edited = [
+        t.model_copy(update={"description": "otra descripción"}) if t.slug == vocab[0].slug else t
+        for t in vocab
+    ]
+    assert index_build.vocab_fingerprint(edited) != before, "a description edit moves it"
+
+    renamed = [t.model_copy(update={"slug": f"{t.slug}z"}) if t is vocab[0] else t for t in vocab]
+    assert sorted(t.slug for t in renamed) == [t.slug for t in renamed], "sort position kept"
+    assert index_build.vocab_fingerprint(renamed) != before, "and so does a slug"
+
+    assert index_build.vocab_fingerprint(list(reversed(vocab))) == before, "order-independent"
+
+
+def test_the_topics_fingerprint_covers_the_overview_every_note_and_the_slug(corpus) -> None:
+    """The synthesised text of the topic plane, hashed through the SAME emitter the index uses.
+
+    `topic_overview` and `topic_note` are surface types the index stores and `search`
+    serves, so each is hashed through `surface_fingerprint` — the one definition — rather
+    than through a second concatenation that could drift from it (rule 5). Three axes, and
+    each is a chunk a consumer can be served: the overview, ANY note (not just the first),
+    and the slug those chunks are filed under.
+
+    THE RENAME PRESERVES SORT POSITION ON PURPOSE. The first version of this assertion
+    refiled the page as `renombrado`, which sorts AFTER `ai-policy` — so the two pages'
+    text swapped places in the concatenation and the hash moved whether or not the slug was
+    hashed at all. Measured: under the mutant `parts.append(slug)` deleted, that version
+    stayed GREEN and only `test_the_topics_fingerprint_agrees_with_the_emitter` went red.
+    Rule 1, in the test written to pin the slug. `agent-evaluationz` sorts where
+    `agent-evaluation` did, so the slug is the only thing that changed.
+
+    Seen red under two mutations: dropping the notes comprehension (the second assertion)
+    and `parts.append(slug)` deleted (the third). Hashing `page.overview` directly instead
+    of through `surface_fingerprint` stays GREEN here and is caught by
+    `test_the_topics_fingerprint_agrees_with_the_emitter` below — the reason that test
+    exists.
+    """
+    _store, _vocab, pages = corpus
+    before = index_build.topics_fingerprint(pages)
+
+    page = pages["agent-evaluation"]
+    assert len(page.notes) >= 2, "this test is only meaningful on a page with several notes"
+
+    edited = {**pages, "agent-evaluation": page.model_copy(update={"overview": "otro resumen"})}
+    assert index_build.topics_fingerprint(edited) != before, "the overview is hashed"
+
+    last_note_changed = page.model_copy(update={"notes": [*page.notes[:-1], "otra nota"]})
+    edited = {**pages, "agent-evaluation": last_note_changed}
+    assert index_build.topics_fingerprint(edited) != before, "and EVERY note, not just the first"
+
+    refiled = {("agent-evaluationz" if s == "agent-evaluation" else s): p for s, p in pages.items()}
+    assert sorted(refiled) == ["agent-evaluationz", "ai-policy"], "the sort position is unchanged"
+    assert index_build.topics_fingerprint(refiled) != before, "and the slug they are filed under"
+
+
+def test_the_topics_fingerprint_agrees_with_the_emitter(corpus) -> None:
+    """One definition of "what a topic-page surface is", shared with `knowledge.ids` (rule 5).
+
+    The fingerprint is asserted against `surface_fingerprint` computed HERE from the page's
+    own text, so a change to the emitter's `(version, type, origin, text)` shape moves this
+    fingerprint too and the index re-derives. Hashing the raw text instead would leave a
+    `SURFACE_VERSION` bump invisible to the topic plane while every item plane re-indexed.
+
+    This is NOT the tautology `topics_fingerprint is topics_fingerprint`: the expected value
+    is rebuilt from the page objects through the public emitter, so a version bump inside
+    `surface_fingerprint` propagates to both sides but a change to the *composition* — the
+    surface types used, the order, the slug — moves only one. Seen red under the mutation
+    `surface_fingerprint("topic_note", ...)` → `surface_fingerprint("topic_overview", ...)`
+    for the notes, which every other test in this file passes.
+    """
+    import hashlib
+
+    from xbrain.knowledge.ids import surface_fingerprint
+
+    _store, _vocab, pages = corpus
+    parts: list[str] = []
+    for slug in sorted(pages):
+        page = pages[slug]
+        parts.append(surface_fingerprint("topic_overview", "llm", page.overview))
+        parts += [surface_fingerprint("topic_note", "llm", note) for note in page.notes]
+        parts.append(slug)
+    expected = hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+
+    assert index_build.topics_fingerprint(pages) == expected
+
+
+def test_the_index_loader_and_the_store_doors_parse_through_one_parser_each(
+    three_inputs: Path, corpus
+) -> None:
+    """The seam `parse_store` / `parse_vocab` / `parse_topic_pages` exists FOR THIS (rule 5).
+
+    `load_index_inputs` must bind what it parsed to the exact bytes it read, so it reads
+    through its own handle — and the only honest way to do that without a second copy of
+    every parse is to split the parse out of `load_store` / `load_vocab` /
+    `load_topic_pages` and share it. The property that matters is not "the seam exists" (a
+    tautology the moment it does) but that the TWO READERS OF THE SAME BYTES agree: the
+    path-based door every other stage uses, and the handle-based one the index uses.
+
+    Seen red under the mutation `parse_vocab` → `data.get("topics")` without `Topic(**entry)`
+    (raw dicts out of one door, `Topic` out of the other) and under a `load_index_inputs`
+    that parsed the store with a bare `json.loads`.
+    """
+    from xbrain.rubrics import load_vocab
+    from xbrain.store import load_store, load_topic_pages
+
+    loaded = index_build.load_index_inputs(
+        three_inputs / "items.json", three_inputs / "vocab.yaml", three_inputs / "topics.json"
+    )
+
+    assert loaded.store == load_store(three_inputs / "items.json")
+    assert loaded.vocab == load_vocab(three_inputs / "vocab.yaml")
+    assert loaded.topic_pages == load_topic_pages(three_inputs / "topics.json")

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -421,9 +421,10 @@ def test_the_item_fingerprint_covers_the_topics_the_item_plane_persists(
 def test_the_item_fingerprint_covers_a_content_kind_that_emits_no_surface(corpus) -> None:
     """`item_content_kinds` is a persisted plane, and a kind can arrive with no text at all.
 
-    A no-speech `x_video` (107 of 259 in the corpus) fetched without `--frames` has an empty
-    transcript, no frames and no digest, so it emits NOT ONE surface — and it is still a video
-    the index records in `item_content_kinds` and a kind filter answers from. Measured under
+    A no-speech `x_video` (108 of 260, re-derived 2026-09-03 on store `f76341a3…`; the 107 of
+    259 this replaces was undated, and the corpus moved) fetched without `--frames` has an
+    empty transcript, no frames and no digest, so it emits NOT ONE surface — and it is still a
+    video the index records in `item_content_kinds` and a kind filter answers from. Measured
     the mutant that deletes the sorted-kinds region: green, because every kind in the fixture
     arrives attached to a surface that moves the hash on its own.
 

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -2,8 +2,9 @@
 """The three inputs of the index, the signal bound to them, and their fingerprints
 (Plan 02 §2, §3, steps 3, 4, 9).
 
-TWO SIGNALS, TWO COSTS, TWO PLACES (B3). `store_signal` is an `os.stat` — mtime and size of
-`data/items.json` — and it is what a QUERY can afford on every call. `store_fingerprint` is a
+TWO SIGNALS, TWO COSTS, TWO PLACES (B3). `StoreSignal` is three `os.stat` — mtime and size of
+`data/items.json`, `data/vocab.yaml` and `data/topics.json` (P1a, gate Codex round 05) — and it
+is what a QUERY can afford on every call. `store_fingerprint` is a
 sha256 per item and costs loading the store, so it is paid only by `build`, `update` and
 `status`. The cheap one says *the store moved*; the expensive one says *which items changed,
 and how many*. A false positive on the cheap one costs one warning; a false negative costs
@@ -19,7 +20,7 @@ from pathlib import Path
 import pytest
 
 from xbrain.knowledge import index_build
-from xbrain.knowledge.surfaces import item_surfaces
+from xbrain.knowledge.surfaces import item_surfaces, item_topics
 from xbrain.models import Item, Topic, TopicPage
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -212,6 +213,108 @@ def test_the_item_fingerprint_covers_the_locator_not_only_the_url_the_id_hashes(
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
 
 
+# The positions of three `surfaces` columns inside `SurfaceRow`, written out BY HAND — which is
+# exactly what `surface_row`'s docstring says the correspondence with the persisted DDL still is
+# in this child. 02.7 owes the writer that binds the tuple to the `INSERT` and the readback that
+# makes it structural; naming the positions here only lets an assertion say WHICH column it pins
+# instead of pointing at a bare integer, and it adds no guard `surface_row` does not have.
+URL_COLUMN = 10
+LOCATOR_JSON_COLUMN = 11
+FINGERPRINT_COLUMN = 13
+CHAR_LENGTH_COLUMN = 14
+
+
+def test_the_row_carries_the_url_column_the_schema_persists_beside_the_locator_json(
+    corpus,
+) -> None:
+    """`surfaces.url` is a persisted column of its own, and no test in this file pinned it.
+
+    Two independent reviews reached OPPOSITE readings of the same green mutant, and the
+    disagreement is why this test exists. Dropping `surface.locator.url` from `surface_row`
+    leaves the whole file green: one review read that as an unprotected persisted column,
+    the other as an EQUIVALENT mutant, because the same url is serialised a second time
+    inside `locator_json` and the hash therefore cannot see the first copy disappear. Both
+    measured correctly, and only the second is a statement about the FINGERPRINT. The column
+    is unobservable in the hash and perfectly observable in the PROJECTION, so it is pinned
+    here, on the row, and never through `item_fingerprint` — a test claiming the hash sees it
+    would be pinning the json (rule 1, backwards).
+
+    What is asserted is the very redundancy the second reading rests on, turned from a
+    rationale into an invariant: the two persisted columns must carry the SAME url, on every
+    surface of the corpus. `search` serves `url` on every match (A-1), so a reader resolves a
+    hit back to its bytes through the column without deserialising the locator; a projection
+    that dropped it while `locator_json` kept it would leave the two disagreeing, which is
+    precisely what the mutant does and what this assertion refuses.
+
+    The two preconditions are what stop it passing for the wrong reason: a corpus whose
+    locators all carried `None` would pass with the column deleted, and one where none did
+    would never exercise the `NULL` the DDL allows on it. The fixture holds both — a `post`
+    locates by url, a `summary` by nothing — and that is asserted before anything else is.
+
+    Seen red under the mutant `surface.locator.url` -> `None`, on every surface that has one.
+    """
+    store, _vocab, _pages = corpus
+    rows = [
+        index_build.surface_row(surface)
+        for item in store.values()
+        for surface in item_surfaces(item)
+    ]
+    located = [row for row in rows if json.loads(row[LOCATOR_JSON_COLUMN])["url"] is not None]
+    unlocated = [row for row in rows if json.loads(row[LOCATOR_JSON_COLUMN])["url"] is None]
+    assert located, "some surface must locate by url, or the column is asserted against nothing"
+    assert unlocated, "and some by none, or the NULL the schema allows is never exercised"
+
+    for row in rows:
+        assert row[URL_COLUMN] == json.loads(row[LOCATOR_JSON_COLUMN])["url"], row[0]
+
+
+def test_the_item_fingerprint_covers_the_surface_fingerprint_column_not_its_length(
+    corpus,
+) -> None:
+    """The column that carries the BODY, isolated from the column that carries its length.
+
+    `surface_row` has no text column — the last one is `len(surface.text)` (spec §10.8) — so
+    `surface.fingerprint` is the only thing standing between *the body changed* and an index
+    reporting nothing to do. Nothing pinned it: `surface.fingerprint` -> `None` in
+    `surface_row` left this whole file green. The reason is rule 1's first row, an assertion
+    satisfied by another column — the flagship text test replaces a 48-character summary with
+    a 12-character one, so it moves the fingerprint column AND the length column, and passes
+    through the second when the first is gone.
+
+    So the edit here KEEPS THE LENGTH: 48 characters of summary become 48 different ones, one
+    word swapped for another of the same width. Measured on the shipped code that moves
+    exactly one row and exactly one column of it; with the mutant applied it moves none, and
+    a hand-corrected summary would leave `update` reporting the item current while the index
+    goes on serving the old body — rule 6, on the only column that carries the text.
+
+    Seen red under the mutant `surface.fingerprint` -> `None`: no column moves at all, so the
+    "exactly one column" assertion fails before the fingerprint assertion is reached.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    summary = item.enriched.summary
+    rewritten = summary.replace("recall", "sesgos")
+    assert len(rewritten) == len(summary) and rewritten != summary, (
+        "a body edit that leaves the length untouched is the whole construction"
+    )
+
+    edited = item.model_copy(
+        update={"enriched": item.enriched.model_copy(update={"summary": rewritten})}
+    )
+    before = [index_build.surface_row(s) for s in item_surfaces(item)]
+    after = [index_build.surface_row(s) for s in item_surfaces(edited)]
+    moved = [i for i, (a, b) in enumerate(zip(before, after, strict=True)) if a != b]
+    assert len(moved) == 1, "exactly one surface row moves: the summary whose body was rewritten"
+    row_before, row_after = before[moved[0]], after[moved[0]]
+    columns = [i for i, (a, b) in enumerate(zip(row_before, row_after, strict=True)) if a != b]
+    assert columns == [FINGERPRINT_COLUMN], "and exactly one column of it: the fingerprint"
+    assert row_after[CHAR_LENGTH_COLUMN] == row_before[CHAR_LENGTH_COLUMN], (
+        "the length column did not move, so it cannot be what carries this edit"
+    )
+
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
+
+
 @pytest.mark.parametrize(
     "axis, value",
     [
@@ -257,6 +360,101 @@ def test_the_item_fingerprint_covers_the_item_plane_no_surface_carries(
     rows = [index_build.surface_row(s) for s in surfaces]
 
     edited = item.model_copy(update={axis: Author(**value) if axis == "author" else value})
+    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
+        "no surface row may move, or the fingerprint could differ for another reason"
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), axis
+
+
+@pytest.mark.parametrize("half, value", [("handle", "otravoz"), ("name", "Otra Voz")])
+def test_the_item_fingerprint_covers_the_author_handle_and_the_name_apart(
+    corpus, half: str, value: str
+) -> None:
+    """`items.author_handle` and `items.author_name` are TWO columns, so they need two cases.
+
+    The parametrised test above changes both halves of the author at once, so either half
+    could vanish from `item_fingerprint` and its assertion would still be satisfied by the
+    other — rule 1's first row again, hiding inside a case that does look isolated. Measured:
+    deleting `item.author.name` alone leaves this file green, and so does deleting
+    `item.author.handle` alone; only deleting the pair goes red.
+
+    Each case here moves exactly ONE of them and leaves the other byte-identical, so a case
+    can only pass through the half it names. The construction is the one the test above
+    documents: k02's text is blanked so no `post` surface is emitted and its `enriched`
+    carries no `user_notes`, leaving one `summary` surface attributed to nobody — otherwise
+    `item.author` is also the surface's attribution and the assertion would move through
+    `surface_row` with the metadata half deleted.
+
+    It is observable, and on the repair this repo has already paid for: `refresh-quoted`
+    corrects a display name without touching the handle, and with the name unhashed `update`
+    would report `0 cambiados` while `search` keeps serving the old attribution (rule 6).
+
+    Seen red under two mutants applied separately: `item.author.name` deleted from
+    `item_fingerprint` (the `name` case, the `handle` case still green) and
+    `item.author.handle` deleted (the `handle` case, the `name` case still green).
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"].model_copy(update={"text": ""})
+    surfaces = item_surfaces(item)
+    assert [s.surface_type for s in surfaces] == ["summary"], (
+        "the base item must carry a surface, and not one that repeats the item's author"
+    )
+    rows = [index_build.surface_row(s) for s in surfaces]
+
+    author = item.author.model_copy(update={half: value})
+    assert getattr(author, half) != getattr(item.author, half), "the half under test moved"
+    other = "name" if half == "handle" else "handle"
+    assert getattr(author, other) == getattr(item.author, other), "and the other did not"
+
+    edited = item.model_copy(update={"author": author})
+    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
+        "no surface row may move, or the fingerprint could differ for another reason"
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), half
+
+
+@pytest.mark.parametrize(
+    "axis, patch, topics_after",
+    [
+        ("topics", {"topics": ["agent-evaluation"]}, ("agent-evaluation",)),
+        (
+            "primary_topic",
+            {"primary_topic": "observability"},
+            ("observability", "agent-evaluation"),
+        ),
+    ],
+)
+def test_the_item_fingerprint_covers_the_topics_the_item_plane_persists(
+    corpus, axis: str, patch: dict[str, object], topics_after: tuple[str, ...]
+) -> None:
+    """`topics` is the sixth member of the list `item_fingerprint`'s own docstring enumerates.
+
+    That docstring names the filterable metadata as «source, author, date, topics, content
+    kinds». Five of the six have a test; `topics` had none — `*item_topics(item)` could be
+    deleted from `parts` with this whole file green, because every topic in the fixture
+    belongs to an item whose surfaces move for some other reason.
+
+    It is observable, and it is a repair the pipeline performs routinely: re-run `xbrain
+    topics`, reassign an item, and with the block deleted `update` reports `0 cambiados`
+    while `--topic` goes on serving the old assignment out of `item_topics` (rule 6).
+
+    TWO AXES, BECAUSE THE TABLE PERSISTS TWO THINGS. `item_topics` (`index_schema`) stores
+    `slug` and `is_primary`, and `item_topics()` encodes the second as ORDER — primary first,
+    then the rest, deduplicated. So one case changes the membership with the primary fixed,
+    the other changes the primary with the membership fixed, and each names the tuple it
+    expects: a hash over the set alone would pass the first and fail the second.
+
+    Guarded like the item-plane cases above: not one surface row may move, so the fingerprint
+    cannot have moved through the surfaces instead. Seen red under the mutant that deletes
+    `*item_topics(item)` from `parts` — both cases, and nothing else in the file.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    rows = [index_build.surface_row(s) for s in item_surfaces(item)]
+
+    edited = item.model_copy(update={"enriched": item.enriched.model_copy(update=patch)})
+    assert item_topics(edited) == topics_after, "the case moved the axis it names"
+    assert item_topics(item) != topics_after, "and the base item did not already read that way"
     assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
         "no surface row may move, or the fingerprint could differ for another reason"
     )
@@ -533,6 +731,54 @@ def test_an_unnamed_vocab_or_topics_path_reads_as_empty_with_a_zero_signal(
     assert loaded.topic_pages == {}
     assert (loaded.signal.vocab_yaml_mtime_ns, loaded.signal.vocab_yaml_size) == (0, 0)
     assert (loaded.signal.topics_json_mtime_ns, loaded.signal.topics_json_size) == (0, 0)
+
+
+@pytest.mark.parametrize(
+    "filename, mtime_field, size_field",
+    [
+        ("items.json", "items_json_mtime_ns", "items_json_size"),
+        ("vocab.yaml", "vocab_yaml_mtime_ns", "vocab_yaml_size"),
+        ("topics.json", "topics_json_mtime_ns", "topics_json_size"),
+    ],
+)
+def test_the_query_time_signal_watches_each_of_the_three_inputs(
+    three_inputs: Path, filename: str, mtime_field: str, size_field: str
+) -> None:
+    """P1a's OTHER half: `StoreSignal.of` is the side a query pays, and it had one file tested.
+
+    The loader half is covered — a `load_index_inputs` that defaulted the vocabulary and the
+    topic pages to empty goes red above. `StoreSignal.of` is the comparison every `search`
+    makes against what the manifest sealed, and only `items.json` was ever asserted on it, so
+    `of` could be returned to watching one file — the exact pre-round-05 defect P1a records,
+    where `xbrain topics` wrote `topics.json`, never touched `items.json`, and every later
+    query answered over the old topic plane with nothing declared (spec §9.3 forbids that
+    silence). Measured: zeroing the vocab and topics stats inside `of` left this file green.
+
+    One case per input, each asserting only its own file's two entries, so zeroing ONE stat
+    reddens exactly one case and names which input lost its watch.
+
+    THE THREE SIZES MUST DIFFER, and that is asserted first (rule 1). Compared against its own
+    file's `stat`, an entry that had been filled from a DIFFERENT input's stat would still
+    pass wherever the two files happened to agree; distinct sizes make each assertion
+    answerable only by the file it names. A zero cannot be right either, which the non-empty
+    precondition states.
+
+    Seen red under three mutants applied separately, one per line of `of`: `_stat_signal(…)`
+    -> `(0, 0)` for the items, the vocabulary and the topic pages, each reddening its own case
+    and leaving the other two green.
+    """
+    sizes = [
+        (three_inputs / name).stat().st_size for name in ("items.json", "vocab.yaml", "topics.json")
+    ]
+    assert len(set(sizes)) == 3, "distinct sizes, or one file's stat could satisfy another's entry"
+    assert all(sizes), "and none empty, or a zeroed entry would be indistinguishable from the truth"
+
+    signal = index_build.StoreSignal.of(
+        three_inputs / "items.json", three_inputs / "vocab.yaml", three_inputs / "topics.json"
+    )
+    stat = (three_inputs / filename).stat()
+    assert getattr(signal, mtime_field) == stat.st_mtime_ns, filename
+    assert getattr(signal, size_field) == stat.st_size, filename
 
 
 @pytest.mark.parametrize(

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -13,11 +13,13 @@ serving stale evidence as fresh, so it fails towards the warning.
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
 from xbrain.knowledge import index_build
+from xbrain.knowledge.surfaces import item_surfaces
 from xbrain.models import Item, Topic, TopicPage
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -122,17 +124,21 @@ def test_the_item_fingerprint_covers_what_the_index_stores_about_a_surface(
     for in blood.
 
     Four axes, one parametrised test, each changing ONE field of k07's quoted post and
-    nothing else. The url moves the locator too (`locator.url`), which is the point: the
-    locator is what the consumer resolves the evidence through. `producer` is deliberately
-    NOT here — the index has no producer column, and since round 08 (F7-7) the ASR/VLM
-    surfaces carry none at all, because the store records no transcriber; the producers
-    that ARE recorded (`enriched.executor`, `description_version`) travel with the surface
-    and are not stored columns either.
+    nothing else. The `url` case moves the locator columns but does NOT pin them: it is
+    satisfied through `surface_id`, which hashes the source's kind and url, and it stays
+    green with both locator columns dropped from `surface_row` (round 09, B1). What pins
+    the locator is the test below, which moves a locator field `surface_id` cannot reach.
+
+    `producer` is deliberately NOT here — the index has no producer column, and since round
+    08 (F7-7) the ASR/VLM surfaces carry none at all, because the store records no
+    transcriber; the producers that ARE recorded (`enriched.executor`,
+    `description_version`) travel with the surface and are not stored columns either.
 
     Seen red before the fix on all four: the fingerprint did not move. Seen red again here
     under the mutant `surface_row` → `(None, None, None, …)`, which the file passed 90/90
-    before this test was restored: `surface_row` is the projection `item_fingerprint`
-    hashes, so a column dropped from it is a column the index stores and never re-hashes.
+    before this test was restored — on three of the four, the `url` case being the exception
+    named above: `surface_row` is the projection `item_fingerprint` hashes, so a column
+    dropped from it is a column the index stores and never re-hashes.
     """
     from xbrain.models import Author
 
@@ -146,6 +152,182 @@ def test_the_item_fingerprint_covers_what_the_index_stores_about_a_surface(
         update={"content": item.content.model_copy(update={"sources": sources})}
     )
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), field
+
+
+def test_the_item_fingerprint_covers_the_locator_not_only_the_url_the_id_hashes(
+    corpus,
+) -> None:
+    """The LOCATOR column, which the `[url]` case above does not reach (round 09, B1).
+
+    That case moves the fingerprint through `surface_id`, which hashes the source's kind
+    and url — so it is satisfied with BOTH locator columns dropped from `surface_row`, and
+    the mutant that returns `None` and `""` for `surface.locator.url` and
+    `surface.locator.model_dump_json()` leaves the file green. That is rule 1's first row:
+    an assertion satisfied for the wrong reason, on the projection this child owns.
+
+    `Locator` carries eleven fields and ten of them reach the persisted `locator_json`
+    column (`index_schema`) through no other hashed path. They are how a reader resolves a
+    claim back to the bytes it came from — a frame timestamp says WHERE in the video the
+    slide is, `char_start`/`char_end` say where in a body a quote is — which is the whole
+    mechanism CLAUDE.md rule 7 rests on.
+
+    So this moves exactly one of them: k08's first video frame keeps its description, its
+    `frame_index`, its `source_key` and its source, and only its `frame_timestamp` changes.
+    The two guards are what make it bite for the reason it names — exactly one surface row
+    moves, in exactly one column, and that column deserialises to the new timestamp.
+
+    The sibling column `surface.locator.url` is a DUPLICATE of a field `model_dump_json()`
+    also serialises, so dropping it ALONE is unobservable in the hash by construction: no
+    test can pin it, and one claiming to would be pinning the json.
+
+    Seen red under the mutant that drops the two locator columns from `surface_row`.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k08"]
+    position = next(i for i, s in enumerate(item.content.sources) if s.kind == "x_video")
+    video = item.content.sources[position]
+    assert video.frames, "this test needs a video the index locates frames inside"
+
+    frames = list(video.frames)
+    moved_to = frames[0].timestamp + 37.0
+    frames[0] = frames[0].model_copy(update={"timestamp": moved_to})
+    sources = list(item.content.sources)
+    sources[position] = video.model_copy(update={"frames": frames})
+    edited = item.model_copy(
+        update={"content": item.content.model_copy(update={"sources": sources})}
+    )
+
+    before = [index_build.surface_row(s) for s in item_surfaces(item)]
+    after = [index_build.surface_row(s) for s in item_surfaces(edited)]
+    changed = [i for i, (a, b) in enumerate(zip(before, after, strict=True)) if a != b]
+    assert len(changed) == 1, "exactly one surface row moves: the one whose timestamp changed"
+    row_before, row_after = before[changed[0]], after[changed[0]]
+    columns = [i for i, (a, b) in enumerate(zip(row_before, row_after, strict=True)) if a != b]
+    assert len(columns) == 1, "and exactly one column of that row"
+    assert json.loads(row_after[columns[0]])["frame_timestamp"] == moved_to, (
+        "the column that moved is the serialised locator, carrying the new timestamp"
+    )
+    assert json.loads(row_before[columns[0]])["frame_timestamp"] == video.frames[0].timestamp
+
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
+
+
+@pytest.mark.parametrize(
+    "axis, value",
+    [
+        ("author", {"handle": "someoneelse", "name": "Someone Else"}),
+        ("created_at", datetime(2026, 6, 1, 9, 0, tzinfo=timezone.utc)),
+        ("captured_at", datetime(2026, 6, 2, 9, 0, tzinfo=timezone.utc)),
+        ("bookmark_folder", "to-read"),
+    ],
+)
+def test_the_item_fingerprint_covers_the_item_plane_no_surface_carries(
+    corpus, axis: str, value: object
+) -> None:
+    """The other half of the hash: the `items` columns, pinned where no surface pins them.
+
+    `items` persists `author_handle`, `author_name`, `created_at`, `captured_at` and
+    `bookmark_folder` (`index_schema`), and `items_author` is the index `--author` answers
+    from. The test above pins `source` and nothing else: measured under the mutant that
+    deletes the rest from `item_fingerprint`, this file stayed green, so `item.author`
+    could change and `update` report nothing to do — the evidence repaired and the
+    derivative standing (rule 6), one plane up from G-5 and on the same attribution axis.
+
+    THE BASE ITEM CARRIES NO POST SURFACE, AND THAT IS THE WHOLE CONSTRUCTION (rule 1).
+    `item.author` is ALSO the attribution of the `post` surface and of a `user_note`
+    (`surfaces.item_surfaces`), so on an ordinary item this assertion moves through
+    `surface_row` and passes with the metadata half deleted — satisfied for the wrong
+    reason, which is what the round-09 mutants found. k02's text is blanked so no `post`
+    surface is emitted, and its `enriched` carries no `user_notes`: one `summary` surface
+    remains, attributed to nobody.
+
+    So every case asserts twice: that not one surface row moved — the only other input to
+    this hash — and that the fingerprint moved anyway. Delete the axis from the metadata
+    half and the second assertion fails; the first is what proves it could not have passed
+    through the surfaces instead.
+    """
+    from xbrain.models import Author
+
+    store, _vocab, _pages = corpus
+    item = store["k02"].model_copy(update={"text": ""})
+    surfaces = item_surfaces(item)
+    assert [s.surface_type for s in surfaces] == ["summary"], (
+        "the base item must carry a surface, and not one that repeats the item's author"
+    )
+    rows = [index_build.surface_row(s) for s in surfaces]
+
+    edited = item.model_copy(update={axis: Author(**value) if axis == "author" else value})
+    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
+        "no surface row may move, or the fingerprint could differ for another reason"
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), axis
+
+
+def test_the_item_fingerprint_covers_a_content_kind_that_emits_no_surface(corpus) -> None:
+    """`item_content_kinds` is a persisted plane, and a kind can arrive with no text at all.
+
+    A no-speech `x_video` (107 of 259 in the corpus) fetched without `--frames` has an
+    empty transcript, no frames and no digest, so it emits NOT ONE surface — and it is
+    still a video the index records in `item_content_kinds` and a kind filter answers
+    from. Measured under the mutant that deletes the sorted-kinds block from
+    `item_fingerprint`: green, because every kind in the fixture arrives attached to a
+    surface that moves the hash on its own.
+
+    The hash is over the sorted MULTISET while the table's primary key is
+    `(item_id, kind)` — a set — so a duplicated kind moves the fingerprint without
+    changing the stored plane: the accepted false positive, failing towards the warning
+    like everything else in this module. This case adds a kind the item did not have at
+    all, so it moves both.
+
+    Guarded like the item-plane cases above, and here the guard is also the evidence: the
+    surface rows are identical precisely BECAUSE the silent video emitted nothing. The
+    only other field the patch touches is `content.fetched_at`, which is hashed nowhere —
+    deliberately, and that is the subject of this module's docstring.
+    """
+    from xbrain.models import Content, ContentSourceSuccess
+
+    store, _vocab, _pages = corpus
+    item = store["k02"]
+    assert item.content is None, "the base item must start with no content source at all"
+    rows = [index_build.surface_row(s) for s in item_surfaces(item)]
+
+    silent = ContentSourceSuccess(
+        kind="x_video", url="https://video.example/silent.mp4", text="", has_speech=False
+    )
+    edited = item.model_copy(
+        update={"content": Content(fetched_at=item.captured_at, sources=[silent])}
+    )
+    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
+        "a silent video with no frames and no digest emits no surface"
+    )
+    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
+
+
+def test_the_leading_surface_version_is_the_belt_for_an_item_with_no_surfaces(
+    corpus, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An emitter-version bump has to reach an item that emits nothing.
+
+    `SURFACE_VERSION` is hashed twice over: once at the head of `item_fingerprint`'s parts
+    and once inside every `surface.fingerprint`. For any item that HAS a surface the second
+    copy carries it, which is why deleting the first left this file green — no test held an
+    item with zero surfaces. Such items exist: k01 has no content, no media and no
+    `enriched`, so blanking its text leaves the emitter with nothing to emit, and the
+    leading copy is the only place the version can still reach it. Without it, a bump would
+    leave that item's fingerprint unchanged and `update` would report it current under an
+    emitter version that no longer describes how it would be emitted.
+
+    Patching this module's binding alone is an EXACT simulation here rather than a partial
+    one: a real bump also travels through `ids.surface_fingerprint`, and this item has no
+    surface for it to travel through.
+    """
+    store, _vocab, _pages = corpus
+    item = store["k01"].model_copy(update={"text": ""})
+    assert item_surfaces(item) == (), "the belt is load-bearing only with no surfaces"
+
+    before = index_build.item_fingerprint(item)
+    monkeypatch.setattr(index_build, "SURFACE_VERSION", index_build.SURFACE_VERSION + "-next")
+    assert index_build.item_fingerprint(item) != before
 
 
 def test_the_store_fingerprint_is_order_independent(corpus) -> None:

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -2,13 +2,9 @@
 """The three inputs of the index, the signal bound to them, and their fingerprints
 (Plan 02 §2, §3, steps 3, 4, 9).
 
-TWO SIGNALS, TWO COSTS, TWO PLACES (B3). `StoreSignal` is three `os.stat` — mtime and size of
-`data/items.json`, `data/vocab.yaml` and `data/topics.json` (P1a, gate Codex round 05) — and it
-is what a QUERY can afford on every call. `store_fingerprint` is a
-sha256 per item and costs loading the store, so it is paid only by `build`, `update` and
-`status`. The cheap one says *the store moved*; the expensive one says *which items changed,
-and how many*. A false positive on the cheap one costs one warning; a false negative costs
-serving stale evidence as fresh, so it fails towards the warning.
+TWO SIGNALS, TWO COSTS, TWO PLACES (B3) — three `os.stat` over the three inputs against one
+sha256 per item. The argument for the split, and the direction each fails in, is stated once,
+in `index_build.py`'s module docstring; it is not restated here.
 """
 
 from __future__ import annotations
@@ -36,15 +32,34 @@ def corpus() -> tuple[dict[str, Item], list[Topic], dict[str, TopicPage]]:
 
 
 @pytest.fixture()
-def workspace(tmp_path: Path, corpus) -> Path:
-    """A data/ directory holding the fixture store, so `store_signal` has a real file."""
-    store, _vocab, _pages = corpus
+def three_inputs(tmp_path: Path, corpus) -> Path:
+    """A data/ directory holding ALL THREE inputs, written by the store's own writers."""
+    from xbrain.rubrics import save_vocab
+    from xbrain.store import save_store, save_topic_pages
+
+    store, vocab, pages = corpus
     data = tmp_path / "data"
-    data.mkdir()
-    (data / "items.json").write_text(
-        json.dumps({k: v.model_dump(mode="json") for k, v in store.items()}), encoding="utf-8"
-    )
+    save_store(store, data / "items.json")
+    save_vocab(vocab, data / "vocab.yaml")
+    save_topic_pages(pages, data / "topics.json")
     return data
+
+
+def test_the_canonical_encoding_is_injective_where_ensure_ascii_would_not_be() -> None:
+    """`ensure_ascii=True` collides a lone surrogate PAIR with the astral character it spells
+    — `json.dumps` emits `"\\ud83d\\ude00"` for both — so the setting is a correctness choice
+    and until now only prose held it: measured, the whole file stays GREEN under the mutant
+    `ensure_ascii=False` -> `True`. Asserted on the ENCODER because the surrogate side raises
+    at `_sha256`'s `.encode("utf-8")`, which is fail-closed and not a hash to compare.
+    """
+    assert index_build._canonical("t", ["\ud83d\ude00"]) != index_build._canonical(
+        "t", ["\U0001f600"]
+    )
+
+
+def _rows(item: Item) -> list[index_build.SurfaceRow]:
+    """The surface rows of one item — the exact call every guard below makes, named once."""
+    return [index_build.surface_row(surface) for surface in item_surfaces(item)]
 
 
 # ---------------------------------------------------------------------------
@@ -55,40 +70,24 @@ def workspace(tmp_path: Path, corpus) -> Path:
 def test_the_item_fingerprint_changes_when_indexable_text_changes(corpus) -> None:
     """It hashes the SURFACES, not `(fetched_at, enriched_at)` as Plan 01 §10 sketched.
 
-    Two reasons, and CLAUDE.md rule 6 is both of them. First, `content.fetched_at` cannot
-    reach an item whose `content` is `None` — 960 of 2,404 in the real store (measured
-    2026-09-01 on sha256 `f76341a3…`) — because there
-    is nothing to stamp. Second, a timestamp is a PROXY: a summary edited by hand, or any
-    repair that rewrites text without touching a clock, changes the indexable corpus and
-    leaves the proxy unmoved, so the index would keep serving the old body under a
-    fingerprint that says it is current.
-
-    Hashing the emitted surface fingerprints answers the question directly — *did the text
-    this index holds change?* — and it reaches every item, with or without `content`.
+    CLAUDE.md rule 6 twice over — a timestamp cannot reach the 960 of 2,404 items with no
+    `content` at all, and it is a PROXY that a hand edit leaves unmoved. The measurement and
+    the argument live in `index_build.py`'s module docstring; what this test adds is the
+    executable half. The `content is None` precondition is the POPULATION half of rule 6 and
+    not decoration: on this item a fingerprint over `content.fetched_at` would be constant
+    forever, so it is what makes the edit below observable at all. (A second test asserting
+    only that was a strict subset of this one — same item, same patch, same assertion — and
+    no mutation could redden one without the other, so its precondition moved here.)
     """
     store, _vocab, _pages = corpus
     item = store["k02"]
+    assert item.content is None, "a fingerprint over `content.fetched_at` could not reach it"
     before = index_build.item_fingerprint(item)
     edited = item.model_copy(
         update={"enriched": item.enriched.model_copy(update={"summary": "otro resumen"})}
     )
     assert index_build.item_fingerprint(edited) != before
     assert index_build.item_fingerprint(item) == before, "and it is stable"
-
-
-def test_the_item_fingerprint_reaches_an_item_with_no_content(corpus) -> None:
-    """Step 6 / rule 6: the invalidation signal must reach the population it has to reach.
-
-    `k02` carries no `content` at all, so a fingerprint over `content.fetched_at` would be
-    constant for it forever. Seen red by hashing only the timestamps.
-    """
-    store, _vocab, _pages = corpus
-    item = store["k02"]
-    assert item.content is None, "this test is only meaningful on an item with no content"
-    edited = item.model_copy(
-        update={"enriched": item.enriched.model_copy(update={"summary": "otro resumen"})}
-    )
-    assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
 
 
 def test_the_item_fingerprint_also_covers_the_filterable_metadata(corpus) -> None:
@@ -116,30 +115,19 @@ def test_the_item_fingerprint_covers_what_the_index_stores_about_a_surface(
 ) -> None:
     """G-5: every column the index STORES about a surface moves the fingerprint.
 
-    `surface_fingerprint` is `(version, type, origin, text)` by design — two surfaces with
-    the same text under different provenance must differ, and nothing more. But the index
-    persists more than that in `surfaces`: attribution, title, url, locator and language,
-    which `search` serves on every match (A-1) and `--has-surface` filters on. A change to
-    any of them with the text untouched left `update` seeing nothing to do — the evidence
-    repaired and the derivative standing (rule 6), on the attribution rule this repo paid
-    for in blood.
+    `surface_fingerprint` is `(version, type, origin, text)` by design, and the index persists
+    more than that; why the ROW and not the fingerprint alone is `item_fingerprint`'s
+    docstring, not this one. Four axes, one parametrised test, each changing ONE field of
+    k07's quoted post and nothing else. The `url` case moves the locator columns but does NOT
+    pin them: it is satisfied through `surface_id`, which hashes the source's kind and url,
+    and stays green with both locator columns dropped from `surface_row` (round 09, B1). What
+    pins the locator is the test below, which moves a field `surface_id` cannot reach.
 
-    Four axes, one parametrised test, each changing ONE field of k07's quoted post and
-    nothing else. The `url` case moves the locator columns but does NOT pin them: it is
-    satisfied through `surface_id`, which hashes the source's kind and url, and it stays
-    green with both locator columns dropped from `surface_row` (round 09, B1). What pins
-    the locator is the test below, which moves a locator field `surface_id` cannot reach.
-
-    `producer` is deliberately NOT here — the index has no producer column, and since round
-    08 (F7-7) the ASR/VLM surfaces carry none at all, because the store records no
-    transcriber; the producers that ARE recorded (`enriched.executor`,
-    `description_version`) travel with the surface and are not stored columns either.
-
-    Seen red before the fix on all four: the fingerprint did not move. Seen red again here
-    under the mutant `surface_row` → `(None, None, None, …)`, which the file passed 90/90
-    before this test was restored — on three of the four, the `url` case being the exception
-    named above: `surface_row` is the projection `item_fingerprint` hashes, so a column
-    dropped from it is a column the index stores and never re-hashes.
+    Seen red before the fix on all four: the fingerprint did not move. Seen red again under
+    the mutant `surface_row` → `(None, None, None, …)`, which the file passed 90/90 before
+    this test was restored — on three of the four, the `url` case being the exception named
+    above: `surface_row` is the projection `item_fingerprint` hashes, so a column dropped
+    from it is a column the index stores and never re-hashes.
     """
     from xbrain.models import Author
 
@@ -160,22 +148,15 @@ def test_the_item_fingerprint_covers_the_locator_not_only_the_url_the_id_hashes(
 ) -> None:
     """The LOCATOR column, which the `[url]` case above does not reach (round 09, B1).
 
-    That case moves the fingerprint through `surface_id`, which hashes the source's kind
-    and url — so it is satisfied with BOTH locator columns dropped from `surface_row`, and
-    the mutant that returns `None` and `""` for `surface.locator.url` and
-    `surface.locator.model_dump_json()` leaves the file green. That is rule 1's first row:
-    an assertion satisfied for the wrong reason, on the projection this child owns.
+    That case moves the fingerprint through `surface_id`, so it is satisfied with BOTH locator
+    columns dropped from `surface_row` — rule 1's first row, satisfied for the wrong reason.
 
-    `Locator` carries eleven fields and ten of them reach the persisted `locator_json`
-    column (`index_schema`) through no other hashed path. They are how a reader resolves a
-    claim back to the bytes it came from — a frame timestamp says WHERE in the video the
-    slide is, `char_start`/`char_end` say where in a body a quote is — which is the whole
-    mechanism CLAUDE.md rule 7 rests on.
-
-    So this moves exactly one of them: k08's first video frame keeps its description, its
-    `frame_index`, its `source_key` and its source, and only its `frame_timestamp` changes.
-    The two guards are what make it bite for the reason it names — exactly one surface row
-    moves, in exactly one column, and that column deserialises to the new timestamp.
+    `Locator` carries eleven fields and ten reach the persisted `locator_json` column
+    (`index_schema`) through no other hashed path; they are how a reader resolves a claim back
+    to the bytes it came from, the mechanism CLAUDE.md rule 7 rests on. So this moves exactly
+    one: k08's first video frame keeps its description, `frame_index`, `source_key` and
+    source, and only its `frame_timestamp` changes. The two guards make it bite for the reason
+    it names — exactly one row moves, in one column, deserialising to the new timestamp.
 
     The sibling column `surface.locator.url` is a DUPLICATE of a field `model_dump_json()`
     also serialises, so dropping it ALONE is unobservable in the hash by construction: no
@@ -198,8 +179,8 @@ def test_the_item_fingerprint_covers_the_locator_not_only_the_url_the_id_hashes(
         update={"content": item.content.model_copy(update={"sources": sources})}
     )
 
-    before = [index_build.surface_row(s) for s in item_surfaces(item)]
-    after = [index_build.surface_row(s) for s in item_surfaces(edited)]
+    before = _rows(item)
+    after = _rows(edited)
     changed = [i for i, (a, b) in enumerate(zip(before, after, strict=True)) if a != b]
     assert len(changed) == 1, "exactly one surface row moves: the one whose timestamp changed"
     row_before, row_after = before[changed[0]], after[changed[0]]
@@ -213,11 +194,11 @@ def test_the_item_fingerprint_covers_the_locator_not_only_the_url_the_id_hashes(
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
 
 
-# The positions of three `surfaces` columns inside `SurfaceRow`, written out BY HAND — which is
-# exactly what `surface_row`'s docstring says the correspondence with the persisted DDL still is
-# in this child. 02.7 owes the writer that binds the tuple to the `INSERT` and the readback that
-# makes it structural; naming the positions here only lets an assertion say WHICH column it pins
-# instead of pointing at a bare integer, and it adds no guard `surface_row` does not have.
+# The positions of three `surfaces` columns inside `SurfaceRow`, written out BY HAND — exactly
+# what `surface_row`'s docstring says the correspondence with the persisted DDL still is in this
+# child. 02.7 owes the writer that binds the tuple to the `INSERT` and the readback that makes
+# it structural; naming the positions only lets an assertion say WHICH column it pins, and adds
+# no guard `surface_row` does not have.
 URL_COLUMN = 10
 LOCATOR_JSON_COLUMN = 11
 FINGERPRINT_COLUMN = 13
@@ -229,27 +210,20 @@ def test_the_row_carries_the_url_column_the_schema_persists_beside_the_locator_j
 ) -> None:
     """`surfaces.url` is a persisted column of its own, and no test in this file pinned it.
 
-    Two independent reviews reached OPPOSITE readings of the same green mutant, and the
-    disagreement is why this test exists. Dropping `surface.locator.url` from `surface_row`
-    leaves the whole file green: one review read that as an unprotected persisted column,
-    the other as an EQUIVALENT mutant, because the same url is serialised a second time
-    inside `locator_json` and the hash therefore cannot see the first copy disappear. Both
-    measured correctly, and only the second is a statement about the FINGERPRINT. The column
-    is unobservable in the hash and perfectly observable in the PROJECTION, so it is pinned
-    here, on the row, and never through `item_fingerprint` — a test claiming the hash sees it
-    would be pinning the json (rule 1, backwards).
+    Two independent reviews read the same green mutant OPPOSITELY, and the disagreement is why
+    this test exists: dropping `surface.locator.url` from `surface_row` leaves the whole file
+    green, because the same url is serialised a second time inside `locator_json` and the hash
+    cannot see the first copy disappear. The column is unobservable in the HASH and perfectly
+    observable in the PROJECTION, so it is pinned here, on the row, and never through
+    `item_fingerprint` — a test claiming the hash sees it would be pinning the json (rule 1,
+    backwards). What is asserted is that redundancy turned into an invariant: the two persisted
+    columns must carry the SAME url, on every surface of the corpus, because `search` serves
+    `url` on every match (A-1) without deserialising the locator.
 
-    What is asserted is the very redundancy the second reading rests on, turned from a
-    rationale into an invariant: the two persisted columns must carry the SAME url, on every
-    surface of the corpus. `search` serves `url` on every match (A-1), so a reader resolves a
-    hit back to its bytes through the column without deserialising the locator; a projection
-    that dropped it while `locator_json` kept it would leave the two disagreeing, which is
-    precisely what the mutant does and what this assertion refuses.
-
-    The two preconditions are what stop it passing for the wrong reason: a corpus whose
-    locators all carried `None` would pass with the column deleted, and one where none did
-    would never exercise the `NULL` the DDL allows on it. The fixture holds both — a `post`
-    locates by url, a `summary` by nothing — and that is asserted before anything else is.
+    The two preconditions stop it passing for the wrong reason: a corpus whose locators all
+    carried `None` would pass with the column deleted, and one where none did would never
+    exercise the `NULL` the DDL allows. The fixture holds both — a `post` locates by url, a
+    `summary` by nothing — asserted before anything else is.
 
     Seen red under the mutant `surface.locator.url` -> `None`, on every surface that has one.
     """
@@ -275,17 +249,13 @@ def test_the_item_fingerprint_covers_the_surface_fingerprint_column_not_its_leng
 
     `surface_row` has no text column — the last one is `len(surface.text)` (spec §10.8) — so
     `surface.fingerprint` is the only thing standing between *the body changed* and an index
-    reporting nothing to do. Nothing pinned it: `surface.fingerprint` -> `None` in
-    `surface_row` left this whole file green. The reason is rule 1's first row, an assertion
-    satisfied by another column — the flagship text test replaces a 48-character summary with
-    a 12-character one, so it moves the fingerprint column AND the length column, and passes
-    through the second when the first is gone.
-
-    So the edit here KEEPS THE LENGTH: 48 characters of summary become 48 different ones, one
-    word swapped for another of the same width. Measured on the shipped code that moves
-    exactly one row and exactly one column of it; with the mutant applied it moves none, and
-    a hand-corrected summary would leave `update` reporting the item current while the index
-    goes on serving the old body — rule 6, on the only column that carries the text.
+    reporting nothing to do. Nothing pinned it: `surface.fingerprint` -> `None` left this
+    whole file green, because the flagship text test replaces a 48-character summary with a
+    12-character one and so passes through the LENGTH column when the fingerprint column is
+    gone — rule 1's first row. The edit here KEEPS THE LENGTH: 48 characters become 48
+    different ones. Measured on the shipped code that it moves exactly one row and one column
+    of it; with the mutant it moves none, and a hand-corrected summary would leave `update`
+    reporting the item current while the index serves the old body (rule 6).
 
     Seen red under the mutant `surface.fingerprint` -> `None`: no column moves at all, so the
     "exactly one column" assertion fails before the fingerprint assertion is reached.
@@ -301,8 +271,8 @@ def test_the_item_fingerprint_covers_the_surface_fingerprint_column_not_its_leng
     edited = item.model_copy(
         update={"enriched": item.enriched.model_copy(update={"summary": rewritten})}
     )
-    before = [index_build.surface_row(s) for s in item_surfaces(item)]
-    after = [index_build.surface_row(s) for s in item_surfaces(edited)]
+    before = _rows(item)
+    after = _rows(edited)
     moved = [i for i, (a, b) in enumerate(zip(before, after, strict=True)) if a != b]
     assert len(moved) == 1, "exactly one surface row moves: the summary whose body was rewritten"
     row_before, row_after = before[moved[0]], after[moved[0]]
@@ -337,17 +307,13 @@ def test_the_item_fingerprint_covers_the_item_plane_no_surface_carries(
     derivative standing (rule 6), one plane up from G-5 and on the same attribution axis.
 
     THE BASE ITEM CARRIES NO POST SURFACE, AND THAT IS THE WHOLE CONSTRUCTION (rule 1).
-    `item.author` is ALSO the attribution of the `post` surface and of a `user_note`
-    (`surfaces.item_surfaces`), so on an ordinary item this assertion moves through
-    `surface_row` and passes with the metadata half deleted — satisfied for the wrong
-    reason, which is what the round-09 mutants found. k02's text is blanked so no `post`
-    surface is emitted, and its `enriched` carries no `user_notes`: one `summary` surface
-    remains, attributed to nobody.
-
-    So every case asserts twice: that not one surface row moved — the only other input to
-    this hash — and that the fingerprint moved anyway. Delete the axis from the metadata
-    half and the second assertion fails; the first is what proves it could not have passed
-    through the surfaces instead.
+    `item.author` is ALSO the attribution of the `post` surface and of a `user_note`, so on
+    an ordinary item this assertion moves through `surface_row` and passes with the metadata
+    half deleted — satisfied for the wrong reason, which is what the round-09 mutants found.
+    k02's text is blanked so no `post` surface is emitted and its `enriched` carries no
+    `user_notes`: one `summary` surface remains, attributed to nobody. So every case asserts
+    twice — that not one surface row moved, and that the fingerprint moved anyway; the first
+    proves the second could not have passed through the surfaces instead.
     """
     from xbrain.models import Author
 
@@ -360,7 +326,7 @@ def test_the_item_fingerprint_covers_the_item_plane_no_surface_carries(
     rows = [index_build.surface_row(s) for s in surfaces]
 
     edited = item.model_copy(update={axis: Author(**value) if axis == "author" else value})
-    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
+    assert _rows(edited) == rows, (
         "no surface row may move, or the fingerprint could differ for another reason"
     )
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), axis
@@ -380,14 +346,11 @@ def test_the_item_fingerprint_covers_the_author_handle_and_the_name_apart(
 
     Each case here moves exactly ONE of them and leaves the other byte-identical, so a case
     can only pass through the half it names. The construction is the one the test above
-    documents: k02's text is blanked so no `post` surface is emitted and its `enriched`
-    carries no `user_notes`, leaving one `summary` surface attributed to nobody — otherwise
-    `item.author` is also the surface's attribution and the assertion would move through
-    `surface_row` with the metadata half deleted.
-
-    It is observable, and on the repair this repo has already paid for: `refresh-quoted`
-    corrects a display name without touching the handle, and with the name unhashed `update`
-    would report `0 cambiados` while `search` keeps serving the old attribution (rule 6).
+    documents: k02's text blanked, no `user_notes`, one `summary` surface attributed to
+    nobody. It is observable, and on the repair this repo has already paid for:
+    `refresh-quoted` corrects a display name without touching the handle, and with the name
+    unhashed `update` would report `0 cambiados` while `search` keeps serving the old
+    attribution (rule 6).
 
     Seen red under two mutants applied separately: `item.author.name` deleted from
     `item_fingerprint` (the `name` case, the `handle` case still green) and
@@ -407,7 +370,7 @@ def test_the_item_fingerprint_covers_the_author_handle_and_the_name_apart(
     assert getattr(author, other) == getattr(item.author, other), "and the other did not"
 
     edited = item.model_copy(update={"author": author})
-    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
+    assert _rows(edited) == rows, (
         "no surface row may move, or the fingerprint could differ for another reason"
     )
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), half
@@ -417,11 +380,7 @@ def test_the_item_fingerprint_covers_the_author_handle_and_the_name_apart(
     "axis, patch, topics_after",
     [
         ("topics", {"topics": ["agent-evaluation"]}, ("agent-evaluation",)),
-        (
-            "primary_topic",
-            {"primary_topic": "observability"},
-            ("observability", "agent-evaluation"),
-        ),
+        ("primary", {"primary_topic": "observability"}, ("observability", "agent-evaluation")),
     ],
 )
 def test_the_item_fingerprint_covers_the_topics_the_item_plane_persists(
@@ -430,17 +389,15 @@ def test_the_item_fingerprint_covers_the_topics_the_item_plane_persists(
     """`topics` is the sixth member of the list `item_fingerprint`'s own docstring enumerates.
 
     That docstring names the filterable metadata as «source, author, date, topics, content
-    kinds». Five of the six have a test; `topics` had none — `*item_topics(item)` could be
-    deleted from `parts` with this whole file green, because every topic in the fixture
-    belongs to an item whose surfaces move for some other reason.
-
-    It is observable, and it is a repair the pipeline performs routinely: re-run `xbrain
-    topics`, reassign an item, and with the block deleted `update` reports `0 cambiados`
-    while `--topic` goes on serving the old assignment out of `item_topics` (rule 6).
+    kinds». Five of the six have a test; `topics` had none — the topics region could be
+    deleted with this whole file green, because every topic in the fixture belongs to an item
+    whose surfaces move for some other reason. It is observable, and a repair the pipeline
+    performs routinely: re-run `xbrain topics`, reassign an item, and with the region deleted
+    `update` reports `0 cambiados` while `--topic` serves the old assignment (rule 6).
 
     TWO AXES, BECAUSE THE TABLE PERSISTS TWO THINGS. `item_topics` (`index_schema`) stores
     `slug` and `is_primary`, and `item_topics()` encodes the second as ORDER — primary first,
-    then the rest, deduplicated. So one case changes the membership with the primary fixed,
+    then the rest, deduplicated. One case changes the membership with the primary fixed,
     the other changes the primary with the membership fixed, and each names the tuple it
     expects: a hash over the set alone would pass the first and fail the second.
 
@@ -450,12 +407,12 @@ def test_the_item_fingerprint_covers_the_topics_the_item_plane_persists(
     """
     store, _vocab, _pages = corpus
     item = store["k02"]
-    rows = [index_build.surface_row(s) for s in item_surfaces(item)]
+    rows = _rows(item)
 
     edited = item.model_copy(update={"enriched": item.enriched.model_copy(update=patch)})
     assert item_topics(edited) == topics_after, "the case moved the axis it names"
     assert item_topics(item) != topics_after, "and the base item did not already read that way"
-    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
+    assert _rows(edited) == rows, (
         "no surface row may move, or the fingerprint could differ for another reason"
     )
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item), axis
@@ -464,30 +421,27 @@ def test_the_item_fingerprint_covers_the_topics_the_item_plane_persists(
 def test_the_item_fingerprint_covers_a_content_kind_that_emits_no_surface(corpus) -> None:
     """`item_content_kinds` is a persisted plane, and a kind can arrive with no text at all.
 
-    A no-speech `x_video` (107 of 259 in the corpus) fetched without `--frames` has an
-    empty transcript, no frames and no digest, so it emits NOT ONE surface — and it is
-    still a video the index records in `item_content_kinds` and a kind filter answers
-    from. Measured under the mutant that deletes the sorted-kinds block from
-    `item_fingerprint`: green, because every kind in the fixture arrives attached to a
-    surface that moves the hash on its own.
+    A no-speech `x_video` (107 of 259 in the corpus) fetched without `--frames` has an empty
+    transcript, no frames and no digest, so it emits NOT ONE surface — and it is still a video
+    the index records in `item_content_kinds` and a kind filter answers from. Measured under
+    the mutant that deletes the sorted-kinds region: green, because every kind in the fixture
+    arrives attached to a surface that moves the hash on its own.
 
-    The hash is over the sorted MULTISET while the table's primary key is
-    `(item_id, kind)` — a set — so a duplicated kind moves the fingerprint without
-    changing the stored plane: the accepted false positive, failing towards the warning
-    like everything else in this module. This case adds a kind the item did not have at
-    all, so it moves both.
+    The hash is over the sorted MULTISET while the table's primary key is `(item_id, kind)` —
+    a set — so a duplicated kind moves the fingerprint without changing the stored plane: the
+    accepted false positive. This case adds a kind the item did not have, so it moves both.
 
     Guarded like the item-plane cases above, and here the guard is also the evidence: the
-    surface rows are identical precisely BECAUSE the silent video emitted nothing. The
-    only other field the patch touches is `content.fetched_at`, which is hashed nowhere —
-    deliberately, and that is the subject of this module's docstring.
+    surface rows are identical precisely BECAUSE the silent video emitted nothing. The only
+    other field the patch touches is `content.fetched_at`, hashed nowhere — deliberately, and
+    that is the subject of this module's docstring.
     """
     from xbrain.models import Content, ContentSourceSuccess
 
     store, _vocab, _pages = corpus
     item = store["k02"]
     assert item.content is None, "the base item must start with no content source at all"
-    rows = [index_build.surface_row(s) for s in item_surfaces(item)]
+    rows = _rows(item)
 
     silent = ContentSourceSuccess(
         kind="x_video", url="https://video.example/silent.mp4", text="", has_speech=False
@@ -495,9 +449,7 @@ def test_the_item_fingerprint_covers_a_content_kind_that_emits_no_surface(corpus
     edited = item.model_copy(
         update={"content": Content(fetched_at=item.captured_at, sources=[silent])}
     )
-    assert [index_build.surface_row(s) for s in item_surfaces(edited)] == rows, (
-        "a silent video with no frames and no digest emits no surface"
-    )
+    assert _rows(edited) == rows, "a silent video with no frames and no digest emits no surface"
     assert index_build.item_fingerprint(edited) != index_build.item_fingerprint(item)
 
 
@@ -506,29 +458,25 @@ def test_two_different_items_cannot_share_one_serialisation_across_the_variadic_
 ) -> None:
     """The topics region and the kinds region are ADJACENT, and nothing said where one ends.
 
-    `parts` splices three variable-length regions — `item_topics`, the sorted content kinds
-    and the surface rows — into one flat list joined by `\0`. With no length in front of each,
-    that join is NOT injective: two different item states serialise to the very same bytes.
+    An earlier encoding spliced three variable-length regions — `item_topics`, the sorted
+    content kinds and the surface rows — into one flat `\0`-joined list, which is NOT
+    injective: two different item states serialise to the very same bytes. Neither side is
+    exotic; both are states the store can hold: `primary_topic="thread"` with
+    `topics=["thread"]` and no content, against no topics and one
+    `ContentSourceSuccess(kind="thread", text="")`. `thread` is both a `ContentKind` and a
+    legal topic string (`Enrichment.topics` has no pattern), and a non-video source whose text
+    is blank emits NO surface, so the surface region is byte-identical on both sides.
 
-    Constructed here, and neither side is exotic — both are states the store can hold:
-    `primary_topic="thread"` with `topics=["thread"]` and no content at all, against no topics
-    and one `ContentSourceSuccess(kind="thread", text="")`. `thread` is both a `ContentKind`
-    and a legal topic string — `Enrichment.topics` is `list[str]` with no pattern, so nothing
-    in the TYPE forbids it — and a non-video source whose text is blank emits NO surface, so
-    the surface region is byte-identical on both sides and cannot break the tie.
+    IT FAILS OPEN, the one direction this module is built not to fail in: the two states hash
+    the same, `update` reports the item unchanged, and the persisted `item_topics` /
+    `item_content_kinds` planes go on serving a state the store no longer holds (rule 6). The
+    reading this replaces argued reachability from `Topic.slug`'s pattern — not the hashed
+    field, and "hard to reach" is not "impossible to express".
 
-    IT FAILS OPEN, which is what makes it worth a test in a module whose every other staleness
-    path fails towards the warning: the two states hash the same, `update` reports the item
-    unchanged, and the persisted `item_topics` / `item_content_kinds` planes go on serving a
-    state the store no longer holds (rule 6). The reading this replaces measured how hard the
-    collision was to REACH and argued it from `Topic.slug`'s pattern — but `Topic.slug` is not
-    what is hashed, and "hard to reach" is not the same fact as "impossible to express".
-
-    MEASURED, AND STATED AS MEASURED. Seen RED at `bfbaf87`, both sides hashing
-    `bafd6ed7…`; red again under removal of the WHOLE framing (1 failed, 40 passed —
-    diagonal). Removing any ONE length tag alone leaves this file GREEN, because either
-    surviving tag still separates the two regions. So what this test pins is THE FRAMING,
-    never each tag independently, and no claim of per-tag protection is made for it.
+    WHAT IT PINS IS THE NESTING, not any one marker: each region is its own JSON array inside
+    `_canonical`, so the boundary is structural and no value can move it. Seen RED at
+    `bfbaf87`, both sides hashing `bafd6ed7…`; red again on this tree under the mutant that
+    splices the three regions back into the parent array — 1 failed, 43 passed, diagonal.
 
     The last assertion is the guard; the three before it prove the two states really do differ
     on the axes they name, or an equal-hash assertion could pass on two identical items.
@@ -560,12 +508,64 @@ def test_two_different_items_cannot_share_one_serialisation_across_the_variadic_
 
     assert item_topics(topic_side) == ("thread",), "one state carries `thread` as a TOPIC"
     assert item_topics(kind_side) == (), "and the other carries no topic at all"
-    assert [index_build.surface_row(s) for s in item_surfaces(topic_side)] == [
-        index_build.surface_row(s) for s in item_surfaces(kind_side)
-    ], "the blank thread source emits no surface, so the surface region cannot break the tie"
+    assert _rows(topic_side) == [index_build.surface_row(s) for s in item_surfaces(kind_side)], (
+        "the blank thread source emits no surface, so the surface region cannot break the tie"
+    )
 
     assert index_build.item_fingerprint(topic_side) != index_build.item_fingerprint(kind_side), (
         "a topic named like a content kind must not serialise as that content kind"
+    )
+
+
+def test_a_nul_inside_a_hashed_value_cannot_forge_the_boundary_between_two_atoms(
+    corpus, tmp_path: Path
+) -> None:
+    """The length tags frame the REGIONS. Nothing framed the ATOMS inside them.
+
+    The count tags the previous round added pinned how many topics there ARE, never where
+    each one ENDS, and they lived inside the same joined stream — so one U+0000 in any hashed
+    value re-split it and the tag stopped meaning what it said. `("a\\0b", "c")` and
+    `("a", "b\\0c")` are two topics on both sides, so `topics:2` was byte-identical, and both
+    flatten to the same three tokens. Same class and direction as the region collision above:
+    it fails OPEN, `update` calls the item unchanged, and the `item_topics` plane goes on
+    serving a state the store no longer holds (rule 6).
+
+    NOT A BYTE ONLY MEMORY CAN HOLD. `Enrichment.topics` has no pattern and JSON escapes the
+    NUL, so the round trip through the REAL writer and reader is asserted BEFORE any hash:
+    `save_store` / `load_store` hand back two items that still differ. What the store cannot
+    express cannot collide; this it expresses.
+
+    THE SECOND GUARD MAKES THIS A TEST OF THE ENCODING and not of two objects being different:
+    both sides carry the same number of topics AND their `\\0`-joined flattening is
+    byte-identical, so the serialisation this replaces could not tell them apart by
+    construction. Seen RED at `1c32cf9`, both hashes `f970afed…`.
+    """
+    from xbrain.store import load_store, save_store
+
+    store, _vocab, _pages = corpus
+    plain = store["k02"].enriched.model_copy(update={"primary_topic": None})
+    path = tmp_path / "items.json"
+    sides = []
+    for topics in (["a\0b", "c"], ["a", "b\0c"]):
+        item = store["k02"].model_copy(
+            update={"enriched": plain.model_copy(update={"topics": topics})}
+        )
+        save_store({item.id: item}, path)
+        sides.append(load_store(path))
+    left, right = sides
+
+    assert left != right, "both states survive the store's own writer and reader"
+    flat = ["\0".join(item_topics(side[store["k02"].id])) for side in sides]
+    assert len(item_topics(left["k02"])) == len(item_topics(right["k02"])) == 2, (
+        "`topics:2` on both"
+    )
+    assert flat[0] == flat[1], "and the join this replaces cannot tell the two apart at all"
+
+    assert index_build.item_fingerprint(left["k02"]) != index_build.item_fingerprint(
+        right["k02"]
+    ), "a NUL inside a topic must not move where the next atom begins"
+    assert index_build.store_fingerprint(left) != index_build.store_fingerprint(right), (
+        "and the deep store signal must not inherit the collision"
     )
 
 
@@ -574,15 +574,14 @@ def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this(c
 
     `item_fingerprint` binds `options = options or IndexOptions()` and then reads neither
     `params` nor `vault_dir`, so `item_fingerprint(i, options=A) == item_fingerprint(i)` for
-    every A. Two docstrings say it and nothing executable saw it — `grep -n options` over this
-    file returned nothing, and `vulture` does not flag a parameter that is bound.
+    every A. Two docstrings said it and nothing executable saw it — `vulture` does not flag a
+    parameter that is bound.
 
-    THIS IS A CHARACTERIZATION TEST: green before and after, repairing no defect, and no
-    mutation motivated it. What it buys is the other direction. 02.7's builder is the first
-    consumer that will genuinely read `params` and `vault_dir`, and the commit that makes the
-    fingerprint depend on them MUST turn this red. Reading the parameters while it stayed
-    green would mean the dependency never entered the hash — rule 6 armed: a re-chunk under
-    new parameters that `update` reports as `0 cambiados`.
+    THIS IS A CHARACTERIZATION TEST: green before and after, repairing no defect. What it buys
+    is the other direction. 02.7's builder is the first consumer that will genuinely read
+    `params` and `vault_dir`, and the commit that makes the fingerprint depend on them MUST
+    turn this red; reading them while it stayed green would mean the dependency never entered
+    the hash — rule 6 armed, a re-chunk under new parameters reported as `0 cambiados`.
 
     So in 02.7 DELETE it, never weaken it.
     """
@@ -596,9 +595,9 @@ def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this(c
     vaulted = index_build.IndexOptions(vault_dir=Path("/nowhere"))
     assert index_build.item_fingerprint(item, options=swept) == bare, "params are not read"
     assert index_build.item_fingerprint(item, options=vaulted) == bare, "nor is the vault"
-    assert index_build.store_fingerprint(store, options=swept) == index_build.store_fingerprint(
-        store
-    ), "and `store_fingerprint` hands them to the same discard"
+    bare_store = index_build.store_fingerprint(store)
+    assert index_build.store_fingerprint(store, options=swept) == bare_store, "and so does"
+    assert index_build.store_fingerprint(store, options=vaulted) == bare_store, "the store one"
 
 
 def test_the_leading_surface_version_is_the_belt_for_an_item_with_no_surfaces(
@@ -606,18 +605,16 @@ def test_the_leading_surface_version_is_the_belt_for_an_item_with_no_surfaces(
 ) -> None:
     """An emitter-version bump has to reach an item that emits nothing.
 
-    `SURFACE_VERSION` is hashed twice over: once at the head of `item_fingerprint`'s parts
-    and once inside every `surface.fingerprint`. For any item that HAS a surface the second
-    copy carries it, which is why deleting the first left this file green — no test held an
-    item with zero surfaces. Such items exist: k01 has no content, no media and no
-    `enriched`, so blanking its text leaves the emitter with nothing to emit, and the
-    leading copy is the only place the version can still reach it. Without it, a bump would
-    leave that item's fingerprint unchanged and `update` would report it current under an
-    emitter version that no longer describes how it would be emitted.
-
-    Patching this module's binding alone is an EXACT simulation here rather than a partial
-    one: a real bump also travels through `ids.surface_fingerprint`, and this item has no
-    surface for it to travel through.
+    `SURFACE_VERSION` is hashed twice over: once at the head of the hashed structure and once
+    inside every `surface.fingerprint`. For any item that HAS a surface the second copy
+    carries it, which is why deleting the first left this file green — no test held an item
+    with zero surfaces. Such items exist: k01 has no content, no media and no `enriched`, so
+    blanking its text leaves the emitter with nothing to emit, and the leading copy is the
+    only place the version can still reach it. Without it a bump would leave that item's
+    fingerprint unchanged and `update` would report it current under an emitter version that
+    no longer describes how it would be emitted. Patching this module's binding alone is an
+    EXACT simulation here rather than a partial one: a real bump also travels through
+    `ids.surface_fingerprint`, and this item has no surface for it to travel through.
     """
     store, _vocab, _pages = corpus
     item = store["k01"].model_copy(update={"text": ""})
@@ -635,22 +632,20 @@ def test_the_store_fingerprint_is_order_independent(corpus) -> None:
     assert index_build.store_fingerprint(reversed_store) == index_build.store_fingerprint(store)
 
 
-def test_load_index_inputs_binds_the_signal_to_the_bytes_it_read(workspace, corpus) -> None:
-    """The mechanism behind P1b, at the loader: the signal is `fstat` of the handle the
-    text came from, taken BEFORE the read — so a replacement that lands during the read
-    leaves the objects and the signal describing the same snapshot (the handle keeps the
-    inode it opened; the store's writers replace atomically), and leaves the path pointing
-    at a newer inode the query-time `StoreSignal.of` reports as different.
-
-    Staged INSIDE the read: the handle `load_index_inputs` opens replaces the file on disk
-    the moment it is read from, which is the only place a stat of the path and a stat of
-    the handle can disagree. Seen red under the mutation `stat = path.stat()` taken after
-    the read: the signal then described the replacement, not the bytes parsed.
+def test_load_index_inputs_binds_the_signal_to_the_bytes_it_read(three_inputs, corpus) -> None:
+    """The mechanism behind P1b, at the loader: the signal is `fstat` of the handle the text
+    came from, taken BEFORE the read — so a replacement landing during the read leaves the
+    objects and the signal describing the same snapshot (the handle keeps the inode it opened;
+    the store's writers replace atomically) and leaves the path on a newer inode the
+    query-time `StoreSignal.of` reports as different. Staged INSIDE the read, which is the
+    only place a stat of the path and a stat of the handle can disagree. Seen red under the
+    mutation `stat = path.stat()` taken after the read: the signal then described the
+    replacement, not the bytes parsed.
     """
     from xbrain.store import save_store
 
     store, _vocab, _pages = corpus
-    items = workspace / "items.json"
+    items = three_inputs / "items.json"
     before = index_build.StoreSignal.of(items)
     newer = {**store, "k01": store["k01"].model_copy(update={"text": "replaced during the load"})}
 
@@ -712,7 +707,7 @@ def test_the_store_signal_is_one_stat_per_named_input_and_nothing_else(
     signal = index_build.StoreSignal.of(
         items, three_inputs / "vocab.yaml", three_inputs / "topics.json"
     )
-    assert len(calls) == 3, f"one stat per named input, and nothing else: {calls}"
+    assert len(set(calls)) == len(calls) == 3, f"one stat per NAMED input, all distinct: {calls}"
 
     calls.clear()
     partial = index_build.StoreSignal.of(items)
@@ -733,47 +728,6 @@ def test_the_store_signal_of_a_missing_store_is_zeroed_not_an_exception(tmp_path
     assert signal == index_build.StoreSignal(items_json_mtime_ns=0, items_json_size=0)
 
 
-def _obstruct(path: Path, obstacle: str) -> None:
-    """Make `path` UNREADABLE without removing it — the two shapes an operator meets."""
-    if obstacle == "chmod000":
-        path.chmod(0)
-    else:
-        path.unlink()
-        path.mkdir()
-
-
-@pytest.mark.parametrize(
-    ("obstacle", "error"), [("chmod000", PermissionError), ("directory", IsADirectoryError)]
-)
-def test_an_unreadable_store_is_an_error_never_an_empty_store(
-    workspace: Path, obstacle: str, error: type[OSError]
-) -> None:
-    """A-2 (gate Fable §5.2, round 08 — the DIFF subagent's A-1, reproduced by the gate in
-    two variants): `_read_bound` caught EVERY `OSError` and answered `(None, 0, 0)`, the
-    reading reserved for a file that is ABSENT — so an `items.json` with `chmod 000`, or a
-    directory standing where the file was, loaded as an EMPTY store. On the real index:
-    `status` healthy with `items_removed 2404`, `search` «0 resultados» exit 0 with nothing
-    declared, `update` planning `-2404 items`, and `build --force` replacing 22,286 chunks
-    with the 703 of the topic plane, sealed consistent, exit 0. The loader is the route
-    BEFORE seam (a), the one no door asks, and through it the whole fail-open family came
-    back with a destruction on top.
-
-    `load_store` (`store.py`) reads only an ABSENT file as `{}`; every other `OSError`
-    propagates. The loader now agrees: only `FileNotFoundError` is the empty store, and
-    `EACCES`/`EISDIR`/`EIO` raise, which the CLI prints as `Error: …` with exit 1.
-
-    Seen red on `36f694b`: `loaded.store == {}` on both obstacles, no exception.
-    """
-    _obstruct(workspace / "items.json", obstacle)
-    try:
-        with pytest.raises(error):
-            index_build.load_index_inputs(workspace / "items.json")
-    finally:
-        # Leave the temp dir removable whatever the outcome.
-        if obstacle == "chmod000":
-            (workspace / "items.json").chmod(0o644)
-
-
 def test_an_absent_store_still_reads_as_an_empty_store(tmp_path: Path) -> None:
     """The positive control for the test above: ABSENT is the one reading that stays empty —
     `load_store`'s own semantics, and what `StoreSignal.of` reports as zeros — so a fresh
@@ -786,29 +740,13 @@ def test_an_absent_store_still_reads_as_an_empty_store(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # THREE INPUTS, NOT ONE — and the two fingerprints over the other two
 #
-# The snapshot's suite reached `items.json` on every door and reached `vocab.yaml` /
-# `topics.json` on none: `vocab_fingerprint` and `topics_fingerprint` had no direct test
-# anywhere in it, and no test loaded a workspace that contained the other two files at all.
-# Measured before writing these: the file was green at 14/14 with `load_index_inputs`
-# reduced to `vocab=[], topic_pages={}` and the four vocab/topics signal entries left at
-# zero — which is exactly the pre-round-05 defect P1a records, back with nothing to catch
-# it. This child owns the three-input read and the three fingerprints over it, so the tests
-# come with them (rule 1: each was seen red under the mutation named in its docstring).
+# The snapshot's suite reached `items.json` on every door and `vocab.yaml` / `topics.json` on
+# none: neither fingerprint had a direct test anywhere in it. Measured before writing these:
+# green at 14/14 with `load_index_inputs` reduced to `vocab=[], topic_pages={}` and the four
+# vocab/topics signal entries left at zero — the pre-round-05 defect P1a records, back with
+# nothing to catch it. This child owns the three-input read and the three fingerprints over
+# it (rule 1: each was seen red under the mutation named in its docstring).
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture()
-def three_inputs(tmp_path: Path, corpus) -> Path:
-    """A data/ directory holding ALL THREE inputs, written by the store's own writers."""
-    from xbrain.rubrics import save_vocab
-    from xbrain.store import save_store, save_topic_pages
-
-    store, vocab, pages = corpus
-    data = tmp_path / "data"
-    save_store(store, data / "items.json")
-    save_vocab(vocab, data / "vocab.yaml")
-    save_topic_pages(pages, data / "topics.json")
-    return data
 
 
 def test_load_index_inputs_reads_the_vocabulary_and_the_topic_pages_too(
@@ -818,13 +756,11 @@ def test_load_index_inputs_reads_the_vocabulary_and_the_topic_pages_too(
 
     A topic description enters every assigned item's PROFILE (spec §5.1.A) and the overviews
     and notes are chunks the index serves, so a loader that reads `items.json` and defaults
-    the other two to empty builds an index missing the whole topic plane while every signal
-    it seals says the inputs were read. All six signal entries are the stat of the file that
-    was actually parsed.
-
-    Seen red under the mutation `vocab=[], topic_pages={}` with the four vocab/topics signal
-    entries left at zero — the pre-round-05 shape: `AssertionError` on the vocabulary, and
-    on `vocab_yaml_mtime_ns` once the parse was restored.
+    the other two to empty builds an index missing the whole topic plane while every signal it
+    seals says the inputs were read. All six signal entries are the stat of the file that was
+    actually parsed. Seen red under the mutation `vocab=[], topic_pages={}` with the four
+    vocab/topics signal entries left at zero — the pre-round-05 shape: `AssertionError` on the
+    vocabulary, and on `vocab_yaml_mtime_ns` once the parse was restored.
     """
     _store, vocab, pages = corpus
     loaded = index_build.load_index_inputs(
@@ -882,19 +818,16 @@ def test_the_query_time_signal_watches_each_of_the_three_inputs(
     The loader half is covered — a `load_index_inputs` that defaulted the vocabulary and the
     topic pages to empty goes red above. `StoreSignal.of` is the comparison every `search`
     makes against what the manifest sealed, and only `items.json` was ever asserted on it, so
-    `of` could be returned to watching one file — the exact pre-round-05 defect P1a records,
-    where `xbrain topics` wrote `topics.json`, never touched `items.json`, and every later
-    query answered over the old topic plane with nothing declared (spec §9.3 forbids that
-    silence). Measured: zeroing the vocab and topics stats inside `of` left this file green.
+    `of` could be returned to watching one file — the pre-round-05 defect P1a records, where
+    `xbrain topics` wrote `topics.json`, never touched `items.json`, and every later query
+    answered over the old topic plane with nothing declared (spec §9.3 forbids that silence).
+    Measured: zeroing the vocab and topics stats inside `of` left this file green. One case
+    per input, each asserting only its own file's two entries, so zeroing ONE stat reddens
+    exactly one case and names which input lost its watch.
 
-    One case per input, each asserting only its own file's two entries, so zeroing ONE stat
-    reddens exactly one case and names which input lost its watch.
-
-    THE THREE SIZES MUST DIFFER, and that is asserted first (rule 1). Compared against its own
-    file's `stat`, an entry that had been filled from a DIFFERENT input's stat would still
-    pass wherever the two files happened to agree; distinct sizes make each assertion
-    answerable only by the file it names. A zero cannot be right either, which the non-empty
-    precondition states.
+    THE THREE SIZES MUST DIFFER, asserted first (rule 1): compared against its own file's
+    `stat`, an entry filled from a DIFFERENT input's stat would still pass wherever the two
+    files happened to agree. A zero cannot be right either — the non-empty precondition.
 
     Seen red under three mutants applied separately, one per line of `of`: `_stat_signal(…)`
     -> `(0, 0)` for the items, the vocabulary and the topic pages, each reddening its own case
@@ -914,24 +847,35 @@ def test_the_query_time_signal_watches_each_of_the_three_inputs(
     assert getattr(signal, size_field) == stat.st_size, filename
 
 
+def _obstruct(path: Path, obstacle: str) -> None:
+    """Make `path` UNREADABLE without removing it — the two shapes an operator meets."""
+    if obstacle == "chmod000":
+        path.chmod(0)
+    else:
+        path.unlink()
+        path.mkdir()
+
+
 @pytest.mark.parametrize(
     "obstacle, error", [("chmod000", PermissionError), ("directory", IsADirectoryError)]
 )
-@pytest.mark.parametrize("filename", ["vocab.yaml", "topics.json"])
-def test_an_unreadable_vocab_or_topics_is_an_error_never_an_empty_one(
+@pytest.mark.parametrize("filename", ["items.json", "vocab.yaml", "topics.json"])
+def test_an_unreadable_input_is_an_error_never_an_empty_one(
     three_inputs: Path, filename: str, obstacle: str, error: type[OSError]
 ) -> None:
-    """A-2 reaches all three inputs, not only the one the gate happened to probe.
+    """A-2 (gate Fable §5.2, round 08), on ALL THREE inputs and not only the one it probed.
 
-    The fail-open family the gate found on `items.json` — an unreadable file read as the
-    empty value reserved for an absent one — is a property of `_read_bound`, and the loader
-    routes all three inputs through it. On `vocab.yaml` the same defect is quieter and no
-    less destructive: a `chmod 000` vocabulary loads as «no topics», so every profile is
-    built without its topic descriptions, `topic_rows_behind` sees an empty vocabulary and
-    `update` plans the deletion of the whole topic plane — sealed consistent, exit 0.
+    `_read_bound` caught EVERY `OSError` and answered `(None, 0, 0)`, the reading reserved for
+    a file that is ABSENT, so an unreadable input loaded as an EMPTY one — the whole fail-open
+    family with a destruction on top, enumerated in `_read_bound`'s own docstring and not
+    restated here. The defect is a property of that function and all three inputs route
+    through it, which is why this is parametrised over the three and not over the one the gate
+    happened to probe: on `vocab.yaml` it is quieter and no less destructive, loading as «no
+    topics» so every profile is built without its topic descriptions and `update` plans the
+    deletion of the whole topic plane, exit 0.
 
-    Seen red under the mutation `except OSError` in `_read_bound` (the pre-A-2 shape):
-    `DID NOT RAISE` on all four parametrisations.
+    Seen red on `36f694b` (`loaded.store == {}` on both `items.json` obstacles, no exception)
+    and under the mutation `except OSError` in `_read_bound`: `DID NOT RAISE` on all six.
     """
     _obstruct(three_inputs / filename, obstacle)
     try:
@@ -957,11 +901,10 @@ def test_the_vocab_fingerprint_covers_the_descriptions_not_only_the_slugs(corpus
     And it is order-independent for the same reason `store_fingerprint` is: the order a
     vocabulary happens to be loaded in is a property of the load, not of what it contains.
 
-    Seen red under three mutations: `f"{topic.slug}"` (the description dropped) on the
-    first assertion, `f"{topic.description}"` (the slug dropped) on the second, and
-    `sorted(...)` → `vocab` on the third. The rename PRESERVES SORT POSITION
-    (`agent-evaluationz` sorts where `agent-evaluation` did) so that the second assertion
-    cannot pass merely by reordering the concatenation — the way its first version did on
+    Seen red under three mutations: the description dropped from each pair on the first
+    assertion, the slug dropped on the second, and `sorted(...)` → `vocab` on the third. The
+    rename PRESERVES SORT POSITION (`agent-evaluationz` sorts where `agent-evaluation` did) so
+    the second assertion cannot pass merely by reordering — the way its first version did on
     the topics fingerprint below.
     """
     _store, vocab, _pages = corpus
@@ -989,19 +932,16 @@ def test_the_topics_fingerprint_covers_the_overview_every_note_and_the_slug(corp
     each is a chunk a consumer can be served: the overview, ANY note (not just the first),
     and the slug those chunks are filed under.
 
-    THE RENAME PRESERVES SORT POSITION ON PURPOSE. The first version of this assertion
-    refiled the page as `renombrado`, which sorts AFTER `ai-policy` — so the two pages'
-    text swapped places in the concatenation and the hash moved whether or not the slug was
-    hashed at all. Measured: under the mutant `parts.append(slug)` deleted, that version
-    stayed GREEN and only `test_the_topics_fingerprint_agrees_with_the_emitter` went red.
-    Rule 1, in the test written to pin the slug. `agent-evaluationz` sorts where
-    `agent-evaluation` did, so the slug is the only thing that changed.
+    THE RENAME PRESERVES SORT POSITION ON PURPOSE. The first version refiled the page as
+    `renombrado`, which sorts AFTER `ai-policy` — so the two pages' text swapped places and
+    the hash moved whether or not the slug was hashed at all. Measured: with the slug dropped,
+    that version stayed GREEN and only `…_agrees_with_the_emitter` went red. Rule 1, in the
+    test written to pin the slug. `agent-evaluationz` sorts where `agent-evaluation` did.
 
-    Seen red under two mutations: dropping the notes comprehension (the second assertion)
-    and `parts.append(slug)` deleted (the third). Hashing `page.overview` directly instead
-    of through `surface_fingerprint` stays GREEN here and is caught by
-    `test_the_topics_fingerprint_agrees_with_the_emitter` below — the reason that test
-    exists.
+    Seen red under two mutations: dropping the notes comprehension (the second assertion) and
+    dropping the slug from each page's entry (the third). Hashing `page.overview` directly
+    instead of through `surface_fingerprint` stays GREEN here and is caught by
+    `test_the_topics_fingerprint_agrees_with_the_emitter` below — why that test exists.
     """
     _store, _vocab, pages = corpus
     before = index_build.topics_fingerprint(pages)
@@ -1026,30 +966,96 @@ def test_the_topics_fingerprint_agrees_with_the_emitter(corpus) -> None:
 
     The fingerprint is asserted against `surface_fingerprint` computed HERE from the page's
     own text, so a change to the emitter's `(version, type, origin, text)` shape moves this
-    fingerprint too and the index re-derives. Hashing the raw text instead would leave a
+    fingerprint too and the index re-derives; hashing the raw text instead would leave a
     `SURFACE_VERSION` bump invisible to the topic plane while every item plane re-indexed.
-
     This is NOT the tautology `topics_fingerprint is topics_fingerprint`: the expected value
     is rebuilt from the page objects through the public emitter, so a version bump inside
     `surface_fingerprint` propagates to both sides but a change to the *composition* — the
-    surface types used, the order, the slug — moves only one. Seen red under the mutation
-    `surface_fingerprint("topic_note", ...)` → `surface_fingerprint("topic_overview", ...)`
-    for the notes, which every other test in this file passes.
+    surface types, the order, the slug, the SHAPE the plane is encoded in — moves only one.
+    Seen red under the mutation `surface_fingerprint("topic_note", ...)` →
+    `…("topic_overview", ...)` for the notes, which every other test in this file passes.
     """
     import hashlib
 
     from xbrain.knowledge.ids import surface_fingerprint
 
     _store, _vocab, pages = corpus
-    parts: list[str] = []
-    for slug in sorted(pages):
-        page = pages[slug]
-        parts.append(surface_fingerprint("topic_overview", "llm", page.overview))
-        parts += [surface_fingerprint("topic_note", "llm", note) for note in page.notes]
-        parts.append(slug)
-    expected = hashlib.sha256("\0".join(parts).encode("utf-8")).hexdigest()
+    plane = [
+        [
+            slug,
+            surface_fingerprint("topic_overview", "llm", pages[slug].overview),
+            [surface_fingerprint("topic_note", "llm", n) for n in pages[slug].notes],
+        ]
+        for slug in sorted(pages)
+    ]
+    blob = json.dumps(["topics", plane], ensure_ascii=False)
+    expected = hashlib.sha256(blob.encode("utf-8")).hexdigest()
 
     assert index_build.topics_fingerprint(pages) == expected
+
+
+def test_a_nul_cannot_forge_an_atom_boundary_on_the_vocabulary_or_the_topic_plane(
+    tmp_path: Path,
+) -> None:
+    """The same delimiter injection, on the two planes that never carried a length tag at all.
+
+    `vocab_fingerprint` joined `f"{slug}={description}"` and `topics_fingerprint` joined each
+    page's `[overview_fp, *note_fps, slug]`, both with `\\0` — so a NUL in a description or in
+    a page KEY re-splits the stream exactly as on the item plane. One vocabulary entry can
+    impersonate two, and one topic page whose key smuggles a NUL plus another page's OVERVIEW
+    FINGERPRINT can impersonate two pages. The round 10 brute force that found no
+    `topics_fingerprint` collision drew slugs from an alphabet WITHOUT a NUL, so its 3,608
+    stores could not have reached this one, and `parse_topic_pages` takes the key verbatim.
+    `Topic.slug` IS pattern-constrained, so the vocabulary side injects through `description`.
+
+    Both survive their own writer and reader — PyYAML emits the NUL in a double-quoted scalar,
+    JSON as an escape — asserted before any hash. Each half then guards that the join this
+    replaces produced the SAME bytes for the two states, so neither assertion can pass merely
+    because two objects differ. Seen RED at `1c32cf9`, vocabulary `755851876951afa8…` and
+    topic plane `9e19e27318ea9436…` on both sides.
+    """
+    from xbrain.knowledge.ids import surface_fingerprint
+    from xbrain.rubrics import load_vocab, save_vocab
+    from xbrain.store import load_topic_pages, save_topic_pages
+
+    vocab_path = tmp_path / "vocab.yaml"
+    vocabs = []
+    for entries in ([("a", "x\0b=y")], [("a", "x"), ("b", "y")]):
+        save_vocab([Topic(slug=s, description=d) for s, d in entries], vocab_path)
+        vocabs.append(load_vocab(vocab_path))
+    assert vocabs[0] != vocabs[1], "one entry and two entries, both back through PyYAML"
+    joined = ["\0".join(f"{t.slug}={t.description}" for t in v) for v in vocabs]
+    assert joined[0] == joined[1], "the join this replaces serialised both to the same bytes"
+    assert index_build.vocab_fingerprint(vocabs[0]) != index_build.vocab_fingerprint(vocabs[1]), (
+        "a NUL in a description must not split one vocabulary entry into two"
+    )
+
+    page = TopicPage(
+        slug="b",
+        overview="segunda",
+        notes=[],
+        synthesized_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        post_count_at_synth=1,
+    )
+    first = page.model_copy(update={"slug": "a", "overview": "primera"})
+    smuggled = f"a\0{surface_fingerprint('topic_overview', 'llm', page.overview)}\0b"
+    topics_path = tmp_path / "topics.json"
+    planes = []
+    for pages in ({smuggled: first}, {"a": first, "b": page}):
+        save_topic_pages(pages, topics_path)
+        planes.append(load_topic_pages(topics_path))
+    assert list(planes[0]) != list(planes[1]), "one page filed under a forged key, against two"
+    streams = [
+        "\0".join(
+            f"{surface_fingerprint('topic_overview', 'llm', p.overview)}\0{s}"
+            for s, p in sorted(plane.items())
+        )
+        for plane in planes
+    ]
+    assert streams[0] == streams[1], "and the join this replaces serialised both to the same bytes"
+    assert index_build.topics_fingerprint(planes[0]) != index_build.topics_fingerprint(planes[1]), (
+        "a page key carrying another page's overview fingerprint must not impersonate it"
+    )
 
 
 def test_the_index_loader_and_the_store_doors_parse_through_one_parser_each(
@@ -1058,15 +1064,14 @@ def test_the_index_loader_and_the_store_doors_parse_through_one_parser_each(
     """The seam `parse_store` / `parse_vocab` / `parse_topic_pages` exists FOR THIS (rule 5).
 
     `load_index_inputs` must bind what it parsed to the exact bytes it read, so it reads
-    through its own handle — and the only honest way to do that without a second copy of
-    every parse is to split the parse out of `load_store` / `load_vocab` /
-    `load_topic_pages` and share it. The property that matters is not "the seam exists" (a
-    tautology the moment it does) but that the TWO READERS OF THE SAME BYTES agree: the
-    path-based door every other stage uses, and the handle-based one the index uses.
-
-    Seen red under the mutation `parse_vocab` → `data.get("topics")` without `Topic(**entry)`
-    (raw dicts out of one door, `Topic` out of the other) and under a `load_index_inputs`
-    that parsed the store with a bare `json.loads`.
+    through its own handle — and the only honest way to do that without a second copy of every
+    parse is to split the parse out of `load_store` / `load_vocab` / `load_topic_pages` and
+    share it. The property that matters is not "the seam exists" (a tautology the moment it
+    does) but that the TWO READERS OF THE SAME BYTES agree: the path-based door every other
+    stage uses, and the handle-based one the index uses. Seen red under the mutation
+    `parse_vocab` → `data.get("topics")` without `Topic(**entry)` (raw dicts out of one door,
+    `Topic` out of the other) and under a loader that parsed the store with a bare
+    `json.loads`.
     """
     from xbrain.rubrics import load_vocab
     from xbrain.store import load_store, load_topic_pages


### PR DESCRIPTION
**Plan 02, child 02.6a — the three inputs, the bound signal, the fingerprints.**

| | |
|---|---|
| **base** | `VGonPa/umbrella-knowledge-index-lexical` @ `2c0a631` (unmoved) |
| **head** | `VGonPa/knowledge-index-02-6a-inputs` @ `e4413be` |
| **lineage** | first atomic replacement child of **#160**, now **superseded and closed** (tip `0e1b4a0`, kept as immutable evidence) |
| **sync child due?** | **no** — `git merge-base --is-ancestor origin/develop 2c0a631` → true |
| **next child** | **02.6b — the manifest** (read / write / compat) |

**Every figure below was re-derived against `e4413be`.** The previous body's figures described
`bfbaf87` under a header claiming they described `1c32cf9`; four were stale and one sentence was
false. Each is corrected here **and named**, because a body that quietly fixes its own numbers
teaches the next reader nothing (rule 2, rule 6).

## What round 12 changes, and why round 11's fix was not enough

Round 11 framed the three variadic regions with `topics:N` / `kinds:M` / `rows:K` and this body
claimed that made the stream *"decodable **by construction**"*, removing *"the need for any
argument about which strings can appear"*. **That sentence was false, and three independent
reviewers falsified it.** The tags framed the REGIONS; nothing framed the ATOMS inside them, and
the tags themselves lived inside the same NUL-joined stream they were meant to delimit. One
U+0000 anywhere re-splits it and every later boundary moves — the tag included.

**Three collisions, each reproduced at `1c32cf9`, each surviving its REAL writer and reader** —
so none of them is a byte only memory can hold:

| plane | the two states | both hash |
|---|---|---|
| item / store | `Enrichment.topics` `("a<NUL>b","c")` vs `("a","b<NUL>c")` — same length, so `topics:2` is byte-identical on both sides | `f970afed…` |
| vocabulary | `[Topic("a","x<NUL>b=y")]` vs `[Topic("a","x"), Topic("b","y")]` | `755851876951afa8…` |
| topic plane | one page keyed `"a<NUL><the other page's overview fingerprint><NUL>b"` vs two pages | `9e19e27318ea9436…` |

`Enrichment.topics` is `list[str]` with no pattern, `Topic.description` is unconstrained, and
`parse_topic_pages` takes the page KEY verbatim. JSON persists a NUL as a `` escape and
PyYAML as `\0` in a double-quoted scalar, so **each pair is still two distinct objects after
`save_store`/`load_store`, `save_vocab`/`load_vocab` and `save_topic_pages`/`load_topic_pages`
— which the tests assert BEFORE they compute any hash.** It fails OPEN, the one direction this
module is built not to fail in.

**Round 10's `topics_fingerprint` sweep could not have found this.** It built 3,608 stores with
slugs drawn from an alphabet **without a NUL**, so the collision above was outside its
population. The sweep was honest; its population was the limit (rule 2).

## The fix — one encoder, injective by round trip

`_canonical(domain, value)` replaces the join in **all four** fingerprints:

```python
def _canonical(domain: str, value: object) -> str:
    return json.dumps([domain, value], ensure_ascii=False)
```

`json.loads` recovers the exact structure, so **two different structures cannot encode alike** —
a left inverse, not a hunch. No argument about which strings can appear is left. The three count
tags are **deleted**: the regions are nested JSON arrays now, so the boundary is structural, and
`store_fingerprint` / `vocab_fingerprint` stop using `=`-joined pairs.

Three choices inside it, each **measured** rather than asserted:

- **`ensure_ascii=False` is a correctness setting, not a formatting one.** With `True`, a lone
  surrogate PAIR and the astral character it spells serialise to the **same** escape, which is a
  collision. With `False` they are different bytes, and a lone surrogate raises at
  `.encode("utf-8")` instead: fail-closed, the direction this module fails in everywhere else.
  **Nothing held this** — the flip left the whole suite green, because the fixture corpus is pure
  ASCII. It now has its own red test.
- **`domain` is hashed in.** `store_fingerprint({"a": i})` and a one-entry vocabulary whose slug
  is `a` and whose description is `i`'s fingerprint were **both** `[["a", <64 hex>]]` — measured
  EQUAL. Not consequential while the manifest keeps the planes in separate columns; closed
  anyway, because it costs one argument.
- **`item.bookmark_folder` unwrapped from `or ""`.** `None` and `""` are two states the store can
  hold and they hashed alike.

**Every stored fingerprint is retired by this, with no version bump to announce it.** Over the
live 2,404-item corpus (`data/items.json`, sha256 `f76341a3…`, read-only), `store_fingerprint`
moves `ed83a9a6d6d8942a…` → `1576dd5c03fdf3ec…`. **Free in this tree** — no manifest is sealed
until 02.6b — and expensive after 02.7, so this is the window. Cost: none measurable; the old
scheme already called `json.dumps` once per surface row, the new one calls it once per item.

## Red first — seen red at `1c32cf9`, in an isolated copy

`pyproject.toml` sets `[tool.pytest.ini_options] pythonpath = [".", "src"]` and pytest
**prepends** those, so a `PYTHONPATH` trick run from the worktree silently loads the real module
and an amputation reports green. Every run below is from the copy's own rootdir with
`index_build.__file__` asserted onto it and printed.

```
$ git archive 1c32cf9 | tar -x -C $COPY && cp tests/test_knowledge_index_build.py $COPY/tests/
$ cd $COPY && pytest tests/test_knowledge_index_build.py -q -p no:cacheprovider -o addopts='' -k nul
   module: $COPY/src/xbrain/knowledge/index_build.py   has _canonical: False
2 failed, 42 deselected
$ cd $COPY && pytest tests/test_knowledge_index_build.py -q -p no:cacheprovider -o addopts=''
4 failed, 40 passed
```

The four at the old head are the two NUL tests, the `_canonical` encoder test (the function does
not exist there) and `test_the_topics_fingerprint_agrees_with_the_emitter`, which re-types the
encoding by hand and is therefore *supposed* to move with it. On this head: **44 passed**.

### Mutations on this tree — each measured, and the two that redden nothing are named

| mutation | measured | |
|---|---|---|
| unmutated | **44 passed** | |
| splice the three nested regions back into the parent array | **1 failed, 43 passed** | diagonal — the region test |
| `ensure_ascii=False` to `True` | **1 failed, 43 passed** | diagonal — the encoder test |
| drop the `domain` argument from the payload | **1 failed, 43 passed** | diagonal — the emitter test |
| restore the whole flat NUL-join (the pre-fix encoding) | **3 failed, 41 passed** | region + item NUL + emitter |
| `vocab_fingerprint` back to `f"{slug}={description}"` | **1 failed, 43 passed** | diagonal — the vocabulary test |
| `topics_fingerprint` back to flat `[ov, *notes, slug]` | **2 failed, 42 passed** | topic NUL + emitter |
| `store_fingerprint` back to `f"{id}={fp}"` | **44 passed** | **REDDENS NOTHING — residue, below** |
| `item.bookmark_folder` back to `or ""` | **44 passed** | **REDDENS NOTHING — residue, below** |

**The splice mutation is the load-bearing one.** It shows the region property survives with the
count tags already gone: what three literal tags used to carry is now carried by the JSON
nesting, and a refactor that flattens it cannot land green. Deleting the tags is therefore a
simplification, not a removed guard.

## The figures the previous body got wrong, each named

| claim | was | is |
|---|---|---|
| the numstat transcript's label | `git diff --numstat 2c0a631 bfbaf87` printing `1c32cf9`'s output | re-run below against this head |
| framing-removal mutation | `1 failed, 40 passed` — published twice, once in a **shipped docstring** | the row it described no longer exists; the table above replaces it, measured |
| `index_build.py` coverage from its own test file | `87/87 statements` | **83/83, 100 %** (a reviewer measured `89/89` at `1c32cf9`; the count fell because the tags and the per-row `json.dumps` are gone) |
| "decodable **by construction** … removes the need for any argument about which strings can appear" | asserted | **false as written**, and now true for a different reason — above |
| section Size | "1,494 touched … Source 374, tests 947" (374 + 947 + 26 = 1,347, incoherent) | re-derived below |
| `107 of 259` no-speech videos, in a shipped docstring | undated | **108 of 260**, re-derived 2026-09-03 on store `f76341a3…` |
| "the only executable lines absent from #160 are the three narrowed imports" | true at `bfbaf87`, published under a `1c32cf9` header | retired — this head adds genuinely new code (the encoder and its call sites) |

## The four files

```
$ git diff --numstat 2c0a631 e4413be
385	0	src/xbrain/knowledge/index_build.py
6	1	src/xbrain/rubrics.py
17	2	src/xbrain/store.py
1086	0	tests/test_knowledge_index_build.py
→ +1,494 −3 = 1,497 touched
```

Two are new (the module and its test); the other two are the **parser seams the contract
requires** — `parse_store` / `parse_topic_pages` (`store.py`) and `parse_vocab` (`rubrics.py`).
`load_index_inputs` must bind what it parsed to the exact bytes it read, so it reads through its
own handle, and the only honest way to do that without a **second copy** of every parse is to
split the parse out and share it (rule 5). They are **byte-identical to `0e1b4a0`**
(`git diff 0e1b4a0 e4413be -- src/xbrain/store.py src/xbrain/rubrics.py` → empty) and bound by a
test that avoids the rule-1 identity tautology: it asserts the two READERS OF THE SAME BYTES
agree, not that the seam exists.

## Size

**1,497 touched of the fixed 1,500 ceiling.** The encoding fix and its three new tests were paid
for out of the existing text, not added on top, and here is exactly where the room came from —
none of it removes a property the suite could detect:

- **prose that restated another docstring in the same PR.** The test file's module docstring, the
  timestamp-proxy argument, the destruction narrative for `_read_bound`, the
  `surface_fingerprint`-by-design paragraph and the `producer` paragraph each existed **twice**;
  the canonical copy stays in the source module and the duplicate is now a pointer to it.
- **the two `_read_bound` unreadable-input tests merged into one** parametrised over all three
  inputs (`items.json`, `vocab.yaml`, `topics.json`) times two obstacles. **Identical case count
  (6), and strictly stronger on `items.json`**, which now goes through the three-path loader
  instead of the one-path one. Both consequence narratives survive in the merged docstring.
- **one test folded into its own superset.** `…reaches_an_item_with_no_content` used the same
  fixture item, the same patch and the same assertion as `…changes_when_indexable_text_changes`,
  which additionally asserts stability — no mutation could redden one without the other. Its
  **one** unique line, the `content is None` precondition, moved into the survivor with the
  rule-6 reason it is there.
- **a `_rows(item)` helper** for the projection call every guard makes, and one `parametrize`
  case collapsed onto a single line.

Test count is unchanged at **44** — one test removed, one added. **What moved is not the count
but what the suite can redden:** the test that left was one no mutation could redden alone; the
one that arrived reddens a mutation the whole file previously passed.

Honest context, with the previous body's arithmetic corrected: the plan budgeted **1,125** for
02.6 *entire* — inputs **plus** manifest — and 02.6a alone consumes **1,497**, of which source is
**385** and tests **1,086** (385 + 1,086 + 26 for the two seam files = 1,497, which is the
identity, not a coincidence: both large files are new, so their line counts *are* their
additions). **The excess is tests** — the plan allotted 334 test lines. **02.6b must be sized
against this state**, not against the original 02.6 budget.

## The gate

```
$ bash scripts/check.sh                       # on this exact tree
ALL CRITICAL CHECKS PASSED                    (exit 0)
Tests                   PASS - 2276 tests  (+ 1 xfailed)
Coverage                94%
Coverage (knowledge/)   PASS - 95%   (floor 90)
Ruff / Format / Mypy / Bandit / Vulture / Interrogate / Detect-secrets / Deptry   PASS
Radon                   WARN - grade C  (pre-existing, warn-only)
```

`tests/test_knowledge_index_build.py`: **44 tests**. **`index_build.py` is at 100 % from its own
test file (83/83 statements)** — and that figure is the strongest rule-1 argument in this PR,
because **87 of 87 statements were covered at `f634cc6` while four contract axes could still be
deleted with the suite green**, and because this round found `ensure_ascii` at 100 % coverage and
**0 % protection**. Coverage measures lines executed, never properties pinned.

**The merge tree IS this tree**: `git merge-tree --write-tree 2c0a631 e4413be` =
**`04745ec7a3a1bd98f807d38ca60af5b0b78b9d07`** = `git rev-parse e4413be^{tree}`, so rule 4 is met
with its authorising equality rather than by assertion.

GitHub `quality` on the exact head, read on the **check-run** surface (rule 9, never
`gh pr checks`' exit status): `status=completed`, **`conclusion=success`**,
`head_sha=e4413be3a0306d67d0ae80b11b45e3243d2a5da7`. Umbrella branch protection: `quality`
required, `strict: true`, `enforce_admins: true`, approvals **0** (rule 12).

Tree clean, nothing untracked, **no `zz-support-files/` and no `data/` in the diff** — the
planning-matrix update lives in the internal report and is deliberately not committed.

## Residue, stated as residue

- **Two mutations redden nothing, and they are in the table above rather than left out of it.**
  `store_fingerprint` back to `f"{id}={fp}"` and `bookmark_folder` back to `or ""` both leave 44
  passing. Neither is a live defect — the shipped encoding is injective on both — but neither
  call site has a test that would catch a regression of it. Naming them is the point; a residue
  only the mutation log knows about is a residue nobody will fix.
- **`vocab_fingerprint` is not order-independent when two topics share a slug.**
  `sorted(..., key=slug)` is stable, so two vocabularies differing only in the load order of a
  duplicated slug fingerprint differently, and `parse_vocab` accepts duplicates from YAML. The
  direction is safe (a spurious *changed*), and the order-independence test passes only because
  no fixture has a duplicated slug. Pre-existing, untouched here, and written down because it was
  written down nowhere.
- **N1 is still not taken**: `_stat_signal` catches **every** `OSError` and answers `(0, 0)` while
  `_read_bound` narrows to `FileNotFoundError`. The asymmetry is correct in both directions — a
  `chmod 000` at query time compares unequal and declares the index **behind**, the warning
  direction — but its safety lives in the *other* function and only `_read_bound` explains
  itself. **No test can redden a missing sentence**, so it is deferred rather than spent.
- **L3 (CRLF) is still not taken**: `load_store` reads in text mode and `_read_bound` in binary,
  so on a CRLF file the two doors feed different strings to the same parser. Measured: the
  resulting objects are equal for JSON and YAML, so the "one parser" property holds at object
  level, not at byte level. It is an acceptance criterion for **02.6b**, which re-reads these
  doors.
- **`surface_row` and `index_schema` are still kept in correspondence BY HAND.** 02.7 owes the
  writer that binds the tuple to the `INSERT` and the red-first readback test. Read any claim of
  that guard as 02.7's obligation, never as one discharged.
- `data/` is read **read-only** and by nothing in the shipped code; both corpus figures quoted
  above carry their date and the store hash.

## Next

**02.6b — the manifest**: its field contract, `write_manifest`, `load_manifest`,
`load_compatible_manifest`, `StoreSignal.to_dict` / `from_dict`, and the malformed / nested /
compatibility test family #160 restored at `0e1b4a0`. Those tests must **not** be restored again
by 02.7.

Do not merge — draft, opened before formal review as required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pp9NWtQNXreGpeaK7Qk59x
