### PR TITLE
feat(knowledge): the three inputs read as one snapshot, the signal bound to those bytes (Plan 02, child 02.6a1)

### DIFF
--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -1,0 +1,192 @@
+"""The three inputs of the index, read as ONE snapshot, with the cheap signal bound to it
+(Plan 02 §2, §3; spec §5.6).
+
+ONE CHEAP SIGNAL, PAID ON EVERY QUERY. Indexing is MANUAL BY DECISION (spec §9.2), so the
+failure that actually happens is not corruption — it is *you ran `enrich` and did not
+reindex*. `StoreSignal` is `mtime_ns` and size of the THREE inputs: three `os.stat`, cheap
+enough for every query, and it answers *an input moved*. It cannot answer *WHICH items
+changed* — that is a per-item fingerprint over the emitted surfaces, a different cost paid
+only by build/update/status, and it is the next child's. Nothing here computes one.
+
+The cheap signal can give false positives (a `touch` with no edit) and that is accepted: a
+false positive costs one warning, a false negative costs serving stale evidence as fresh. It
+fails towards the warning, the same direction `origin: unknown -> llm_synthesis` fails.
+
+THE SIGNAL DESCRIBES THE BYTES THAT WERE PARSED, NOT THE PATH. `load_index_inputs` reads each
+input through its OWN handle and takes the signal from `os.fstat` of that handle, BEFORE the
+read; see its docstring for the failure that shape exists to close.
+
+NOTHING HERE WRITES TO THE STORE. The three inputs are read and never touched, and no command
+of this plan snapshots, because none is destructive: `data/index/` is derived and
+reconstructible by definition (spec §5.6).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from xbrain.models import Item, Topic, TopicPage
+from xbrain.rubrics import parse_vocab
+from xbrain.store import parse_store, parse_topic_pages
+
+
+@dataclass(frozen=True)
+class StoreSignal:
+    """The CHEAP change signal: `mtime_ns` and size of the THREE inputs (spec §5.6, P1a).
+
+    Three `os.stat`, so a query can afford it on every call. A missing file yields zeros
+    rather than raising: a query must still say *the index is behind* when the store has been
+    moved away, and `search` is the wrong place to learn it by exception. `_stat_signal` holds
+    that promise for every `OSError`, not only for absence — the reasoning is there.
+
+    THREE FILES, NOT ONE (P1a, gate Codex round 05). Spec §5.6 names `data/items.json`, and
+    that is what the first version stat'ed — but the index derives from `vocab.yaml` and
+    `topics.json` too: a topic description enters every assigned item's PROFILE (spec §5.1.A),
+    and overviews and notes are chunks the index serves. The query door compared `items.json`
+    alone, so `xbrain topics` — which writes `topics.json` and never `items.json` — left every
+    later `search` answering over the old topic plane with nothing declared, the silent
+    staleness spec §9.3 forbids, on two of the three inputs.
+
+    ALL SIX FIELDS ARE REQUIRED, AND THAT IS THE FIX, NOT AN OVERSIGHT. They carried
+    `= 0` defaults so a caller could build a two-input signal; zeros are also what an ABSENT
+    file reads as, so a signal that omitted the vocabulary was byte-identical to one taken
+    over a vocabulary that is not there. Two such signals compare EQUAL forever, however
+    `vocab.yaml` changes — the round-05 defect above, reinstated by one missing argument, in
+    the false-negative direction this signal is built never to fail in. A reader that must
+    supply a legacy zero (a manifest written before the vocabulary and the topic pages were
+    watched) states it at ITS OWN seam, where it knows the entry was absent from the
+    persisted record rather than absent from the caller's mind.
+    """
+
+    items_json_mtime_ns: int
+    items_json_size: int
+    vocab_yaml_mtime_ns: int
+    vocab_yaml_size: int
+    topics_json_mtime_ns: int
+    topics_json_size: int
+
+    @classmethod
+    def of(cls, items_path: Path, vocab_path: Path, topics_path: Path) -> StoreSignal:
+        """The signal of the three inputs AS THEY ARE ON DISK NOW — the query-time side."""
+        items_mtime, items_size = _stat_signal(items_path)
+        vocab_mtime, vocab_size = _stat_signal(vocab_path)
+        topics_mtime, topics_size = _stat_signal(topics_path)
+        return cls(
+            items_json_mtime_ns=items_mtime,
+            items_json_size=items_size,
+            vocab_yaml_mtime_ns=vocab_mtime,
+            vocab_yaml_size=vocab_size,
+            topics_json_mtime_ns=topics_mtime,
+            topics_json_size=topics_size,
+        )
+
+
+def _stat_signal(path: Path) -> tuple[int, int]:
+    """`(mtime_ns, size)` of one input file, or `(0, 0)` when it cannot be stat'ed.
+
+    EVERY `OSError` IS SWALLOWED HERE, and the breadth is the contract, not laziness: this is
+    the function a query pays on every call, and its whole promise is that a query can always
+    ANSWER — declaring the index behind — instead of learning about the filesystem by
+    exception from inside `search`. Absence is the common case; a path standing inside a
+    regular file, a directory whose permissions were dropped, an `EIO` from a failing mount
+    are the same answer to the only question asked here, *did this input move*, and zeros make
+    the comparison unequal, which is the warning.
+
+    `_read_bound` is the DELIBERATE opposite and the pair is the design: what the loader
+    cannot read is an error, because an unreadable store is not an empty one.
+    """
+    try:
+        stat = path.stat()
+    except OSError:
+        return 0, 0
+    return stat.st_mtime_ns, stat.st_size
+
+
+@dataclass(frozen=True)
+class IndexInputs:
+    """The three inputs of the index AND the cheap signal of the snapshot they were read from.
+
+    The signal travels WITH the objects because it describes them (P1b): taken from the path
+    at any other moment it describes whatever file is there then, which is what let a manifest
+    certify an `items.json` its own base had never seen.
+    """
+
+    store: dict[str, Item]
+    vocab: list[Topic]
+    topic_pages: dict[str, TopicPage]
+    signal: StoreSignal
+
+
+def load_index_inputs(items_path: Path, vocab_path: Path, topics_path: Path) -> IndexInputs:
+    """Read the three inputs and return them WITH the signal of the bytes that were read.
+
+    THE SIGNAL IS BOUND TO THE SNAPSHOT, NOT TO THE PATH (P1b, gate Codex round 05). The shape
+    this closes: a caller loads the store, commits rows from it, and only then seals
+    `StoreSignal.of(items_path)` — a `stat` of whatever file the path points at by then. A
+    save landing in that window puts the rows under the OLD objects and the signal under the
+    NEW file's mtime and size, so a later query compares EQUAL and answers over stale rows
+    with nothing declared. The gate's probe A: `raceonlytoken` in the file, not in the rows,
+    `degraded: ("no_embeddings",)`, `items_changed=1`, `behind=False`.
+
+    Every file is read through ITS OWN HANDLE and the signal is `os.fstat` of that handle,
+    taken BEFORE the read. Both halves matter and they fail differently. The HANDLE closes the
+    atomic case: the store's writers replace files (`os.replace`), so an open handle keeps the
+    inode it opened, the bytes parsed are that inode's, and the replacement leaves the PATH on
+    a newer inode that query-time `StoreSignal.of` reports as different — the index declares
+    itself behind. BEFORE closes the in-place case: `save_vocab` rewrites through
+    `write_text`, which truncates the inode the reader is holding, so a stat taken after the
+    read would describe bytes this loader never parsed and seal them as the snapshot; taken
+    before, it is older than the content, the comparison is unequal, and the index is again
+    declared behind. Same direction, the warning.
+
+    A MISSING file reads as its empty value and a zero signal, exactly as `load_store`,
+    `load_vocab`, `load_topic_pages` and `StoreSignal.of` treat it. A file that EXISTS and
+    cannot be read RAISES (A-2) — see `_read_bound`.
+    """
+    items_text, items_mtime, items_size = _read_bound(items_path)
+    vocab_text, vocab_mtime, vocab_size = _read_bound(vocab_path)
+    topics_text, topics_mtime, topics_size = _read_bound(topics_path)
+    return IndexInputs(
+        store=parse_store(items_text) if items_text is not None else {},
+        vocab=parse_vocab(vocab_text) if vocab_text is not None else [],
+        topic_pages=parse_topic_pages(topics_text) if topics_text is not None else {},
+        signal=StoreSignal(
+            items_json_mtime_ns=items_mtime,
+            items_json_size=items_size,
+            vocab_yaml_mtime_ns=vocab_mtime,
+            vocab_yaml_size=vocab_size,
+            topics_json_mtime_ns=topics_mtime,
+            topics_json_size=topics_size,
+        ),
+    )
+
+
+def _read_bound(path: Path) -> tuple[str | None, int, int]:
+    """`(text, mtime_ns, size)` of one input, the stat taken on the handle the text came from.
+
+    `(None, 0, 0)` FOR AN ABSENT FILE, AND FOR NOTHING ELSE (A-2, round 08). The first version
+    caught every `OSError` and answered `(None, 0, 0)`, so a file that EXISTS and cannot be
+    read — a `chmod 000`, a directory standing in its place, an `EIO` from a failing mount —
+    loaded as the empty store reserved for a missing one: the cheap signal still stat'ed fine,
+    so no door saw anything wrong, and on the real index `status` reported `items_removed
+    2404` as healthy, `search` answered zero results with exit 0, `update` planned the deletion
+    of every item and `build --force` replaced 22,286 chunks with the topic plane's 703, sealed
+    consistent, exit 0. `load_store` only ever read an ABSENT file as `{}`; this loader agrees,
+    and every other `OSError` propagates to the caller unswallowed. Turning it into
+    `Error: <file>` and exit 1 is the door's job and no door in this tree loads through here
+    yet: read that as the obligation the first consumer owes, never as behaviour shipped here.
+
+    A file that exists and is not UTF-8 raises `UnicodeDecodeError`, which is a `ValueError`
+    and not an `OSError` at all, so it is outside the `FileNotFoundError` guard by type as
+    well as by intent — the same thing `load_store` does at the same seam.
+    """
+    try:
+        handle = path.open("rb")
+    except FileNotFoundError:
+        return None, 0, 0
+    with handle:
+        stat = os.fstat(handle.fileno())
+        data = handle.read()
+    return data.decode("utf-8"), stat.st_mtime_ns, stat.st_size

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -16,9 +16,10 @@ THE SIGNAL DESCRIBES THE BYTES THAT WERE PARSED, NOT THE PATH. `load_index_input
 input through its OWN handle and takes the signal from `os.fstat` of that handle, BEFORE the
 read; see its docstring for the failure that shape exists to close.
 
-NOTHING HERE WRITES TO THE STORE. The three inputs are read and never touched, and no command
-of this plan snapshots, because none is destructive: `data/index/` is derived and
-reconstructible by definition (spec §5.6).
+NOTHING HERE WRITES TO THE STORE. The three inputs are read and never touched, and THIS module
+ships no command and takes no snapshot — it only reads (`data/index/` is derived and
+reconstructible, spec §5.6). Said of this module, not of the plan: `build --force` DOES destroy a
+good index, and round 08 caught it doing exactly that at exit 0.
 """
 
 from __future__ import annotations
@@ -31,6 +32,12 @@ from xbrain.models import Item, Topic, TopicPage
 from xbrain.rubrics import parse_vocab
 from xbrain.store import parse_store, parse_topic_pages
 
+UNSTATTABLE = (-1, -1)
+"""What a query reads for an input it cannot stat, IMPOSSIBLE ON A REAL `os.stat`, and that is
+the whole contract. `st_size` is a byte count and never negative, while a pre-epoch `st_mtime_ns`
+IS negative (measured) — so the SIZE is the half that makes the pair unforgeable. And
+`_read_bound` RAISES on every obstruction producing it, so no snapshot can ever SEAL it."""
+
 
 @dataclass(frozen=True)
 class StoreSignal:
@@ -38,8 +45,8 @@ class StoreSignal:
 
     Three `os.stat`, so a query can afford it on every call. A missing file yields zeros
     rather than raising: a query must still say *the index is behind* when the store has been
-    moved away, and `search` is the wrong place to learn it by exception. `_stat_signal` holds
-    that promise for every `OSError`, not only for absence — the reasoning is there.
+    moved away, and `search` is the wrong place to learn it by exception. An input obstructed
+    for ANY OTHER reason reads as `UNSTATTABLE` and never as those zeros — `_stat_signal`.
 
     THREE FILES, NOT ONE (P1a, gate Codex round 05). Spec §5.6 names `data/items.json`, and
     that is what the first version stat'ed — but the index derives from `vocab.yaml` and
@@ -84,31 +91,46 @@ class StoreSignal:
 
 
 def _stat_signal(path: Path) -> tuple[int, int]:
-    """`(mtime_ns, size)` of one input file, or `(0, 0)` when it cannot be stat'ed.
+    """`(mtime_ns, size)` of one input: zeros when ABSENT, `UNSTATTABLE` when OBSTRUCTED.
 
     EVERY `OSError` IS SWALLOWED HERE, and the breadth is the contract, not laziness: this is
     the function a query pays on every call, and its whole promise is that a query can always
     ANSWER — declaring the index behind — instead of learning about the filesystem by
-    exception from inside `search`. Absence is the common case; measured, the two other
-    reachable ones are a path standing INSIDE a regular file (`NotADirectoryError`, `ENOTDIR`)
-    and a PARENT directory whose permissions were dropped (`PermissionError`, `EACCES`), and
-    an `EIO` from a failing mount is the same shape without a way to stage it here. All of
-    them are one answer to the only question this asks — *did this input move* — and zeros
-    make the comparison unequal, which is the warning.
+    exception from inside `search`. Measured, the reachable ones are a path standing INSIDE a
+    regular file (`NotADirectoryError`, `ENOTDIR`), a symlink loop (`ELOOP`) and a PARENT
+    directory whose permissions were dropped (`PermissionError`, `EACCES`); an `EIO` from a
+    failing mount is the same shape with no way to stage it here.
+
+    BUT ABSENCE IS NOT ONE OF THEM, AND SPLITTING IT OFF IS THE ROUND-09 FIX (Codex, HIGH). Both
+    read `(0, 0)` before. `_read_bound` SEALS zeros for an ABSENT input, so an index built while
+    `items.json` was missing compared EQUAL to a query taken once that same path could no longer
+    be stat'ed: it certifies itself current over an input it never opened, and *I could not stat
+    it* is never evidence that nothing moved. Absence keeps the zeros — a manifest's legacy zero
+    still reads as absence — and every other `OSError` answers `UNSTATTABLE`. The warning again.
+
+    THE ZEROS STILL COLLIDE WITH ONE REAL STATE, the harmless one: a file that EXISTS, is EMPTY
+    and carries an `mtime_ns` of exactly 0 stats as `(0, 0)` (measured). It takes a deliberate
+    `os.utime(path, ns=(0, 0))` — no writer here emits a zero-byte input (2, 11 and 2 bytes,
+    measured) — and both readings mean the same downstream: `parse_vocab("")` is `[]` either way,
+    and `parse_store("")` RAISES rather than passing as an empty store. Left alone: separating it
+    would need a sentinel a real stat CAN produce, which is what the one above is not.
 
     WHAT DOES NOT REACH THIS `except`, and it is worth knowing which: `stat` needs neither
     read permission on the file nor the file to be a file, so a `chmod 000` FILE and a
     directory standing in its place both stat FINE. They are exactly the obstacles that reach
     `_read_bound` instead, which is why the test that holds this breadth had to be built on
-    `ENOTDIR` and not on either of those.
+    `ENOTDIR` and not on either of those. Nor does a path carrying an embedded NUL: it raises
+    `ValueError` before any syscall, and it is the one shape that escapes the promise above.
 
     `_read_bound` is the DELIBERATE opposite and the pair is the design: what the loader
     cannot read is an error, because an unreadable store is not an empty one.
     """
     try:
         stat = path.stat()
-    except OSError:
+    except FileNotFoundError:
         return 0, 0
+    except OSError:
+        return UNSTATTABLE
     return stat.st_mtime_ns, stat.st_size
 
 
@@ -174,7 +196,9 @@ def load_index_inputs(items_path: Path, vocab_path: Path, topics_path: Path) -> 
 def _read_bound(path: Path) -> tuple[str | None, int, int]:
     """`(text, mtime_ns, size)` of one input, the stat taken on the handle the text came from.
 
-    `(None, 0, 0)` FOR AN ABSENT FILE, AND FOR NOTHING ELSE (A-2, round 08). The first version
+    `(None, 0, 0)` FOR AN ABSENT TARGET, AND FOR NOTHING ELSE (A-2, round 08) — a dangling
+    symlink is that same case and not a further one, since `open` resolves it and raises the very
+    `ENOENT` an absent path raises, exactly as all three doors read it. The first version
     caught every `OSError` and answered `(None, 0, 0)`, so a file that EXISTS and cannot be
     read — a `chmod 000`, a directory standing in its place, an `EIO` from a failing mount —
     loaded as the empty store reserved for a missing one: the cheap signal still stat'ed fine,
@@ -185,14 +209,19 @@ def _read_bound(path: Path) -> tuple[str | None, int, int]:
     into `Error: <file>` and exit 1 is the door's job and no door in this tree loads through
     here yet: read that as the obligation the first consumer owes, never as behaviour shipped.
 
-    THIS LOADER IS STRICTER THAN THE THREE DOORS, ON EXACTLY TWO SHAPES, AND DELIBERATELY.
-    `load_store` / `load_vocab` / `load_topic_pages` gate on `Path.exists()`, which swallows
-    every `OSError` from its own `stat` and answers False for more than a missing file:
-    measured, a path standing inside a regular file (`ENOTDIR`) and a symlink loop (`ELOOP`)
-    both read back as `{}` / `[]` / `{}` through those doors, while opening either RAISES
-    here. That is the A-2 direction — an unreadable input is not an empty one — so the
-    divergence is the feature. It is also not hypothetical: `ENOTDIR` is the very obstruction
-    this module's own `_stat_signal` test builds, and it asserts this raise.
+    THIS LOADER IS STRICTER THAN THE THREE DOORS, ON EXACTLY TWO `OSError` SHAPES, DELIBERATELY.
+    `load_store` / `load_vocab` / `load_topic_pages` gate on `Path.exists()`, which answers False
+    for more than a missing file: it swallows exactly `pathlib`'s `_IGNORED_ERRNOS` — `ENOENT`,
+    `ENOTDIR`, `EBADF`, `ELOOP` — and RE-RAISES the rest, `PermissionError` (`EACCES`) included
+    (measured on CPython 3.12.11, the version CI pins). Two of those four are where this loader
+    parts company: a path inside a regular file (`ENOTDIR`) and a symlink loop (`ELOOP`) read back
+    as `{}` / `[]` / `{}` through those doors, while opening either RAISES here. Under `EACCES`
+    there is nothing to argue — the door raises too. That is the A-2 direction — an unreadable
+    input is not an empty one — so the divergence is the feature. It is also not hypothetical:
+    `ENOTDIR` is the obstruction this module's own `_stat_signal` test builds, and it asserts
+    this raise. A THIRD shape parts them and is NOT an `OSError`, which is why the count above
+    is scoped: `Path.exists()` also answers False on a `ValueError`, so a path with an embedded
+    NUL reads as `{}` / `[]` / `{}` through the doors while both halves here raise (measured).
 
     A file that exists and is not UTF-8 raises `UnicodeDecodeError`, which is a `ValueError`
     and not an `OSError` at all, so it is outside the `FileNotFoundError` guard by type as

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -89,10 +89,18 @@ def _stat_signal(path: Path) -> tuple[int, int]:
     EVERY `OSError` IS SWALLOWED HERE, and the breadth is the contract, not laziness: this is
     the function a query pays on every call, and its whole promise is that a query can always
     ANSWER — declaring the index behind — instead of learning about the filesystem by
-    exception from inside `search`. Absence is the common case; a path standing inside a
-    regular file, a directory whose permissions were dropped, an `EIO` from a failing mount
-    are the same answer to the only question asked here, *did this input move*, and zeros make
-    the comparison unequal, which is the warning.
+    exception from inside `search`. Absence is the common case; measured, the two other
+    reachable ones are a path standing INSIDE a regular file (`NotADirectoryError`, `ENOTDIR`)
+    and a PARENT directory whose permissions were dropped (`PermissionError`, `EACCES`), and
+    an `EIO` from a failing mount is the same shape without a way to stage it here. All of
+    them are one answer to the only question this asks — *did this input move* — and zeros
+    make the comparison unequal, which is the warning.
+
+    WHAT DOES NOT REACH THIS `except`, and it is worth knowing which: `stat` needs neither
+    read permission on the file nor the file to be a file, so a `chmod 000` FILE and a
+    directory standing in its place both stat FINE. They are exactly the obstacles that reach
+    `_read_bound` instead, which is why the test that holds this breadth had to be built on
+    `ENOTDIR` and not on either of those.
 
     `_read_bound` is the DELIBERATE opposite and the pair is the design: what the loader
     cannot read is an error, because an unreadable store is not an empty one.
@@ -173,14 +181,25 @@ def _read_bound(path: Path) -> tuple[str | None, int, int]:
     so no door saw anything wrong, and on the real index `status` reported `items_removed
     2404` as healthy, `search` answered zero results with exit 0, `update` planned the deletion
     of every item and `build --force` replaced 22,286 chunks with the topic plane's 703, sealed
-    consistent, exit 0. `load_store` only ever read an ABSENT file as `{}`; this loader agrees,
-    and every other `OSError` propagates to the caller unswallowed. Turning it into
-    `Error: <file>` and exit 1 is the door's job and no door in this tree loads through here
-    yet: read that as the obligation the first consumer owes, never as behaviour shipped here.
+    consistent, exit 0. Every other `OSError` propagates to the caller unswallowed. Turning it
+    into `Error: <file>` and exit 1 is the door's job and no door in this tree loads through
+    here yet: read that as the obligation the first consumer owes, never as behaviour shipped.
+
+    THIS LOADER IS STRICTER THAN THE THREE DOORS, ON EXACTLY TWO SHAPES, AND DELIBERATELY.
+    `load_store` / `load_vocab` / `load_topic_pages` gate on `Path.exists()`, which swallows
+    every `OSError` from its own `stat` and answers False for more than a missing file:
+    measured, a path standing inside a regular file (`ENOTDIR`) and a symlink loop (`ELOOP`)
+    both read back as `{}` / `[]` / `{}` through those doors, while opening either RAISES
+    here. That is the A-2 direction — an unreadable input is not an empty one — so the
+    divergence is the feature. It is also not hypothetical: `ENOTDIR` is the very obstruction
+    this module's own `_stat_signal` test builds, and it asserts this raise.
 
     A file that exists and is not UTF-8 raises `UnicodeDecodeError`, which is a `ValueError`
     and not an `OSError` at all, so it is outside the `FileNotFoundError` guard by type as
-    well as by intent — the same thing `load_store` does at the same seam.
+    well as by intent — and there the three doors agree, because they decode too. It is a
+    REFUSAL, not a repair: decoding with `errors="replace"` would turn undecodable bytes into
+    U+FFFD and index them as if they were the corpus, which is the fail-open family this whole
+    module exists to close, one layer lower.
     """
     try:
         handle = path.open("rb")

--- a/src/xbrain/rubrics.py
+++ b/src/xbrain/rubrics.py
@@ -150,7 +150,12 @@ def load_vocab(path: Path) -> list[Topic]:
     """Load the topic vocabulary; an empty list if the file does not exist."""
     if not path.exists():
         return []
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return parse_vocab(path.read_text(encoding="utf-8"))
+
+
+def parse_vocab(text: str) -> list[Topic]:
+    """The vocabulary from its YAML text — the ONE parser (see `store.parse_store`)."""
+    data = yaml.safe_load(text) or {}
     return [Topic(**entry) for entry in data.get("topics", [])]
 
 

--- a/src/xbrain/store.py
+++ b/src/xbrain/store.py
@@ -14,7 +14,17 @@ def load_store(path: Path) -> dict[str, Item]:
     """Load the item store; an empty dict if the file does not exist."""
     if not path.exists():
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    return parse_store(path.read_text(encoding="utf-8"))
+
+
+def parse_store(text: str) -> dict[str, Item]:
+    """The item store from its JSON text — the ONE parser, shared with the index loader.
+
+    Split from `load_store` so a reader that must bind what it parsed to the exact bytes it
+    read (`knowledge.index_build.load_index_inputs`) can read through its own file handle and
+    still parse through this function, instead of a second copy of these two lines.
+    """
+    raw = json.loads(text)
     return {item_id: Item.model_validate(data) for item_id, data in raw.items()}
 
 
@@ -40,7 +50,12 @@ def load_topic_pages(path: Path) -> dict[str, TopicPage]:
     """Load the topic-page store; an empty dict if the file does not exist."""
     if not path.exists():
         return {}
-    raw = json.loads(path.read_text(encoding="utf-8"))
+    return parse_topic_pages(path.read_text(encoding="utf-8"))
+
+
+def parse_topic_pages(text: str) -> dict[str, TopicPage]:
+    """The topic-page store from its JSON text — the ONE parser (see `parse_store`)."""
+    raw = json.loads(text)
     return {slug: TopicPage.model_validate(data) for slug, data in raw.items()}
 
 

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -8,6 +8,7 @@ fails in — is stated once, in `index_build.py`'s module docstring; it is not r
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from pathlib import Path
 
@@ -312,6 +313,29 @@ def test_neither_door_can_be_called_without_the_vocabulary_and_the_topic_pages()
             index_build.StoreSignal(*range(arity))  # type: ignore[call-arg]
 
 
+def test_the_signal_has_six_fields_in_order_none_defaulted_and_is_frozen() -> None:
+    """A DEFAULTED SEVENTH FIELD IS THE ROUND-05 DEFECT BACK, AND THE SWEEP ABOVE CANNOT SEE IT.
+
+    Measured: `guardrails_yaml_mtime_ns: int = 0` left 20 of 20 GREEN, because a default changes
+    no REQUIRED arity — so the sweep catches the SAFE variant (a required seventh field, red on
+    collection) and misses the dangerous one, this child's own thesis failing on itself one input
+    later. Zeros are what an ABSENT file reads as, so a defaulted field is a signal that compares
+    EQUAL forever over an input nobody passed. ORDER is pinned in the same breath because 02.6b
+    serialises this into a manifest, where a reorder that keeps the arity re-binds every value in
+    silence; and FROZEN, because a signal re-bindable after the read is not sealed (also 20/20).
+    """
+    fields = dataclasses.fields(index_build.StoreSignal)
+    inputs = ("items_json", "vocab_yaml", "topics_json")
+    assert [f.name for f in fields] == [f"{i}_{k}" for i in inputs for k in ("mtime_ns", "size")]
+    assert all(f.default is dataclasses.MISSING for f in fields), "no field may carry a default"
+    assert all(f.default_factory is dataclasses.MISSING for f in fields)
+
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        index_build.StoreSignal(*range(6)).items_json_size = 1  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        index_build.IndexInputs({}, [], {}, ZERO).store = {}  # type: ignore[misc]
+
+
 def test_an_input_that_is_not_utf8_is_refused_not_repaired(three_inputs: Path) -> None:
     """Undecodable bytes are a REFUSAL, and the refusal is the only thing standing there.
 
@@ -326,18 +350,16 @@ def test_an_input_that_is_not_utf8_is_refused_not_repaired(three_inputs: Path) -
     here — unlike `ENOTDIR` and `ELOOP`, where it is deliberately stricter — and a claim of
     agreement is worth exactly what the assertion that both raise is worth.
 
-    And the raised object is asserted NOT to be an `OSError`: that is what puts it outside the
-    `FileNotFoundError` guard by TYPE and not merely by intent, which is the sentence
-    `_read_bound` uses to explain why the guard cannot swallow it.
+    A third assertion stood here — `not isinstance(caught.value, OSError)` — and it is gone:
+    `pytest.raises(UnicodeDecodeError)` already fixes the type, so it could not fail (rule 1).
     """
     from xbrain.rubrics import load_vocab
 
     items, vocab, topics = _paths(three_inputs)
     vocab.write_bytes(b"topics:\n- slug: a\n  description: \xff\xfe not utf-8\n")
 
-    with pytest.raises(UnicodeDecodeError) as caught:
+    with pytest.raises(UnicodeDecodeError):
         index_build.load_index_inputs(items, vocab, topics)
-    assert not isinstance(caught.value, OSError), "outside the FileNotFoundError guard by type"
 
     with pytest.raises(UnicodeDecodeError):
         load_vocab(vocab)
@@ -371,14 +393,16 @@ def test_a_missing_input_is_zeroed_on_the_query_side_and_empty_on_the_load_side(
         (2, "topics_json_mtime_ns", "topics_json_size"),
     ],
 )
-def test_an_input_that_cannot_be_stat_ed_is_zeroed_for_a_query_and_raises_for_a_load(
+def test_an_input_that_cannot_be_stat_ed_answers_for_a_query_and_raises_for_a_load(
     three_inputs: Path, index: int, mtime_field: str, size_field: str
 ) -> None:
     """The two directions of A-2, on ONE obstruction, which is the only way to see the pair.
 
     `_stat_signal` swallows every `OSError`, not only `FileNotFoundError`, and this is the
     test that holds it: a query must be able to ANSWER — declaring the index behind — instead
-    of learning about the filesystem by exception from inside `search`. The obstruction is a
+    of learning about the filesystem by exception from inside `search`. What it answers is
+    `UNSTATTABLE`, NOT the zeros an absent input reads as — the round-09 split, whose
+    consequence is the transition test below. The obstruction is a
     path standing INSIDE a regular file, which raises `NotADirectoryError` (`ENOTDIR`); the
     two obstacles the loader test below uses cannot reach this promise, because `stat` needs
     neither read permission on a file nor the file to be a file, so both of them stat fine and
@@ -398,7 +422,8 @@ def test_an_input_that_cannot_be_stat_ed_is_zeroed_for_a_query_and_raises_for_a_
     paths[index] = paths[index] / "not-a-directory"
 
     signal = index_build.StoreSignal.of(*paths)
-    assert (getattr(signal, mtime_field), getattr(signal, size_field)) == (0, 0), "zeroed"
+    obstructed = (getattr(signal, mtime_field), getattr(signal, size_field))
+    assert obstructed == index_build.UNSTATTABLE, "obstructed, and not the ABSENT zeros"
     others = [
         (m, s)
         for k, (m, s) in enumerate(
@@ -410,10 +435,45 @@ def test_an_input_that_cannot_be_stat_ed_is_zeroed_for_a_query_and_raises_for_a_
         )
         if k != index
     ]
-    assert all(m and s for m, s in others), f"the other two inputs still stat'ed: {others}"
+    assert all(m > 0 and s > 0 for m, s in others), f"the other two still stat'ed: {others}"
 
     with pytest.raises(NotADirectoryError):
         index_build.load_index_inputs(*paths)
+
+
+def test_a_signal_sealed_over_an_absent_input_is_unequal_once_it_cannot_be_stat_ed(
+    tmp_path: Path,
+) -> None:
+    """ABSENT AND OBSTRUCTED MUST NOT BE THE SAME VALUE (Codex round 09, the blocking HIGH).
+
+    Both read `(0, 0)` before the split, and `_read_bound` SEALS zeros for an absent input — so
+    an index built while an input was missing compared EQUAL to a query taken once that same path
+    could no longer be stat'ed, certifying itself current over an input it never opened. Seen red
+    at `8febb37`: `sealed == current`, both all-zero, while the loader raised on the same path.
+
+    The obstruction is a self-referential symlink AT THE SEALED PATH (`ELOOP`), so the only thing
+    that moves between the two readings is whether that input can be stat'ed. The pair is one
+    promise, so it is one test: the query ANSWERS (what `search` pays on every call must never
+    raise from inside the filesystem) and the load RAISES (an unreadable input is not an empty).
+
+    THE SENTINEL'S SAFETY IS ASSERTED ON THE SIZE, NEVER ON THE MTIME, and asserting only
+    `== UNSTATTABLE` would be rule 1's row 4 — both sides out of the same module, satisfied by
+    whatever the constant says. Measured: an empty file at `os.utime(p, ns=(-1, -1))` stats to
+    exactly `(-1, 0)`, so a `-1` MTIME is forgeable by a real input and `UNSTATTABLE = (-1, 0)`
+    left this file GREEN at 26 of 26. A negative SIZE is not forgeable, which is the contract.
+    """
+    items, vocab, topics = _paths(tmp_path)
+    sealed = index_build.load_index_inputs(items, vocab, topics).signal
+    assert sealed == ZERO, "an absent input still seals zeros, and that stays true"
+
+    items.symlink_to(items)
+
+    current = index_build.StoreSignal.of(items, vocab, topics)
+    assert current != sealed, "absent at seal must not read as unchanged once obstructed"
+    assert (current.items_json_mtime_ns, current.items_json_size) == index_build.UNSTATTABLE
+    assert index_build.UNSTATTABLE[1] < 0, "the SIZE half is what a real `st_size` cannot be"
+    with pytest.raises(OSError):
+        index_build.load_index_inputs(items, vocab, topics)
 
 
 def _obstruct(path: Path, obstacle: str) -> None:
@@ -500,3 +560,55 @@ def test_the_index_loader_and_the_store_doors_parse_through_one_parser_each(
     assert loaded.store == load_store(items)
     assert loaded.vocab == load_vocab(vocab)
     assert loaded.topic_pages == load_topic_pages(topics)
+
+
+@pytest.mark.parametrize(
+    "name, door, key",
+    [
+        ("parse_store", "load_store", "store"),
+        ("parse_vocab", "load_vocab", "vocab"),
+        ("parse_topic_pages", "load_topic_pages", "topic_pages"),
+    ],
+)
+def test_the_door_and_the_index_loader_share_one_parser_object(
+    three_inputs: Path, monkeypatch: pytest.MonkeyPatch, name: str, door: str, key: str
+) -> None:
+    """Rule 5 BOUND IN CODE: re-inlining EITHER side left the test above at 20 of 20 GREEN.
+
+    That test compares the two readers' OUTPUTS, so a byte-identical second copy satisfies it.
+    Three legs here, each reddening a mutation the other two miss, all three measured. The DOOR
+    resolves its parser in its own module at call time, so a re-inlined `load_store` fails leg 1.
+    The LOADER is unreachable that way at all — `from xbrain.store import parse_store` binds the
+    OBJECT into `index_build`'s namespace at IMPORT time — so leg 2 needs its own patch. And
+    neither can tell ONE parser from TWO that behave alike, which is what rule 5 forbids, so leg
+    3 is identity: NOT rule 1's banned tautology precisely because legs 1 and 2 patch two
+    DIFFERENT names — measured, `index_build` shadowing `parse_store` with its own byte-identical
+    copy passes both of them and reddens exactly here.
+    """
+    import xbrain.rubrics as rubrics
+    import xbrain.store as store
+
+    home = rubrics if name == "parse_vocab" else store
+    path = dict(zip(("store", "vocab", "topic_pages"), _paths(three_inputs)))[key]
+    marker = object()
+
+    monkeypatch.setattr(home, name, lambda text: marker)
+    assert getattr(home, door)(path) is marker, "the door re-inlined its parse"
+
+    monkeypatch.setattr(index_build, name, lambda text: marker)
+    loaded = index_build.load_index_inputs(*_paths(three_inputs))
+    assert getattr(loaded, key) is marker, "the index loader re-inlined its parse"
+
+    monkeypatch.undo()
+    assert getattr(index_build, name) is getattr(home, name), "two parsers, not one"
+
+
+def test_the_stat_guard_is_no_broader_than_os_error() -> None:
+    """Widening `_stat_signal`'s `except OSError` to `except Exception` left 20 of 20 GREEN.
+
+    The breadth is deliberate but BOUNDED: under `except Exception` a `None` path — #161's own
+    signature defect — is swallowed into a signal instead of raising, the fail-open family this
+    module exists to close. Reached through the public door, so it pins observable behaviour.
+    """
+    with pytest.raises(AttributeError):
+        index_build.StoreSignal.of(None, Path("v"), Path("t"))  # type: ignore[arg-type]

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -1,0 +1,417 @@
+# tests/test_knowledge_index_build.py
+"""The three inputs of the index, read as one snapshot, with the cheap signal bound to it
+(Plan 02 §2, §3, steps 3 and 4).
+
+The argument for the cheap signal — what it can answer, what it cannot, and the direction it
+fails in — is stated once, in `index_build.py`'s module docstring; it is not restated here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from xbrain.knowledge import index_build
+from xbrain.models import Item, Topic, TopicPage
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+ZERO = index_build.StoreSignal(0, 0, 0, 0, 0, 0)
+
+
+@pytest.fixture()
+def corpus() -> tuple[dict[str, Item], list[Topic], dict[str, TopicPage]]:
+    raw = json.loads((FIXTURES / "knowledge_corpus.json").read_text(encoding="utf-8"))
+    store = {k: Item.model_validate(v) for k, v in raw["items"].items()}
+    vocab = [Topic.model_validate(v) for v in raw["vocab"].values()]
+    pages = {k: TopicPage.model_validate(v) for k, v in raw["topics"].items()}
+    return store, vocab, pages
+
+
+@pytest.fixture()
+def three_inputs(tmp_path: Path, corpus) -> Path:
+    """A data/ directory holding ALL THREE inputs, written by the store's own writers."""
+    from xbrain.rubrics import save_vocab
+    from xbrain.store import save_store, save_topic_pages
+
+    store, vocab, pages = corpus
+    data = tmp_path / "data"
+    save_store(store, data / "items.json")
+    save_vocab(vocab, data / "vocab.yaml")
+    save_topic_pages(pages, data / "topics.json")
+    return data
+
+
+def _paths(data: Path) -> tuple[Path, Path, Path]:
+    """The three inputs, in the order every door of this module takes them."""
+    return data / "items.json", data / "vocab.yaml", data / "topics.json"
+
+
+# ---------------------------------------------------------------------------
+# P1b — the signal describes the bytes that were PARSED
+#
+# Two races, two different physical mechanisms, and only the second can catch a stat taken
+# after the read. An ATOMIC REPLACE (`os.replace`, what `save_store` does) leaves the open
+# handle on the old inode, whose stat never moves, so `fstat` before and after the read agree
+# and the ordering is invisible. An IN-PLACE REWRITE (`write_text`, what `save_vocab` does)
+# truncates the very inode the reader is holding, and there the ordering is the whole story.
+# Both writers are real and in this repo, so both cases are reachable.
+# ---------------------------------------------------------------------------
+
+
+def test_load_index_inputs_binds_the_signal_to_the_handle_not_to_the_path(
+    three_inputs: Path, corpus
+) -> None:
+    """The HANDLE half of P1b: an atomic replacement landing mid-read cannot be sealed.
+
+    `save_store` writes through `os.replace`, so the handle keeps the inode it opened: the
+    bytes parsed are that inode's, the signal is that inode's, and the PATH is left on a newer
+    inode that query-time `StoreSignal.of` reports as different — the index declares itself
+    behind rather than certifying rows it never read.
+
+    STAGED BETWEEN THE `open` AND THE STAT, which is the only window where a stat of the PATH
+    and a stat of the HANDLE can disagree: once the handle is open the two name different
+    inodes. An earlier version of this test raced inside `read` instead and stayed GREEN under
+    its own mutation — `path.stat()` ran before the replacement landed, so it read the same
+    file either way and pinned nothing (rule 1, caught by executing the mutation).
+
+    Seen red under the mutation `stat = os.fstat(handle.fileno())` -> `stat = path.stat()`:
+    the signal then described the replacement while the parsed rows were the old ones, and
+    `loaded.signal != before` — a manifest certifying an `items.json` it had never read.
+    """
+    from xbrain.store import save_store
+
+    store, _vocab, _pages = corpus
+    items, vocab, topics = _paths(three_inputs)
+    before = index_build.StoreSignal.of(items, vocab, topics)
+    newer = {**store, "k01": store["k01"].model_copy(update={"text": "replaced during the load"})}
+
+    class RacingPath(type(items)):
+        def open(self, *args, **kwargs):
+            handle = super().open(*args, **kwargs)
+            save_store(newer, items)  # the race: the replace lands with the handle already open
+            return handle
+
+    loaded = index_build.load_index_inputs(RacingPath(items), vocab, topics)
+    after = index_build.StoreSignal.of(items, vocab, topics)
+
+    assert after != before, "the replacement really moved the file the path names"
+    assert loaded.store["k01"].text == store["k01"].text, "the parse saw the bytes it read"
+    assert loaded.signal == before, "the signal describes the snapshot that was parsed"
+    assert loaded.signal != after, "so the index declares itself behind, which is the warning"
+
+
+def test_the_signal_is_stat_before_read_so_an_in_place_rewrite_cannot_reseal_it(
+    three_inputs: Path, corpus
+) -> None:
+    """The BEFORE half of P1b, which the handle half above cannot reach.
+
+    `save_vocab` rewrites through `write_text`: same inode, truncated under the reader. A stat
+    taken AFTER the read therefore describes the REPLACEMENT while the text in hand is the
+    original — the loader would seal a signal for bytes it never parsed, and the next query,
+    comparing that sealed signal against the same file, finds them EQUAL and answers over the
+    old vocabulary with nothing declared. That is the false negative the whole module exists
+    to make impossible, and it is invisible to an atomic-replace race.
+
+    Taken BEFORE, the signal is the older content's, so the comparison against disk is
+    UNEQUAL and the index is declared behind — the direction this fails in, at one `update`.
+
+    Seen red under the mutation `os.fstat(handle.fileno())` moved BELOW `data = handle.read()`
+    in `_read_bound`: `loaded.signal != before`, the sealed size being the replacement's.
+    """
+    from xbrain.rubrics import save_vocab
+
+    _store, vocab_topics, _pages = corpus
+    items, vocab, topics = _paths(three_inputs)
+    before = index_build.StoreSignal.of(items, vocab, topics)
+    longer = [
+        t.model_copy(update={"description": t.description + " — rewritten in place"})
+        for t in vocab_topics
+    ]
+
+    class RewritingHandle:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def fileno(self):
+            return self._handle.fileno()
+
+        def read(self):
+            data = self._handle.read()
+            save_vocab(longer, vocab)  # in-place: truncates the inode still open here
+            return data
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return self._handle.__exit__(*exc)
+
+    class RewritingPath(type(vocab)):
+        def open(self, *args, **kwargs):
+            return RewritingHandle(super().open(*args, **kwargs))
+
+    loaded = index_build.load_index_inputs(items, RewritingPath(vocab), topics)
+
+    after = index_build.StoreSignal.of(items, vocab, topics)
+    assert after.vocab_yaml_size != before.vocab_yaml_size, "the rewrite really moved the file"
+    assert [t.description for t in loaded.vocab] == [t.description for t in vocab_topics], (
+        "the parse saw the bytes it read, not the rewrite"
+    )
+    assert loaded.signal == before, "and the signal is those bytes', not the rewrite's"
+    assert loaded.signal != after, "so the index declares itself behind, which is the warning"
+
+
+# ---------------------------------------------------------------------------
+# P1a — THREE INPUTS, NOT ONE, on both sides
+# ---------------------------------------------------------------------------
+
+
+def test_load_index_inputs_reads_all_three_inputs_each_bound_to_its_own_handle(
+    three_inputs: Path, corpus
+) -> None:
+    """P1a at the loader: the index derives from THREE files, so the loader reads three.
+
+    A topic description enters every assigned item's PROFILE (spec §5.1.A) and the overviews
+    and notes are chunks the index serves, so a loader that reads `items.json` and defaults
+    the other two to empty builds an index missing the whole topic plane while every signal it
+    seals says the inputs were read.
+
+    THE THREE SIZES MUST DIFFER, asserted first (rule 1): each entry is checked against its own
+    file's `stat`, so an entry filled from a DIFFERENT input's handle would still pass wherever
+    the two files happened to agree, and a zero would be indistinguishable from a real reading.
+
+    Seen red under three mutations: `vocab=[], topic_pages={}` with the four vocab/topics
+    entries left at zero (the pre-round-05 shape) — `AssertionError` on the vocabulary; and
+    the vocabulary's and the topic pages' signal entries each filled from the OTHER input's
+    handle — `AssertionError` naming the file whose entry was wrong.
+    """
+    _store, vocab_topics, pages = corpus
+    items, vocab, topics = _paths(three_inputs)
+    sizes = [p.stat().st_size for p in (items, vocab, topics)]
+    assert len(set(sizes)) == 3, "distinct sizes, or one file's stat could satisfy another's entry"
+    assert all(sizes), "and none empty, or a zeroed entry would be indistinguishable from truth"
+
+    loaded = index_build.load_index_inputs(items, vocab, topics)
+
+    assert {t.slug: t.description for t in loaded.vocab} == {
+        t.slug: t.description for t in vocab_topics
+    }, "descriptions included: they enter every assigned item's profile"
+    assert set(loaded.topic_pages) == set(pages), "the topic pages were read"
+    assert loaded.topic_pages["agent-evaluation"].overview == pages["agent-evaluation"].overview
+
+    for path, mtime_field, size_field in [
+        (items, "items_json_mtime_ns", "items_json_size"),
+        (vocab, "vocab_yaml_mtime_ns", "vocab_yaml_size"),
+        (topics, "topics_json_mtime_ns", "topics_json_size"),
+    ]:
+        stat = path.stat()
+        assert getattr(loaded.signal, mtime_field) == stat.st_mtime_ns, path.name
+        assert getattr(loaded.signal, size_field) == stat.st_size, path.name
+
+
+@pytest.mark.parametrize(
+    "filename, mtime_field, size_field",
+    [
+        ("items.json", "items_json_mtime_ns", "items_json_size"),
+        ("vocab.yaml", "vocab_yaml_mtime_ns", "vocab_yaml_size"),
+        ("topics.json", "topics_json_mtime_ns", "topics_json_size"),
+    ],
+)
+def test_the_query_time_signal_watches_each_of_the_three_inputs(
+    three_inputs: Path, filename: str, mtime_field: str, size_field: str
+) -> None:
+    """P1a's OTHER half: `StoreSignal.of` is the side a query pays, and it watched one file.
+
+    This is the comparison every `search` makes against what a manifest sealed. Watching
+    `items.json` alone is the round-05 defect: `xbrain topics` writes `topics.json`, never
+    touches `items.json`, and every later query answers over the old topic plane with nothing
+    declared — the silence spec §9.3 forbids. One case per input, each asserting only its own
+    file's two entries, so zeroing ONE stat reddens exactly one case and names which input
+    lost its watch. The distinct-and-non-empty precondition is the same rule-1 guard as above.
+
+    Seen red under three mutants applied separately, one per line of `of`: `_stat_signal(…)`
+    -> `(0, 0)` for the items, the vocabulary and the topic pages, each reddening its own case
+    and leaving the other two green.
+    """
+    paths = _paths(three_inputs)
+    sizes = [p.stat().st_size for p in paths]
+    assert len(set(sizes)) == 3, "distinct sizes, or one file's stat could satisfy another's entry"
+    assert all(sizes), "and none empty, or a zeroed entry would be indistinguishable from truth"
+
+    signal = index_build.StoreSignal.of(*paths)
+    stat = (three_inputs / filename).stat()
+    assert getattr(signal, mtime_field) == stat.st_mtime_ns, filename
+    assert getattr(signal, size_field) == stat.st_size, filename
+
+
+def test_the_store_signal_is_one_stat_per_input_and_nothing_else(
+    three_inputs: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The cheap signal must stay cheap, or it is the expensive one under a different name.
+
+    Three stats, all distinct: a signal that grew a second stat per file and a signal that
+    stat'ed one input twice in place of another are different regressions, and both move this
+    count. The `set` is what catches the second — cross-wiring keeps the total at three.
+    """
+    real_stat = Path.stat
+    calls: list[Path] = []
+
+    def counted(self, *args, **kwargs):
+        calls.append(self)
+        return real_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", counted)
+    index_build.StoreSignal.of(*_paths(three_inputs))
+
+    assert len(set(calls)) == len(calls) == 3, f"one stat per input, all distinct: {calls}"
+
+
+# ---------------------------------------------------------------------------
+# A-2 — the asymmetry: a query always ANSWERS, a load never invents an empty store
+# ---------------------------------------------------------------------------
+
+
+def test_a_missing_input_is_zeroed_on_the_query_side_and_empty_on_the_load_side(
+    tmp_path: Path,
+) -> None:
+    """ABSENT is the one reading that stays empty — `load_store`'s own semantics — so a fresh
+    checkout with no `data/` still loads and still says the index is behind. Both doors are
+    asserted here because they are the two halves of one promise: the query answers, the load
+    yields the empty value, and only what EXISTS and cannot be read parts them (below)."""
+    paths = _paths(tmp_path / "nothing")
+
+    assert index_build.StoreSignal.of(*paths) == ZERO
+    loaded = index_build.load_index_inputs(*paths)
+    assert (loaded.store, loaded.vocab, loaded.topic_pages) == ({}, [], {})
+    assert loaded.signal == ZERO
+
+
+@pytest.mark.parametrize(
+    "index, mtime_field, size_field",
+    [
+        (0, "items_json_mtime_ns", "items_json_size"),
+        (1, "vocab_yaml_mtime_ns", "vocab_yaml_size"),
+        (2, "topics_json_mtime_ns", "topics_json_size"),
+    ],
+)
+def test_an_input_that_cannot_be_stat_ed_is_zeroed_for_a_query_and_raises_for_a_load(
+    three_inputs: Path, index: int, mtime_field: str, size_field: str
+) -> None:
+    """The two directions of A-2, on ONE obstruction, which is the only way to see the pair.
+
+    `_stat_signal` swallows every `OSError`, not only `FileNotFoundError`, and this is the
+    test that holds it: a query must be able to ANSWER — declaring the index behind — instead
+    of learning about the filesystem by exception from inside `search`. The obstruction is a
+    path standing INSIDE a regular file, which raises `NotADirectoryError` (`ENOTDIR`); the
+    two obstacles the loader test below uses cannot reach this promise, because `stat` needs
+    neither read permission on a file nor the file to be a file, so both of them stat fine and
+    the breadth of the `except` stayed unguarded by every test in the snapshot this re-cuts.
+
+    The OTHER TWO inputs must come back non-zero, asserted here (rule 1): a `StoreSignal.of`
+    that gave up and returned zeros everywhere would satisfy the first half on its own, and a
+    call that never ran at all would satisfy it too.
+
+    Seen red under the mutation `except OSError` -> `except FileNotFoundError` in
+    `_stat_signal`: `NotADirectoryError` out of `StoreSignal.of`, on each of the three cases.
+
+    The SAME path is an error for `load_index_inputs`, and that is the design, not an
+    inconsistency: an unreadable input is not an empty one, so the loader lets it through.
+    """
+    paths = list(_paths(three_inputs))
+    paths[index] = paths[index] / "not-a-directory"
+
+    signal = index_build.StoreSignal.of(*paths)
+    assert (getattr(signal, mtime_field), getattr(signal, size_field)) == (0, 0), "zeroed"
+    others = [
+        (m, s)
+        for k, (m, s) in enumerate(
+            [
+                (signal.items_json_mtime_ns, signal.items_json_size),
+                (signal.vocab_yaml_mtime_ns, signal.vocab_yaml_size),
+                (signal.topics_json_mtime_ns, signal.topics_json_size),
+            ]
+        )
+        if k != index
+    ]
+    assert all(m and s for m, s in others), f"the other two inputs still stat'ed: {others}"
+
+    with pytest.raises(NotADirectoryError):
+        index_build.load_index_inputs(*paths)
+
+
+def _obstruct(path: Path, obstacle: str) -> None:
+    """Make `path` UNREADABLE without removing it — the two shapes an operator meets."""
+    if obstacle == "chmod000":
+        path.chmod(0)
+    else:
+        path.unlink()
+        path.mkdir()
+
+
+@pytest.mark.parametrize(
+    "obstacle, error", [("chmod000", PermissionError), ("directory", IsADirectoryError)]
+)
+@pytest.mark.parametrize("filename", ["items.json", "vocab.yaml", "topics.json"])
+def test_an_unreadable_input_is_an_error_never_an_empty_one(
+    three_inputs: Path, filename: str, obstacle: str, error: type[OSError]
+) -> None:
+    """A-2 (gate Fable §5.2, round 08), on ALL THREE inputs and not only the one it probed.
+
+    `_read_bound` caught EVERY `OSError` and answered `(None, 0, 0)`, the reading reserved for
+    a file that is ABSENT, so an unreadable input loaded as an EMPTY one — the whole fail-open
+    family with a destruction on top, enumerated in `_read_bound`'s own docstring and not
+    restated here. The defect is a property of that function and all three inputs route
+    through it, which is why this is parametrised over the three and not over the one the gate
+    happened to probe: on `vocab.yaml` it is quieter and no less destructive, loading as «no
+    topics» so every profile is built without its topic descriptions and `update` plans the
+    deletion of the whole topic plane, exit 0.
+
+    Seen red under the mutation `except FileNotFoundError` -> `except OSError` in
+    `_read_bound`: `DID NOT RAISE` on all six cases.
+    """
+    _obstruct(three_inputs / filename, obstacle)
+    try:
+        with pytest.raises(error):
+            index_build.load_index_inputs(*_paths(three_inputs))
+    finally:
+        if obstacle == "chmod000":
+            (three_inputs / filename).chmod(0o644)
+
+
+# ---------------------------------------------------------------------------
+# Rule 5 — one parser per input, shared by the two readers of the same bytes
+# ---------------------------------------------------------------------------
+
+
+def test_the_index_loader_and_the_store_doors_parse_through_one_parser_each(
+    three_inputs: Path,
+) -> None:
+    """The seam `parse_store` / `parse_vocab` / `parse_topic_pages` exists FOR THIS (rule 5).
+
+    `load_index_inputs` must bind what it parsed to the exact bytes it read, so it reads
+    through its own handle — and the only honest way to do that without a second copy of every
+    parse is to split the parse out of `load_store` / `load_vocab` / `load_topic_pages` and
+    share it. The property that matters is not "the seam exists" (a tautology the moment it
+    does) but that the TWO READERS OF THE SAME BYTES agree: the path-based door every other
+    stage uses, and the handle-based one the index uses.
+
+    WHAT IT CANNOT CATCH, SAID OUT LOUD (rule 1): once both doors delegate, a defect INSIDE a
+    shared parser moves both sides of every assertion here identically and this test stays
+    green. Measured — `parse_vocab` reduced to `data.get("topics")` (raw dicts instead of
+    `Topic`) leaves it PASSING, and reddens the two tests above that compare against typed
+    values instead. What this one pins is the property it names, DIVERGENCE: seen red under a
+    loader that parsed the store with a bare `json.loads` (`Item` out of one door, dicts out
+    of the other) and under a loader that defaulted the vocabulary and the topic pages away.
+    """
+    from xbrain.rubrics import load_vocab
+    from xbrain.store import load_store, load_topic_pages
+
+    items, vocab, topics = _paths(three_inputs)
+    loaded = index_build.load_index_inputs(items, vocab, topics)
+
+    assert loaded.store == load_store(items)
+    assert loaded.vocab == load_vocab(vocab)
+    assert loaded.topic_pages == load_topic_pages(topics)

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -269,6 +269,80 @@ def test_the_store_signal_is_one_stat_per_input_and_nothing_else(
     assert len(set(calls)) == len(calls) == 3, f"one stat per input, all distinct: {calls}"
 
 
+def test_neither_door_can_be_called_without_the_vocabulary_and_the_topic_pages() -> None:
+    """THE FIX THIS CHILD EXISTS FOR, AND WITHOUT THIS TEST IT CAN BE REVERTED IN SILENCE.
+
+    Measured on the tree before this test was written: restoring `Path | None = None` on both
+    doors, or restoring the four `= 0` defaults on the dataclass, left **18 of 18 GREEN**.
+    Every other test passes all three paths explicitly, so every one of them is satisfied just
+    as happily by the OPTIONAL signature — and `mypy` runs on `src/` alone (`scripts/check.sh`),
+    where a restored default is type-correct at every call site. A hundred per cent of
+    statements were covered and not one assertion died when the defect came back. Rule 1 in
+    its purest form: the fix could not be made to go red.
+
+    WHAT IS BEING PREVENTED, once more, because it is the whole point: zeros are also what an
+    ABSENT file reads as, so a signal that OMITTED the vocabulary was byte-identical to one
+    taken over a vocabulary that is not there — and two such signals compare EQUAL forever,
+    however `vocab.yaml` changes. The false-negative direction this module is built never to
+    fail in, reachable by leaving one argument off the shortest call.
+
+    Each case names the parameter it is missing, so a failure says WHICH half regressed: the
+    two doors are the `Path | None` mutant, the constructor is the `= 0` mutant.
+
+    THE CONSTRUCTOR IS SWEPT OVER EVERY ARITY, not probed at one. A first version asserted
+    only `StoreSignal(1, 2)`, and a mutant that restored the defaults on the LAST THREE fields
+    — leaving `vocab_yaml_mtime_ns` required — still raised there, naming that field, and the
+    suite stayed GREEN at 20 of 20. A default on any TRAILING subset is the same defect, so
+    the assertion has to be that a signal of fewer than six values does not exist at all.
+    """
+    path = Path("items.json")
+
+    with pytest.raises(TypeError, match="vocab_path"):
+        index_build.StoreSignal.of(path)  # type: ignore[call-arg]
+    with pytest.raises(TypeError, match="topics_path"):
+        index_build.StoreSignal.of(path, path)  # type: ignore[call-arg]
+
+    with pytest.raises(TypeError, match="vocab_path"):
+        index_build.load_index_inputs(path)  # type: ignore[call-arg]
+    with pytest.raises(TypeError, match="topics_path"):
+        index_build.load_index_inputs(path, path)  # type: ignore[call-arg]
+
+    for arity in range(6):
+        with pytest.raises(TypeError, match="required positional argument"):
+            index_build.StoreSignal(*range(arity))  # type: ignore[call-arg]
+
+
+def test_an_input_that_is_not_utf8_is_refused_not_repaired(three_inputs: Path) -> None:
+    """Undecodable bytes are a REFUSAL, and the refusal is the only thing standing there.
+
+    Measured before this test existed: `data.decode("utf-8")` weakened to
+    `errors="replace"` left **18 of 18 GREEN**. That mutation does not fail — it SUCCEEDS,
+    turning undecodable bytes into U+FFFD and handing them on to be indexed as if they were
+    the corpus. It is the fail-open family this module exists to close, one layer below the
+    one the rest of the file guards: not an unreadable file read as empty, but a corrupt file
+    read as CONTENT.
+
+    The two doors are asserted TOGETHER because `_read_bound`'s docstring claims they agree
+    here — unlike `ENOTDIR` and `ELOOP`, where it is deliberately stricter — and a claim of
+    agreement is worth exactly what the assertion that both raise is worth.
+
+    And the raised object is asserted NOT to be an `OSError`: that is what puts it outside the
+    `FileNotFoundError` guard by TYPE and not merely by intent, which is the sentence
+    `_read_bound` uses to explain why the guard cannot swallow it.
+    """
+    from xbrain.rubrics import load_vocab
+
+    items, vocab, topics = _paths(three_inputs)
+    vocab.write_bytes(b"topics:\n- slug: a\n  description: \xff\xfe not utf-8\n")
+
+    with pytest.raises(UnicodeDecodeError) as caught:
+        index_build.load_index_inputs(items, vocab, topics)
+    assert not isinstance(caught.value, OSError), "outside the FileNotFoundError guard by type"
+
+    with pytest.raises(UnicodeDecodeError):
+        load_vocab(vocab)
+
+
 # ---------------------------------------------------------------------------
 # A-2 — the asymmetry: a query always ANSWERS, a load never invents an empty store
 # ---------------------------------------------------------------------------
@@ -371,6 +445,12 @@ def test_an_unreadable_input_is_an_error_never_an_empty_one(
 
     Seen red under the mutation `except FileNotFoundError` -> `except OSError` in
     `_read_bound`: `DID NOT RAISE` on all six cases.
+
+    `chmod000` ASSUMES A NON-ROOT RUNNER — root ignores the permission bits and the open would
+    succeed, so the case would report `DID NOT RAISE`. That is a FALSE RED, which is the safe
+    direction, and it does not arise here: `quality.yml` runs on `ubuntu-latest` with no
+    `container:`, so the job is the unprivileged `runner` user. The `directory` case needs no
+    such caveat.
     """
     _obstruct(three_inputs / filename, obstacle)
     try:
@@ -405,6 +485,11 @@ def test_the_index_loader_and_the_store_doors_parse_through_one_parser_each(
     values instead. What this one pins is the property it names, DIVERGENCE: seen red under a
     loader that parsed the store with a bare `json.loads` (`Item` out of one door, dicts out
     of the other) and under a loader that defaulted the vocabulary and the topic pages away.
+
+    AND IT COMPARES THE DOORS ONLY ON FILES THAT EXIST, which is the whole domain where they
+    are meant to agree. On a path standing inside a regular file, or on a symlink loop, they
+    DIVERGE BY DESIGN — `load_store` gates on `Path.exists()` and reads both as `{}`, while
+    this loader raises — and `_read_bound`'s docstring is where that asymmetry is argued.
     """
     from xbrain.rubrics import load_vocab
     from xbrain.store import load_store, load_topic_pages


### PR DESCRIPTION
The **READ** half of 02.6: what the index reads, and what signal describes exactly the bytes it read. It computes **no fingerprint** — that is **02.6a2**, the next child, which lands **before anything is sealed**.

**Range (exact):** base `2c0a63131acd241b7369738b8420b08f0f94d900` (umbrella tip) … head `3666e9fc94f684c24da81122f5978c4c5b85642b`

> **Round 09 review-fix commit** on top of `8febb37`. Four independent reviews (Codex + three Opus axes) returned **NEEDS_FIXES** with **one HIGH**. All of it is answered below, and the HIGH is closed **behaviourally**, not by documentation.

## Why this exists as its own child

`#161` (`e4413be`) put the three inputs, the signal and the four fingerprints in one PR: **1,497 touched lines** — 133 % of the plan's budget for 02.6 *entire*. Four independent reviews returned **NEEDS_FIXES with no BLOCKER on correctness**: the encoder survived every attack and the gate was green on the exact head. What failed was the **completeness of the contract**, and with three lines of headroom the PR could not absorb even the cheapest documentation repair.

Rule 15's second half — *if a boundary cannot produce a coherent state, move the boundary and write down why*. Moved:

| child | scope | why it is a unit |
|---|---|---|
| **02.6a1 (this)** | `parse_store` · `parse_topic_pages` · `parse_vocab` · `StoreSignal` · `_stat_signal` · `IndexInputs` · `_read_bound` · `load_index_inputs` | the **read** contract. Computes no hash, so it depends on nothing in 02.6a2 |
| **02.6a2 (next)** | `surface_row`/`SurfaceRow` · `IndexOptions` · the four fingerprints · `_canonical` · `_sha256` | the **derivation** contract. Consumes this bundle, and owes the coverage gaps `#161`'s review named (HIGH-1, M1, M2) |
| 02.6b | manifest + invalidation | **seals nothing until 02.6a2 has landed** |

`#161` is **not deleted and not rewritten**. It is frozen at `VGonPa/knowledge-index-02-6a-reviewed-snapshot-161` → `e4413be3a0306d67d0ae80b11b45e3243d2a5da7` and closed as superseded.

---

# Round 09 — what the reviews found, and what changed

## The HIGH: a missing input and a later unreadable input had the identical signal

`_stat_signal` mapped **every** `OSError` to `(0, 0)`, and `_read_bound` **seals** `(0, 0)` for an absent input. So a signal sealed while an input was **absent** compared **EQUAL** to a query taken once that same path could no longer be stat'ed: the index certifies itself current over an input it never opened. Silent, which spec §9.3 forbids, and in the **false-negative** direction this module is built never to fail in.

**Reproduced on the pristine head before the fix** (`8febb37`, and the transition regression fails on exactly this assertion):

```
sealed  (items.json absent)    : StoreSignal(0, 0, 0, 0, 0, 0)
current (items.json now ELOOP) : StoreSignal(0, 0, 0, 0, 0, 0)
EQUAL -> True                  ; load_index_inputs RAISES OSError(62)
```

**The fix — a sentinel a real `stat` cannot forge, and nothing can seal.**

```python
UNSTATTABLE = (-1, -1)
...
    try:
        stat = path.stat()
    except FileNotFoundError:
        return 0, 0
    except OSError:
        return UNSTATTABLE
```

Two properties carry it, and both are stated in the code:

- **Unforgeable, and the SIZE is the half that does the work.** `st_size` is a byte count and is never negative. A pre-epoch `st_mtime_ns` **is** negative (measured), so the mtime half guarantees nothing on its own — an **empty file at `os.utime(p, ns=(-1, -1))` stats to exactly `(-1, 0)`**. The test therefore asserts `UNSTATTABLE[1] < 0`, the *contract*, not `== UNSTATTABLE`, the *constant*: it kills `(-1, 0)`, `(1, 1)` and `(0, 0)` and correctly permits `(0, -1)` and `(-1, -2)`.
- **Unsealable.** `_read_bound` **raises** on every obstruction that produces it, so `load_index_inputs` can never write a `-1` into a snapshot. A query that reads `UNSTATTABLE` is therefore unequal to **every** sealed signal.

**This was the one thing the first draft of this fix got wrong**, and both advisors found it independently: every assertion compared against the *symbol* `index_build.UNSTATTABLE`, which is satisfied by whatever the constant says — CLAUDE.md rule 1's row 4 (*both sides came from the same module*) reappearing **inside the fix written to close a collision**. `UNSTATTABLE = (-1, 0)` left the suite green, and `(-1, 0)` is a reading a real file produces.

**Absent keeps its zeros**, so a manifest's legacy zero still reads as absence and nothing about the absent path's behaviour moved. **No seventh `StoreSignal` field was added.**

**Exactly one case changes**, and the PR does not claim more: *absent at seal → obstructed at query*. Absent→absent, present→obstructed and absent→present already compared correctly and still do.

## What the fix does NOT close, documented in the code this time (C-2)

The zeros still collide with one real state: a file that **exists**, is **empty**, and carries an `mtime_ns` of exactly 0 stats as `(0, 0)` (measured). It takes a deliberate `os.utime(path, ns=(0, 0))` — no writer here emits a zero-byte input (`save_store({})` 2 bytes, `save_vocab([])` 11, `save_topic_pages({})` 2, measured) — and both readings mean the same thing downstream: `parse_vocab("")` is `[]` either way, and `parse_store("")` **raises** rather than passing as an empty store. Left alone deliberately: separating it would need a sentinel a real `stat` **can** produce, which is exactly what the one above is not. This note previously lived **only in the PR body**; it is now in `_stat_signal`'s docstring, where 02.6b's implementer reads it.

## The two guards that did not guard what they said

| finding | mutation that was **GREEN** at `8febb37` | now |
|---|---|---|
| **B-1 / B-6** | a **seventh field with `= 0`** (and the `default_factory` variant) | **RED** — `dataclasses.fields` pins the six names **in order**, and that every default is `MISSING` |
| **B-2 / C-3** | re-inlining the parse on **either** side of all three seams | **RED** — both sides pinned, plus identity |

**B-1 was this child's own thesis failing on itself.** The arity sweep catches a *required* seventh field and misses the *defaulted* one, because a default changes no required arity — and zeros are what an absent file reads as, so a defaulted field is a signal that compares EQUAL forever over an input nobody passed.

**B-2 needed three legs, because `from xbrain.store import parse_store` binds the object at IMPORT time** (verified: patching `xbrain.store.parse_store` reaches `load_store` and **not** the loader). So: patch the parser on its **home module** and assert the **door** returns the marker; patch the same name on **`index_build`** and assert the **loader** returns it; then `monkeypatch.undo()` and assert the two names are **one object**. The identity leg is **not** rule 1's banned tautology, and there is a receipt: a mutant where `index_build` shadows `parse_store` with its own byte-identical copy **passes both behavioural legs and fails only the identity**.

## Claim accuracy (rule 2) — one docstring was simply false

`_read_bound` said `Path.exists()` *"swallows every `OSError` from its own `stat`"*. **False**, and re-measured here rather than taken on trust:

```
python 3.12.11 (darwin) — the version CI pins
pathlib._IGNORED_ERRNOS == (2, 20, 9, 62) -> ENOENT, ENOTDIR, EBADF, ELOOP
EACCES in that list? False   -> Path.exists() RE-RAISES PermissionError
```

The file **contradicted itself**: `_stat_signal`'s docstring names `EACCES` as a reachable `path.stat()` error, and `Path.exists()` calls that same `stat`. The docstring now names the ignore-list and says that under `EACCES` there is no divergence to argue — the door raises too. The *operative* claim beside it — **stricter than the doors on exactly two shapes** (`ENOTDIR` + `ELOOP`) — is true only of `OSError` shapes, and is now scoped that way. There is a **third** divergence and it is **not** an `OSError`: `Path.exists()` also answers `False` on a `ValueError`, so a path with an embedded **NUL** reads as `{}` / `[]` / `{}` through the doors while both halves here **raise** (measured — none of the four reviews tested a non-`OSError`). The same shape is the one hole in `_stat_signal`'s *"a query can always ANSWER"*, and it is now named there too.

Also corrected:

- **B-8** — *"`(None, 0, 0)` for an ABSENT **FILE**, and for nothing else"* over-claimed: a **dangling symlink** yields it too. It now says **ABSENT TARGET**, and names why that is the same case and not a further one (`open` resolves the link and raises the very `ENOENT` an absent path raises, exactly as all three doors read it — measured).
- **C-4** — *"no command of this plan snapshots, because none is destructive"* was present-tense and over-wide. Scoped to **this module**, with the counter-example named: `build --force` **does** destroy a good index, and round 08 caught it doing so at exit 0.

## Cheap pins and one deletion

- **B-5** — widening `_stat_signal`'s `except OSError` to `except Exception` was GREEN; now RED, pinned **through the public door** (`StoreSignal.of(None, …)` must raise, not swallow a `None` path into a signal — `#161`'s own signature defect).
- **B-7** — `frozen=True` on both dataclasses was unpinned; now two `FrozenInstanceError` assertions. A *sealed* signal that can be re-bound after the read is not sealed.
- **B-4** — `assert not isinstance(caught.value, OSError)` **deleted**: `pytest.raises(UnicodeDecodeError)` already fixes the type, so it could not fail. Rule 1's own banned shape, found independently by two reviewers.
- The existing `ENOTDIR` test now asserts `UNSTATTABLE` rather than `(0, 0)`, and its companion assertion was strengthened from `all(m and s …)` to `all(m > 0 and s > 0 …)` so a give-up-everywhere mutant returning the sentinel cannot satisfy it.

---

## Evidence, all executed on the exact final tree

**Red first, on the behaviour and not on a missing symbol.** Run against a module with `UNSTATTABLE` defined but the old single `except` (so the red isolates semantics, not the name):

```
>       assert current != sealed, "absent at seal must not read as unchanged once obstructed"
E       AssertionError: absent at seal must not read as unchanged once obstructed
E       assert StoreSignal(0,0,0,0,0,0) != StoreSignal(0,0,0,0,0,0)
```

**Eighteen mutations**, each in a fresh copy with the loaded module path asserted onto it, the anchor asserted **unique** and a **no-op abort**. Controls green before, midway and after. **Zero survivors.**

> **One contaminated reading, recorded because rule 2 is about how a different answer could come out — here it did, and the cause was my instrument.** A control run came back red on a byte-identical tree. The cause: a line-swap mutant is **byte-size identical**, and CPython validates a `.pyc` on *(mtime, size)*, so a copy landing in the same coarse timestamp re-used stale bytecode. The harness now purges `__pycache__` and sets `PYTHONDONTWRITEBYTECODE=1` between runs, and every number above is from the hardened harness.

| mutation | before | after |
|---|---|---|
| 7th field `guardrails_yaml_mtime_ns: int = 0` | 20 passed | **1 failed** |
| 7th field via `field(default_factory=int)` | 20 passed | **1 failed** |
| `_stat_signal`: `except OSError` → `except Exception` | 20 passed | **5 failed** |
| both dataclasses lose `frozen=True` | 20 passed | **1 failed** |
| door `load_store` re-inlines its parse | 20 passed | **1 failed** |
| door `load_vocab` re-inlines its parse | 20 passed | **1 failed** |
| `load_index_inputs` re-inlines its parse | 20 passed | **1 failed** |
| loader shadows `parse_store` with its own copy | 20 passed | **1 failed** |
| `UNSTATTABLE` weakened to `(0, 0)` | n/a | **1 failed** |
| `UNSTATTABLE` weakened to the **reachable** `(-1, 0)` | **26 passed — SURVIVED** | **1 failed** |
| `UNSTATTABLE` weakened to `(1, 1)` | **26 passed — SURVIVED** | **1 failed** |
| two `StoreSignal` fields **reordered** (arity unchanged) | 20 passed | **1 failed** |
| `load_topic_pages` re-inlines its parse | 20 passed | **1 failed** |
| drop the `FileNotFoundError` arm (absent → sentinel) | n/a | **1 failed** |
| `_read_bound` → `except OSError` (the A-2 regression) | — | **10 failed** |
| `os.fstat` moved **below** the read | — | **1 failed** |
| `decode(errors="replace")` (fail-open) | — | **1 failed** |

**Gate on the exact final tree:** `scripts/check.sh` → `2258 passed, 1 xfailed`, coverage **94 %**, `knowledge/` **95 %** (floor 90), `ALL CRITICAL CHECKS PASSED`, `SCRIPT_EXIT=0`. **26 tests** in this file (was 20).

**Mechanics:** `git merge-tree --write-tree 2c0a631 HEAD` equals `HEAD^{tree}` — rule 4 met by **equality**, not assertion. `origin/develop` (`0bd9527`) **is** an ancestor of the base, so **no sync child is due**. Umbrella protection read back live: `quality` required · `strict: true` · `enforce_admins: true` · approvals **0**.

**Size: 880 touched lines** against a **900** ceiling. Four files, no `data/`, no `zz-support-files/`, no plan or report files, no `xfail`/`skip` added.

## Independent review before requesting review (rule 3: judge ≠ party, and the judge must EXECUTE)

Two read-only Opus advisors with independent context, split **by axis** — one on sentinel/state design, one on regression and seam tests.

| report | sha256 |
|---|---|
| `/tmp/xbrain-pr162-fix-signal-advice.md` (31,649 B) | `d29df740f65d090a4114a26bc58314014745859c99611af7a179cf64ef3de9c2` |
| `/tmp/xbrain-pr162-fix-tests-advice.md` (27,376 B) | `5581fe7492ffef51f8379b04c767e01238defe14926d790e5a2dc2e4b13e38e7` |

They **converged independently** on the same surviving mutation and the same one-line fix, which is the strongest signal in the set that it is real. Every finding — theirs and the four reviews' — was **re-executed here** before being accepted: the four `pathlib` errnos, the negative-mtime measurement, the empty-writer byte counts (2 / 11 / 2), the import-time binding constraint and the NUL-path `ValueError`.

**Two corrections owed back to the earlier reviews**, both measured here:

- `claude-final` §Z-1 states *"a sealed `(0, 0)` implies the input was ABSENT at build time — nothing else can produce one."* **False**: an existing, empty `vocab.yaml` at `mtime_ns == 0` seals `(0, 0)` through the ordinary success path and parses to `[]`. Consequence-free, but the absolute is wrong, and the shipped docstring does not repeat it.
- `B-1`'s own recommended fix line — `all(f.default is MISSING …)` — is **incomplete**: it survives `field(default_factory=int)`. Both assertions ship.

**Carried forward, not silently dropped.** Linux/ext4 `mtime_ns` granularity remains **NOT RUN** (no container runtime), and it fails false-negative. A new residual neither review found: a **same-size replacement whose mtime is deliberately preserved** — what `cp -p`, `rsync -t`, `tar -x` and most backup restores do — leaves the signal byte-identical. That is a *deterministic* false negative, not a probabilistic one. It is out of scope for a signal this child declares cheap and fallible in exactly that way, and it is recorded in 02.6b's risk list.

## What this deliberately does NOT do

No fingerprint, no `surface_row`, no manifest, no CLI door, no writer. `load_index_inputs` has **no consumer in `src/`** in this tree, and the docstrings say so rather than describing a door that does not exist. Because there is no consumer, the HIGH was **unreachable in production at this head** — it is fixed here because 02.6b is the child that makes it reachable, and the encoding is cheaper to correct before anything is sealed than after.

**Next child: 02.6a2**, onto this same umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Hw47Ex2ir8f2F21V9h7nQ
