### PR TITLE
feat(knowledge): the item/store fingerprints, with the planes that used to move unseen (Plan 02, child 02.6a2a)

### DIFF
--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -435,12 +435,17 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
     this atom separates. A fingerprint that distinguishes two states the writer stores alike is
     worse than one that distinguishes neither, so collapsing them is 02.7's, not a detail.
 
-    ONE KNOWN FALSE POSITIVE, AND IT IS THE DIRECTION THIS MODULE FAILS IN ON PURPOSE. The
-    topics region keeps the order `Enrichment.topics` was written in, while `item_topics` on
-    disk is a SET keyed `(item_id, slug)` — so a re-enrichment returning the same topics in a
-    different order re-hashes an item whose rows do not move (2,073 of 2,404 items carry more
-    than one topic). One wasted rewrite, never a stale row, the trade the cheap signal already
-    makes. `kinds` needs no such trade: `surfaces.item_content_kinds` — the ONE derivation
+    THREE KNOWN FALSE POSITIVES, ALL IN THE DIRECTION THIS MODULE FAILS IN ON PURPOSE — and
+    this said ONE until someone reordered the other two and watched the hash move. The topics
+    region keeps the order `Enrichment.topics` was written in while `item_topics` on disk is a
+    SET keyed `(item_id, slug)`, so a re-enrichment returning the same topics in a different
+    order re-hashes an item whose rows do not move (2,073 of 2,404 items carry more than one
+    topic). The failures and links regions are order-sensitive the same way, and neither
+    `source_failures` nor `unfetched_links` has a primary key or an order column either;
+    `fetch` rewriting `content.sources` is how the first of those becomes reachable. All three
+    cost one wasted rewrite and never a stale row — the trade the cheap signal already makes,
+    and the reason the count being wrong was cheap and being unstated would not have been.
+    `kinds` needs no such trade: `surfaces.item_content_kinds` — the ONE derivation
     `knowledge_item` also reads — deduplicates, so the region and the rows are the same object.
 
     THE VARIADIC REGIONS ARE NESTED, NEVER SPLICED. Flattening them into one delimited list is
@@ -471,6 +476,11 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
       emitter produces nothing (a whitespace-only `summary`/`digest` is the same shape: profile
       on truthiness, emitter on `_blank()`, which strips). Constructible, 0 of 2,404 today, and
       02.7's — the only writer that sees both sides.
+
+    `items.store_fingerprint` IS THIS VALUE, which is why it appears in neither list above: a
+    hash cannot be inside itself. The NAME is historical and is a trap for 02.7's writer — the
+    only writer that ever existed put a PER-ITEM digest in that column
+    (`b61e04b:index_build.py:760-761`), never a store-level one.
 
     Read this fingerprint as *what changed about the item*, never as *what changed about its
     indexed rows*.

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -8,16 +8,14 @@ DECISION (spec §9.2), so the failure that actually happens is not corruption �
 - The CHEAP one, `StoreSignal`, is `mtime_ns` and size of the THREE inputs: three `os.stat`,
   cheap enough for EVERY query, answering *an input moved*. It cannot say WHICH items.
 - The DEEP ones, `item_fingerprint` and `store_fingerprint`, walk the corpus and emit every
-  surface to answer *which items changed, and how many*. They are paid ONLY by
-  `build` / `update` / `status`, and by nothing a query touches. No path in this module makes
-  a cheap reader pay a deep one, and none may — that separation is 02.6a1's contract and this
-  child inherits it unchanged.
+  surface to answer *which items changed*. They are paid ONLY by `build`/`update`/`status`.
+  No path here makes a cheap reader pay a deep one, and none may — 02.6a1's contract.
 
 WHAT IS NOT HERE, AND WHY IT IS NOT A HOLE. `vocab_fingerprint` and `topics_fingerprint` are
-the other two planes and are the NEXT child's (02.6a2b); they will consume `_canonical` and
-`_sha256` from here and nothing else. The manifest that seals any of the four is 02.6b's.
-Nothing in this tree consumes a fingerprint yet, which is exactly why the coverage gaps
-review #161 named are being closed HERE — free before a manifest exists, expensive after.
+the other two planes and are 02.6a2b's; they will consume `_canonical` and `_sha256` from here
+and nothing else, and the manifest that seals any of the four is 02.6b's. Nothing in this tree
+consumes a fingerprint yet, which is why the coverage gaps review #161 named are closed HERE —
+free before a manifest exists, expensive after.
 
 The cheap signal can give false positives (a `touch` with no edit) and that is accepted: a
 false positive costs one warning, a false negative costs serving stale evidence as fresh. It
@@ -49,8 +47,9 @@ from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams
 from xbrain.knowledge.ids import SURFACE_VERSION
 from xbrain.knowledge.models import KnowledgeSurface
 from xbrain.knowledge.surfaces import (
-    CONTENT_KIND_TO_SURFACE_TYPES,
+    article_block_texts,
     failed_sources,
+    item_content_kinds,
     item_surfaces,
     item_topics,
     unfetched_links,
@@ -275,18 +274,14 @@ class IndexOptions:
     were stamped on the ASR/VLM surfaces as `producer`, a provenance claim the store cannot
     back, and the emitter no longer takes them. See `surfaces.item_surfaces`.
 
-    CARRIED INERT IN THIS CHILD, AND SAYING SO IS THE POINT. Neither `params` nor `vault_dir`
-    is read ANYWHERE in this tree, so `item_fingerprint(item, options=X)` silently discards
-    `X`: a caller who passes the chunker's parameters expecting the fingerprint to cover them
-    would be wrong today. The dataclass travels here so the signature 02.7 consumes is already
-    the ported one — never because anything already reads it. Two persisted columns are
-    unreachable for exactly this reason and are named where they are missed:
-    `items.note_path` (needs `vault_dir`) and `items.skipped_empty_text` (needs `params`),
-    both in `item_fingerprint`.
-
-    `tests/test_knowledge_index_build.py` pins the inertness by BEHAVIOUR — two different
-    `IndexOptions` hashing alike — so 02.7's first consumer cannot land without that test
-    going red and being changed on purpose.
+    CARRIED INERT IN THIS CHILD, AND SAYING SO IS THE POINT. Neither field is read ANYWHERE in
+    this tree, so `item_fingerprint(item, options=X)` silently discards `X` and a caller who
+    passed the chunker's parameters expecting them to be covered would be wrong. The dataclass
+    travels so the signature 02.7 consumes is already the ported one, never because anything
+    reads it; two persisted columns are unreachable for exactly this reason and are named in
+    `item_fingerprint` (`items.note_path` needs `vault_dir`, `items.skipped_empty_text` needs
+    `params`). The tests pin the inertness by BEHAVIOUR — two different `IndexOptions` hashing
+    alike — so 02.7's first consumer cannot land without reddening that test on purpose.
     """
 
     params: ChunkerParams = DEFAULT_CHUNKER_PARAMS
@@ -318,20 +313,16 @@ def surface_row(surface: KnowledgeSurface) -> SurfaceRow:
     """What the index STORES about a surface — the projection of one `surfaces` row.
 
     ONE PROJECTION, AND 02.7's WRITER HAS TO CONSUME IT — WHICH IT DOES NOT YET.
-    `item_fingerprint` hashes this tuple today; the writer that binds it to the `INSERT` into
-    `surfaces` lands in 02.7, and no writer exists in this tree at all. So the correspondence
-    with the persisted DDL (`index_schema._SCHEMA`: fifteen columns, this tuple's order and
-    types) is kept BY HAND: nothing FORCES a column added to `surfaces` to be hashed here.
-    What this child ships instead of that force is a totality test that reads the fifteen
-    column names straight out of the DDL and compares the arity — it catches a column ADDED
-    to the schema, and it cannot catch a column REORDERED into a same-typed neighbour.
-    Making the binding structural is 02.7's job: its writer binds THIS function instead of
-    assembling a second tuple, and it writes the readback test — red first — proving the
-    stored and the hashed row cannot drift. Read any claim of that guard here as 02.7's
-    obligation, never as one discharged.
+    `item_fingerprint` hashes this tuple today; the writer that binds it to the `INSERT` lands
+    in 02.7, and no writer exists in this tree at all, so the correspondence with the persisted
+    DDL (`index_schema._SCHEMA`: fifteen columns, this order and these types) is kept BY HAND.
+    What ships instead of that force is a totality test reading the column names straight out
+    of the DDL: it catches a column ADDED, and cannot catch one REORDERED into a same-typed
+    neighbour. Making the binding structural is 02.7's — its writer binds THIS function rather
+    than assembling a second tuple, and writes the readback test, red first. Read any claim of
+    that guard here as 02.7's obligation, never as one discharged.
 
-    The last column is a LENGTH, never the body (spec §10.8); the body is covered by
-    `fingerprint`, which hashes it.
+    The last column is a LENGTH, never the body (spec §10.8), which `fingerprint` hashes.
     """
     return (
         surface.surface_id,
@@ -359,19 +350,16 @@ def declined_media(item: Item) -> tuple[int, int]:
     produce, and `items.skipped_decorative` / `items.skipped_no_speech` are where the index
     records that it declined them rather than that it found nothing.
 
-    HASHED, BECAUSE OTHERWISE THEY MOVE UNSEEN. Both are persisted columns and both are pure
-    functions of the item, so leaving them out reproduces HIGH-1's exact shape one plane
-    over: `xbrain describe` classifying a photo as decorative flips `skipped_decorative`
-    0 -> 1 while emitting NO surface, changing no other hashed atom — the row on disk moves
-    and `update` reports the item unchanged (rule 6).
-
-    DEFINED HERE ONCE SO 02.7 CONSUMES IT. The writer that fills those two columns has to
-    produce the same pair; deriving it a second time next to the `UPDATE` is the five-hands
-    divergence of rule 5, and this is the seam that stops it.
+    HASHED, BECAUSE OTHERWISE THEY MOVE UNSEEN. Both are persisted columns and pure functions
+    of the item, so leaving them out reproduces HIGH-1's shape one plane over: `xbrain describe`
+    classifying a photo as decorative flips `skipped_decorative` 0 -> 1 while emitting NO
+    surface and changing no other hashed atom — the row on disk moves and `update` reports the
+    item unchanged (rule 6). DEFINED HERE ONCE SO 02.7 CONSUMES IT: deriving the pair a second
+    time next to the `UPDATE` is rule 5's five-hands divergence.
 
     The third counter, `skipped_empty_text`, is NOT here and cannot be: it is
-    `len(chunks) - stored`, a property of the chunker's parameters, which reach this module
-    only through the inert `IndexOptions`. See `item_fingerprint`.
+    `len(chunks) - stored`, under the chunker parameters that reach this module only through
+    the inert `IndexOptions`. See `item_fingerprint`.
     """
     decorative = sum(
         1
@@ -389,15 +377,13 @@ def declined_media(item: Item) -> tuple[int, int]:
 def _model_atoms(model: BaseModel) -> list[list[object]]:
     """One pydantic projection as `[[field_name, value], ...]`, in field-definition order.
 
-    STRUCTURAL ON PURPOSE, and it is the difference between this child and the review that
-    named HIGH-1. A hand-written field list is what let `source_failures` and
-    `unfetched_links` change on disk while every fingerprint stood still; walking
-    `model_fields` means a field ADDED to `SourceFailure` or `UnfetchedLink` enters the hash
-    the moment it exists, with nobody having to remember. The NAME is hashed beside the value
-    so a rename — which is a schema change — moves the fingerprint too.
-
-    It fails CLOSED on a field this encoder cannot represent: `json.dumps` raises `TypeError`
-    on a `datetime` or a `set`, loudly, at the first build, rather than dropping it.
+    STRUCTURAL ON PURPOSE, and the difference between this child and the review that named
+    HIGH-1. A hand-written field list is what let `source_failures` and `unfetched_links` change
+    on disk while every fingerprint stood still; walking `model_fields` means a field ADDED to
+    `SourceFailure` or `UnfetchedLink` enters the hash the moment it exists, with nobody having
+    to remember, and the NAME is hashed beside the value so a rename moves it too. It fails
+    CLOSED on a field this encoder cannot represent: `json.dumps` raises `TypeError` on a
+    `datetime` or a `set`, loudly, at the first build, rather than dropping it.
     """
     return [[name, getattr(model, name)] for name in type(model).model_fields]
 
@@ -405,103 +391,101 @@ def _model_atoms(model: BaseModel) -> list[list[object]]:
 def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
     """sha256 over everything about this item that the INDEX PERSISTS.
 
-    Four planes, because four tables carry a row keyed by this item and every one of them can
-    change without the others moving:
+    Five planes, because five tables carry a row keyed by this item and each can move alone:
 
-    - **`surfaces`** — the SURFACE ROWS, `surface_row` being the projection of every column
-      that table holds. That covers the surface fingerprint (emitter version, type, origin,
-      body) AND the attribution, title, url, locator and language `search` serves on every
-      match (A-1).
+    - **`surfaces`** — the SURFACE ROWS. `surface_row` is every column that table holds, so
+      this covers the surface fingerprint AND the attribution, title, url, locator and
+      language `search` serves on every match (A-1).
     - **`items`** / **`item_topics`** / **`item_content_kinds`** — the filterable METADATA. A
       changed author changes what `--author` returns with no text moved.
     - **`source_failures`** and **`unfetched_links`** — HIGH-1 of review #161, and the reason
-      this child exists. Both tables are written per item, both are read back by `get`, and
-      before this neither moved any fingerprint: a link that started returning 404, or a fetch
-      that began failing, rewrote the row on disk while `update` reported the item unchanged.
+      this child exists. Both are written per item and read back by `get`, and before this
+      neither moved any fingerprint: a link that started returning 404, or a fetch that began
+      failing, rewrote the row on disk while `update` reported the item unchanged.
+    - **`chunks`** — the BLOCK PARTITION of every X Article, as the ordered LENGTHS of its
+      `ArticleTextBlock` bodies, keyed by `surface_id` (never by position: `fetch` rewrites
+      `content.sources`). `ContentSourceSuccess` validates `text == "".join(blocks)`, so the
+      flattened body is a function of the partition and NOT the reverse: two block lists that
+      concatenate alike leave `surface_row` and `surface.fingerprint` identical while
+      `chunk_surfaces(..., blocks_by_surface_id=article_block_texts(item))` — called today by
+      `cli.py` and `evaluation.py` — cuts different `chunk_id`s, offsets, bodies and
+      `chunks_fts` rows. Measured 2026-09-03 on the live store: **41** items carry usable
+      blocks and **41 of 41** carry more than one. LENGTHS, never the bodies: the
+      concatenation is already hashed by `surface.fingerprint`, so only the cuts were
+      missing, and a second copy of the text is what spec §10.8 forbids.
 
     THE ROW, NOT THE SURFACE FINGERPRINT ALONE (G-5). `surface_fingerprint` is
-    `(version, type, origin, text)` by design and must stay so; but hashing only that here
-    meant a `refresh-quoted` that filled in the author of a quoted post without touching its
-    body left `update` reporting `0 cambiados` and `search` serving the old attribution — the
-    evidence repaired, the derivative standing (rule 6), on the attribution rule this repo
-    paid for in blood. `producer` is NOT hashed: the index has no producer column, and the
-    producers the store records travel with the surface `get` re-emits (F7-7). Deliberately
-    NOT `(item_id, content.fetched_at, enriched.enriched_at)` — a timestamp is a claim about
-    when something was written, never about what it says.
+    `(version, type, origin, text)` by design and must stay so; hashing only that here meant a
+    `refresh-quoted` that filled in a quoted post's author without touching its body left
+    `update` reporting `0 cambiados` and `search` serving the old attribution — rule 6, on the
+    attribution rule this repo paid for in blood. `producer` is NOT hashed (no producer column;
+    the producers travel with the surface `get` re-emits, F7-7), and neither is any timestamp:
+    a timestamp claims when something was written, never what it says.
 
-    `primary_topic` IS ITS OWN ATOM, beside the topics tuple and not folded into it. It is a
-    persisted `items` column and a persisted `item_topics.is_primary` flag, and
-    `item_topics()` puts the primary first and then DEDUPLICATES — so an enrichment with
-    `primary_topic=None, topics=["a", "b"]` and one with `primary_topic="a", topics=["b"]`
-    produce the identical tuple `("a", "b")` while the stored column reads `NULL` against
-    `"a"`. `Enrichment.primary_topic` is `str | None`, so both states load from a real
-    `items.json` — and measured 2026-09-03 on the live store (2,404 items, sha256
-    `f76341a3...`), **0** of them sit in the colliding class. Constructible, not present:
-    what keeps them absent is `guardrails.yaml`, which the model does not enforce, so read
-    the zero as today's corpus and never as an invariant.
-
-    02.7 INHERITS A SECOND HALF OF THIS, worth knowing before it writes the row: the two
-    obsolete writers derive `item_topics.is_primary` differently — one compares the slug to
-    `primary_topic`, the other takes position 0 with a `or topics[0]` fallback — and they
-    disagree on exactly the falsy-primary states this atom now separates. A fingerprint that
-    distinguishes two states while the writer stores them alike is worse than one that
-    distinguishes neither, so collapsing those two derivations is 02.7's, not a detail.
+    `primary_topic` IS ITS OWN ATOM, beside the topics tuple and not folded into it: it is a
+    persisted `items` column AND a persisted `item_topics.is_primary` flag, and `item_topics()`
+    puts the primary first and then DEDUPLICATES, so `primary_topic=None, topics=["a", "b"]`
+    and `primary_topic="a", topics=["b"]` produce the identical tuple `("a", "b")` while the
+    stored column reads `NULL` against `"a"`. Both states load from a real `items.json`;
+    measured 2026-09-03 (2,404 items, sha256 `f76341a3...`), **0** sit in that class — what
+    keeps them absent is `guardrails.yaml`, which the model does not enforce, so read the zero
+    as today's corpus and never as an invariant. 02.7 inherits the second half: the two
+    obsolete writers derive `item_topics.is_primary` differently (slug-vs-`primary_topic`, and
+    position 0 with a `or topics[0]` fallback) and disagree on exactly the falsy-primary states
+    this atom separates. A fingerprint that distinguishes two states the writer stores alike is
+    worse than one that distinguishes neither, so collapsing them is 02.7's, not a detail.
 
     ONE KNOWN FALSE POSITIVE, AND IT IS THE DIRECTION THIS MODULE FAILS IN ON PURPOSE. The
-    topics region keeps the order `Enrichment.topics` was written in, while the `item_topics`
-    plane on disk is a SET keyed `(item_id, slug)` plus `is_primary` — so a re-enrichment
-    that returns the same topics in a different order re-hashes an item whose rows do not
-    move. Measured 2026-09-03: 2,073 of 2,404 items carry more than one topic, so the
-    population is most of the corpus. It costs one wasted rewrite and never a stale row,
-    which is the trade the cheap signal already makes. `kinds` is the opposite case and is
-    `sorted()`: `item_content_kinds` is a set too, and there the normalisation is free.
+    topics region keeps the order `Enrichment.topics` was written in, while `item_topics` on
+    disk is a SET keyed `(item_id, slug)` — so a re-enrichment returning the same topics in a
+    different order re-hashes an item whose rows do not move (2,073 of 2,404 items carry more
+    than one topic). One wasted rewrite, never a stale row, the trade the cheap signal already
+    makes. `kinds` needs no such trade: `surfaces.item_content_kinds` — the ONE derivation
+    `knowledge_item` also reads — deduplicates, so the region and the rows are the same object.
 
-    THE VARIADIC REGIONS ARE NESTED, NEVER SPLICED. Flattening `topics`, `kinds`, `rows`,
-    the failures and the links into one delimited list is NOT injective: `topics=("thread",)`
-    with no sources serialised exactly like no topics with one blank `thread` source, so two
-    item states hashed alike and `update` called the item unchanged — rule 6, failing OPEN.
-    Each region is its own JSON array, so the boundary is STRUCTURAL, and `_canonical` makes
-    the atoms inside them unforgeable too.
+    THE VARIADIC REGIONS ARE NESTED, NEVER SPLICED. Flattening them into one delimited list is
+    NOT injective: `topics=("thread",)` with no sources serialised exactly like no topics with
+    one blank `thread` source, so two item states hashed alike and `update` called the item
+    unchanged — rule 6, failing OPEN. Each region is its own JSON array, so the boundary is
+    STRUCTURAL, and `_canonical` makes the atoms inside them unforgeable too.
 
-    **THE TWO PERSISTED COLUMNS THIS CANNOT REACH, named rather than left to be discovered.**
-    Neither is a defect of the encoding; both are inputs this child does not have:
+    **WHAT THIS STILL CANNOT REACH, named rather than left to be discovered.** None is a defect
+    of the encoding; all are inputs this child does not have.
 
-    - `items.note_path` is not a projection of the STORE at all. `surfaces._note_path` stats
-      the VAULT (`candidate.exists()`) under `IndexOptions.vault_dir`, so generating a note
-      changes that column while nothing about the item moves. A store fingerprint cannot see
-      it by construction; the invalidation has to come from a vault-side signal, and that is
-      02.6b's (manifest) and 02.7's (writer) obligation, not a hole to be plugged here.
-    - `items.skipped_empty_text` is `len(chunks) - stored` — the chunker's arithmetic, under
-      `IndexOptions.params`, which is inert here. Measured in the obsolete monolith it is
-      structurally 0 today (the emitters drop a blank surface at `_blank` before chunking),
-      but "0 today" is not "covered".
+    - `items.note_path` — `surfaces._note_path` stats the VAULT under `IndexOptions.vault_dir`,
+      so generating a note moves that column while nothing about the item does. 02.6b / 02.7.
+    - `items.skipped_empty_text` — `len(chunks) - stored`, the chunker's arithmetic under the
+      inert `IndexOptions.params`; structurally 0 today, and "0 today" is not "covered". 02.7.
+    - `CHUNKER_VERSION` (`ids.py:43`) and `ChunkerParams` — the first is stamped into every
+      `chunk_id` and `chunks.fingerprint`, the second decides where every span falls (measured,
+      `800/0` against `400/0`: 5 rows against 9 over one body). A bump of either rewrites the
+      whole `chunks` plane with this fingerprint unmoved, and that is CORRECT: a manifest
+      refusing the query outright beats per-item invalidation. 02.6b's — and `ids.py:42` names
+      `load_compatible_manifest` as its home, a function that does not exist in this tree yet.
+    - `profiles.profile_text` — a `vocab.yaml` edit splices each assigned topic's DESCRIPTION
+      into it (spec §5.1.A) and rewrites `profiles`/`profiles_fts` for every assigned item while
+      this fingerprint, which takes no vocabulary, cannot move: 02.6a2b's, reaching the item
+      plane through 02.7's rebuild. Its OTHER half is NOT, and filing it there would record a
+      debt under an owner who cannot discharge it — `profile.py:_titles` gates on
+      `if source.title`, so a title on a blank-bodied source reaches the profile while the
+      emitter produces nothing (a whitespace-only `summary`/`digest` is the same shape: profile
+      on truthiness, emitter on `_blank()`, which strips). Constructible, 0 of 2,404 today, and
+      02.7's — the only writer that sees both sides.
 
-    **A fourth, on the `profiles` plane, and it is not an omission here.**
-    `profile.profile_text` splices each assigned topic's DESCRIPTION into the item's profile
-    (spec §5.1.A), so a `vocab.yaml` edit rewrites `profiles.profile_text` — and its
-    `profiles_fts` row — for every assigned item, while this fingerprint, which takes no
-    vocabulary, cannot move; the obsolete monolith even stored THIS hash in
-    `profiles.fingerprint`. The invalidation is `vocab_fingerprint`'s (02.6a2b) and it
-    reaches the item plane only through the update's rebuild (02.7). Read this fingerprint as
-    *what changed about the item*, never as *what changed about its indexed rows*.
+    Read this fingerprint as *what changed about the item*, never as *what changed about its
+    indexed rows*.
 
-    A fifth, on the plane below: `source_failures.attempts` is a DDL column with no field on
-    the knowledge `SourceFailure`, so nothing here can hash it and nothing here emits it.
-    02.7 either adds the field — `_model_atoms` then picks it up with no change, but
-    `SourceFailure` also travels in `EvidenceBundle.failures`, and `contracts.py` holds that
-    an optional field with a default is NOT exempt, so that door costs an
-    `EvidenceBundle.schema_version` bump — or drops the column, which costs a
-    `SCHEMA_VERSION` bump instead. It may not do neither, and neither door is free.
+    `source_failures.attempts` USED TO BE ON THAT LIST and is not any more: it was the only
+    column across both failure planes with no field on the knowledge projection this hashes,
+    and `index_schema.SCHEMA_VERSION` "4" drops it rather than adding the field. The reasoning,
+    and the test that stops either side moving alone, are recorded there.
 
     `options` IS NOT READ HERE. It is accepted so the signature 02.7 consumes is already the
     ported one, and discarded — see `IndexOptions`.
     """
     options = options or IndexOptions()
     decorative, no_speech = declined_media(item)
-    kinds = sorted(
-        source.kind
-        for _index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
-    )
+    kinds = sorted(item_content_kinds(item))
     return _sha256(
         _canonical(
             "item",
@@ -519,6 +503,7 @@ def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
                 list(item_topics(item)),
                 kinds,
                 [surface_row(surface) for surface in item_surfaces(item)],
+                [[s, [len(t) for t in b]] for s, b in sorted(article_block_texts(item).items())],
                 [_model_atoms(failure) for failure in failed_sources(item)],
                 [_model_atoms(link) for link in unfetched_links(item)],
                 [decorative, no_speech],
@@ -536,13 +521,13 @@ def store_fingerprint(store: Mapping[str, Item], *, options: IndexOptions | None
     id ending in a hex run from re-cutting the boundary and presenting a different store as
     this one.
 
-    NOT PAID BY A QUERY. This walks every item and emits every surface; the cheap
-    `StoreSignal` above is what a query affords on every call, and keeping the two apart is
-    the whole point of 02.6a1's contract. Nothing in this module makes a status path read
-    deeply, and nothing may. The tempting shape is a fingerprint computed beside
-    `IndexInputs.signal`, *since we have already parsed the store*: measured 2026-09-03 on
-    the live store (2,404 items, sha256 `f76341a3...`), the parse is ~130 ms and this walk
-    adds ~134 ms — a 2x on a door `status` calls.
+    NOT PAID BY A QUERY. This walks every item and emits every surface; the cheap `StoreSignal`
+    above is what a query affords on every call, and keeping the two apart is 02.6a1's whole
+    contract. The tempting shape is a fingerprint computed beside `IndexInputs.signal`, *since
+    we have already parsed the store*: measured on the live store (2,404 items, sha256
+    `f76341a3...`), this walk costs the same ORDER as the parse itself, so folding it in
+    roughly doubles a door `status` calls. Read that as a ratio and not as a millisecond
+    figure — three measurements on this machine gave three answers.
     """
     return _sha256(
         _canonical(
@@ -557,41 +542,31 @@ def _canonical(domain: str, value: object) -> str:
     INJECTIVE ON THE PAYLOAD DOMAIN THESE FINGERPRINTS ACTUALLY BUILD, and the scope of that
     claim is the claim. JSON is NOT injective over Python values in general — `(1, 2)` and
     `[1, 2]` encode identically, and so do `{1: "a"}` and `{"1": "a"}` — so an unqualified
-    *injective by round trip* would be false the moment someone believed it. What holds, and
-    what the payloads here are built out of, is: `str`, `int`, `None`, and SEQUENCES of those
-    nested to any depth. Over that domain `json.loads` recovers the exact structure, so two
-    different structures cannot encode alike and no argument about which strings may appear
-    is left. Three consequences a future payload must respect:
+    *injective by round trip* would be false the moment someone believed it. What holds is the
+    domain these payloads are built out of: `str`, `int`, `None`, and SEQUENCES of those nested
+    to any depth, over which `json.loads` recovers the exact structure. Three consequences a
+    future payload must respect: `list` and `tuple` are the SAME value here (`surface_row`
+    returns a tuple and is safe only because its position is what carries it); no `dict` may
+    enter, its keys being coerced to strings, which is why `_model_atoms` emits
+    `[[name, value], ...]`; and no `float` may enter, `allow_nan=False` making a stray
+    `NaN`/`Infinity` RAISE rather than emit a literal no reader could parse back.
 
-    - **`list` and `tuple` are the same value here.** `surface_row` returns a tuple and the
-      regions around it are lists; that is fine because they are POSITIONAL, never because
-      the encoder tells them apart. Nothing may distinguish two item states by sequence type.
-    - **No `dict` may enter.** Its keys are coerced to strings, which collides. `_model_atoms`
-      exists partly for this: it turns a pydantic projection into `[[name, value], ...]`
-      instead of a mapping.
-    - **No `float` may enter.** `allow_nan=False` is here so a stray `NaN`/`Infinity` RAISES
-      instead of emitting the non-JSON literals `NaN`/`Infinity`, which no reader could parse
-      back — fail closed, at the first build, rather than a blob that only looks canonical.
-
-    This replaced a NUL-JOIN, which framed nothing below the region: both store writers
-    persist a NUL, so a stored value could re-split the stream and move every later boundary,
-    including the count tags meant to fix them. Measured before the change: two topic lists,
-    two vocabularies and two topic planes, each pair distinct after `save`/`load` and each
-    pair hashing alike.
+    This replaced a NUL-JOIN, which framed nothing below the region: both store writers persist
+    a NUL, so a stored value could re-split the stream and move every later boundary, including
+    the count tags meant to fix them. Measured before the change: two topic lists, two
+    vocabularies and two topic planes, each pair distinct after `save`/`load` and hashing alike.
 
     `ensure_ascii=False` IS THE INJECTIVE SETTING, a correctness choice: with `True` a lone
-    surrogate PAIR and the astral character it spells serialise to the same escape, which is
-    a collision; with `False` they differ and a lone surrogate raises at `.encode("utf-8")`.
-    That raise is REACHABLE from a real `items.json` and not only from a constructed model:
-    the escape is pure ASCII on disk, so `_read_bound`'s decode succeeds and `json.loads`
-    hands back the lone surrogate intact. It surfaces as a raw `UnicodeEncodeError` — a
-    `ValueError`, so no `OSError` handler at any door will catch it — and turning it into a
-    named message is the first consumer's obligation, exactly as `_read_bound`'s is.
-    `domain` is hashed IN so two planes cannot serialise alike — `store_fingerprint({"a": i})`
-    and a one-entry vocabulary with slug `a` and description `i`'s fingerprint were both
-    `[["a", <64 hex>]]`, measured EQUAL. Closed because it costs one argument. (NUL is spelled
-    in words here: as an escape in a non-raw docstring it puts a real one in `__doc__` —
-    three, in the first version of this text.)
+    surrogate PAIR and the astral character it spells serialise to the same escape, which is a
+    collision; with `False` they differ and a lone surrogate raises at `.encode("utf-8")`. That
+    raise is REACHABLE from a real `items.json` — the escape is pure ASCII on disk, so
+    `_read_bound`'s decode succeeds and `json.loads` hands back the surrogate intact — and it
+    surfaces as a raw `UnicodeEncodeError`, a `ValueError` no `OSError` handler will catch;
+    naming it is the first consumer's obligation, exactly as `_read_bound`'s is. `domain` is
+    hashed IN so two planes cannot serialise alike: `store_fingerprint({"a": i})` and a
+    one-entry vocabulary with slug `a` and description `i`'s fingerprint were both
+    `[["a", <64 hex>]]`, measured EQUAL. (NUL is spelled in words here: as an escape in a
+    non-raw docstring it puts a real one in `__doc__` — three, in the first version.)
     """
     return json.dumps([domain, value], ensure_ascii=False, allow_nan=False)
 

--- a/src/xbrain/knowledge/index_build.py
+++ b/src/xbrain/knowledge/index_build.py
@@ -1,12 +1,23 @@
-"""The three inputs of the index, read as ONE snapshot, with the cheap signal bound to it
-(Plan 02 §2, §3; spec §5.6).
+"""The three inputs of the index read as ONE snapshot, and the DEEP fingerprints of the
+item/store plane (Plan 02 §2, §3; spec §5.6).
 
-ONE CHEAP SIGNAL, PAID ON EVERY QUERY. Indexing is MANUAL BY DECISION (spec §9.2), so the
-failure that actually happens is not corruption — it is *you ran `enrich` and did not
-reindex*. `StoreSignal` is `mtime_ns` and size of the THREE inputs: three `os.stat`, cheap
-enough for every query, and it answers *an input moved*. It cannot answer *WHICH items
-changed* — that is a per-item fingerprint over the emitted surfaces, a different cost paid
-only by build/update/status, and it is the next child's. Nothing here computes one.
+TWO SIGNALS, AND THE WHOLE DESIGN IS THAT THEY COST DIFFERENT THINGS. Indexing is MANUAL BY
+DECISION (spec §9.2), so the failure that actually happens is not corruption — it is *you ran
+`enrich` and did not reindex*.
+
+- The CHEAP one, `StoreSignal`, is `mtime_ns` and size of the THREE inputs: three `os.stat`,
+  cheap enough for EVERY query, answering *an input moved*. It cannot say WHICH items.
+- The DEEP ones, `item_fingerprint` and `store_fingerprint`, walk the corpus and emit every
+  surface to answer *which items changed, and how many*. They are paid ONLY by
+  `build` / `update` / `status`, and by nothing a query touches. No path in this module makes
+  a cheap reader pay a deep one, and none may — that separation is 02.6a1's contract and this
+  child inherits it unchanged.
+
+WHAT IS NOT HERE, AND WHY IT IS NOT A HOLE. `vocab_fingerprint` and `topics_fingerprint` are
+the other two planes and are the NEXT child's (02.6a2b); they will consume `_canonical` and
+`_sha256` from here and nothing else. The manifest that seals any of the four is 02.6b's.
+Nothing in this tree consumes a fingerprint yet, which is exactly why the coverage gaps
+review #161 named are being closed HERE — free before a manifest exists, expensive after.
 
 The cheap signal can give false positives (a `touch` with no edit) and that is accepted: a
 false positive costs one warning, a false negative costs serving stale evidence as fresh. It
@@ -24,11 +35,27 @@ good index, and round 08 caught it doing exactly that at exit 0.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
-from xbrain.models import Item, Topic, TopicPage
+from pydantic import BaseModel
+
+from xbrain.executors.api import iter_content_sources
+from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams
+from xbrain.knowledge.ids import SURFACE_VERSION
+from xbrain.knowledge.models import KnowledgeSurface
+from xbrain.knowledge.surfaces import (
+    CONTENT_KIND_TO_SURFACE_TYPES,
+    failed_sources,
+    item_surfaces,
+    item_topics,
+    unfetched_links,
+)
+from xbrain.models import Item, MediaPhotoDescribed, Topic, TopicPage
 from xbrain.rubrics import parse_vocab
 from xbrain.store import parse_store, parse_topic_pages
 
@@ -238,3 +265,336 @@ def _read_bound(path: Path) -> tuple[str | None, int, int]:
         stat = os.fstat(handle.fileno())
         data = handle.read()
     return data.decode("utf-8"), stat.st_mtime_ns, stat.st_size
+
+
+@dataclass(frozen=True)
+class IndexOptions:
+    """Everything a build needs that is not the corpus itself.
+
+    The configured transcribe/vision commands no longer travel here (F7-7, round 08): they
+    were stamped on the ASR/VLM surfaces as `producer`, a provenance claim the store cannot
+    back, and the emitter no longer takes them. See `surfaces.item_surfaces`.
+
+    CARRIED INERT IN THIS CHILD, AND SAYING SO IS THE POINT. Neither `params` nor `vault_dir`
+    is read ANYWHERE in this tree, so `item_fingerprint(item, options=X)` silently discards
+    `X`: a caller who passes the chunker's parameters expecting the fingerprint to cover them
+    would be wrong today. The dataclass travels here so the signature 02.7 consumes is already
+    the ported one — never because anything already reads it. Two persisted columns are
+    unreachable for exactly this reason and are named where they are missed:
+    `items.note_path` (needs `vault_dir`) and `items.skipped_empty_text` (needs `params`),
+    both in `item_fingerprint`.
+
+    `tests/test_knowledge_index_build.py` pins the inertness by BEHAVIOUR — two different
+    `IndexOptions` hashing alike — so 02.7's first consumer cannot land without that test
+    going red and being changed on purpose.
+    """
+
+    params: ChunkerParams = DEFAULT_CHUNKER_PARAMS
+    vault_dir: Path | None = None
+
+
+# The column order of `surfaces`, as ONE tuple type: hashed by `item_fingerprint`, and the
+# tuple 02.7's writer is meant to bind its `INSERT` to.
+SurfaceRow = tuple[
+    str,
+    str,
+    str,
+    str,
+    str,
+    str,
+    int,
+    str | None,
+    str | None,
+    str | None,
+    str | None,
+    str,
+    str | None,
+    str,
+    int,
+]
+
+
+def surface_row(surface: KnowledgeSurface) -> SurfaceRow:
+    """What the index STORES about a surface — the projection of one `surfaces` row.
+
+    ONE PROJECTION, AND 02.7's WRITER HAS TO CONSUME IT — WHICH IT DOES NOT YET.
+    `item_fingerprint` hashes this tuple today; the writer that binds it to the `INSERT` into
+    `surfaces` lands in 02.7, and no writer exists in this tree at all. So the correspondence
+    with the persisted DDL (`index_schema._SCHEMA`: fifteen columns, this tuple's order and
+    types) is kept BY HAND: nothing FORCES a column added to `surfaces` to be hashed here.
+    What this child ships instead of that force is a totality test that reads the fifteen
+    column names straight out of the DDL and compares the arity — it catches a column ADDED
+    to the schema, and it cannot catch a column REORDERED into a same-typed neighbour.
+    Making the binding structural is 02.7's job: its writer binds THIS function instead of
+    assembling a second tuple, and it writes the readback test — red first — proving the
+    stored and the hashed row cannot drift. Read any claim of that guard here as 02.7's
+    obligation, never as one discharged.
+
+    The last column is a LENGTH, never the body (spec §10.8); the body is covered by
+    `fingerprint`, which hashes it.
+    """
+    return (
+        surface.surface_id,
+        surface.owner_type,
+        surface.owner_id,
+        surface.surface_type,
+        surface.origin,
+        surface.trust_class,
+        int(surface.derived),
+        surface.attribution.handle if surface.attribution else None,
+        surface.attribution.name if surface.attribution else None,
+        surface.title,
+        surface.locator.url,
+        surface.locator.model_dump_json(),
+        surface.language,
+        surface.fingerprint,
+        len(surface.text),
+    )
+
+
+def declined_media(item: Item) -> tuple[int, int]:
+    """`(decorative, no_speech)` — the two omissions the `items` row COUNTS (spec §5.6).
+
+    A decorative photo and a silent video are surfaces the emitter deliberately does not
+    produce, and `items.skipped_decorative` / `items.skipped_no_speech` are where the index
+    records that it declined them rather than that it found nothing.
+
+    HASHED, BECAUSE OTHERWISE THEY MOVE UNSEEN. Both are persisted columns and both are pure
+    functions of the item, so leaving them out reproduces HIGH-1's exact shape one plane
+    over: `xbrain describe` classifying a photo as decorative flips `skipped_decorative`
+    0 -> 1 while emitting NO surface, changing no other hashed atom — the row on disk moves
+    and `update` reports the item unchanged (rule 6).
+
+    DEFINED HERE ONCE SO 02.7 CONSUMES IT. The writer that fills those two columns has to
+    produce the same pair; deriving it a second time next to the `UPDATE` is the five-hands
+    divergence of rule 5, and this is the seam that stops it.
+
+    The third counter, `skipped_empty_text`, is NOT here and cannot be: it is
+    `len(chunks) - stored`, a property of the chunker's parameters, which reach this module
+    only through the inert `IndexOptions`. See `item_fingerprint`.
+    """
+    decorative = sum(
+        1
+        for entry in item.media
+        if isinstance(entry, MediaPhotoDescribed) and (entry.is_decorative or not entry.description)
+    )
+    no_speech = sum(
+        1
+        for _index, source in iter_content_sources(item, {"x_video"})
+        if source.has_speech is False
+    )
+    return decorative, no_speech
+
+
+def _model_atoms(model: BaseModel) -> list[list[object]]:
+    """One pydantic projection as `[[field_name, value], ...]`, in field-definition order.
+
+    STRUCTURAL ON PURPOSE, and it is the difference between this child and the review that
+    named HIGH-1. A hand-written field list is what let `source_failures` and
+    `unfetched_links` change on disk while every fingerprint stood still; walking
+    `model_fields` means a field ADDED to `SourceFailure` or `UnfetchedLink` enters the hash
+    the moment it exists, with nobody having to remember. The NAME is hashed beside the value
+    so a rename — which is a schema change — moves the fingerprint too.
+
+    It fails CLOSED on a field this encoder cannot represent: `json.dumps` raises `TypeError`
+    on a `datetime` or a `set`, loudly, at the first build, rather than dropping it.
+    """
+    return [[name, getattr(model, name)] for name in type(model).model_fields]
+
+
+def item_fingerprint(item: Item, *, options: IndexOptions | None = None) -> str:
+    """sha256 over everything about this item that the INDEX PERSISTS.
+
+    Four planes, because four tables carry a row keyed by this item and every one of them can
+    change without the others moving:
+
+    - **`surfaces`** — the SURFACE ROWS, `surface_row` being the projection of every column
+      that table holds. That covers the surface fingerprint (emitter version, type, origin,
+      body) AND the attribution, title, url, locator and language `search` serves on every
+      match (A-1).
+    - **`items`** / **`item_topics`** / **`item_content_kinds`** — the filterable METADATA. A
+      changed author changes what `--author` returns with no text moved.
+    - **`source_failures`** and **`unfetched_links`** — HIGH-1 of review #161, and the reason
+      this child exists. Both tables are written per item, both are read back by `get`, and
+      before this neither moved any fingerprint: a link that started returning 404, or a fetch
+      that began failing, rewrote the row on disk while `update` reported the item unchanged.
+
+    THE ROW, NOT THE SURFACE FINGERPRINT ALONE (G-5). `surface_fingerprint` is
+    `(version, type, origin, text)` by design and must stay so; but hashing only that here
+    meant a `refresh-quoted` that filled in the author of a quoted post without touching its
+    body left `update` reporting `0 cambiados` and `search` serving the old attribution — the
+    evidence repaired, the derivative standing (rule 6), on the attribution rule this repo
+    paid for in blood. `producer` is NOT hashed: the index has no producer column, and the
+    producers the store records travel with the surface `get` re-emits (F7-7). Deliberately
+    NOT `(item_id, content.fetched_at, enriched.enriched_at)` — a timestamp is a claim about
+    when something was written, never about what it says.
+
+    `primary_topic` IS ITS OWN ATOM, beside the topics tuple and not folded into it. It is a
+    persisted `items` column and a persisted `item_topics.is_primary` flag, and
+    `item_topics()` puts the primary first and then DEDUPLICATES — so an enrichment with
+    `primary_topic=None, topics=["a", "b"]` and one with `primary_topic="a", topics=["b"]`
+    produce the identical tuple `("a", "b")` while the stored column reads `NULL` against
+    `"a"`. `Enrichment.primary_topic` is `str | None`, so both states load from a real
+    `items.json` — and measured 2026-09-03 on the live store (2,404 items, sha256
+    `f76341a3...`), **0** of them sit in the colliding class. Constructible, not present:
+    what keeps them absent is `guardrails.yaml`, which the model does not enforce, so read
+    the zero as today's corpus and never as an invariant.
+
+    02.7 INHERITS A SECOND HALF OF THIS, worth knowing before it writes the row: the two
+    obsolete writers derive `item_topics.is_primary` differently — one compares the slug to
+    `primary_topic`, the other takes position 0 with a `or topics[0]` fallback — and they
+    disagree on exactly the falsy-primary states this atom now separates. A fingerprint that
+    distinguishes two states while the writer stores them alike is worse than one that
+    distinguishes neither, so collapsing those two derivations is 02.7's, not a detail.
+
+    ONE KNOWN FALSE POSITIVE, AND IT IS THE DIRECTION THIS MODULE FAILS IN ON PURPOSE. The
+    topics region keeps the order `Enrichment.topics` was written in, while the `item_topics`
+    plane on disk is a SET keyed `(item_id, slug)` plus `is_primary` — so a re-enrichment
+    that returns the same topics in a different order re-hashes an item whose rows do not
+    move. Measured 2026-09-03: 2,073 of 2,404 items carry more than one topic, so the
+    population is most of the corpus. It costs one wasted rewrite and never a stale row,
+    which is the trade the cheap signal already makes. `kinds` is the opposite case and is
+    `sorted()`: `item_content_kinds` is a set too, and there the normalisation is free.
+
+    THE VARIADIC REGIONS ARE NESTED, NEVER SPLICED. Flattening `topics`, `kinds`, `rows`,
+    the failures and the links into one delimited list is NOT injective: `topics=("thread",)`
+    with no sources serialised exactly like no topics with one blank `thread` source, so two
+    item states hashed alike and `update` called the item unchanged — rule 6, failing OPEN.
+    Each region is its own JSON array, so the boundary is STRUCTURAL, and `_canonical` makes
+    the atoms inside them unforgeable too.
+
+    **THE TWO PERSISTED COLUMNS THIS CANNOT REACH, named rather than left to be discovered.**
+    Neither is a defect of the encoding; both are inputs this child does not have:
+
+    - `items.note_path` is not a projection of the STORE at all. `surfaces._note_path` stats
+      the VAULT (`candidate.exists()`) under `IndexOptions.vault_dir`, so generating a note
+      changes that column while nothing about the item moves. A store fingerprint cannot see
+      it by construction; the invalidation has to come from a vault-side signal, and that is
+      02.6b's (manifest) and 02.7's (writer) obligation, not a hole to be plugged here.
+    - `items.skipped_empty_text` is `len(chunks) - stored` — the chunker's arithmetic, under
+      `IndexOptions.params`, which is inert here. Measured in the obsolete monolith it is
+      structurally 0 today (the emitters drop a blank surface at `_blank` before chunking),
+      but "0 today" is not "covered".
+
+    **A fourth, on the `profiles` plane, and it is not an omission here.**
+    `profile.profile_text` splices each assigned topic's DESCRIPTION into the item's profile
+    (spec §5.1.A), so a `vocab.yaml` edit rewrites `profiles.profile_text` — and its
+    `profiles_fts` row — for every assigned item, while this fingerprint, which takes no
+    vocabulary, cannot move; the obsolete monolith even stored THIS hash in
+    `profiles.fingerprint`. The invalidation is `vocab_fingerprint`'s (02.6a2b) and it
+    reaches the item plane only through the update's rebuild (02.7). Read this fingerprint as
+    *what changed about the item*, never as *what changed about its indexed rows*.
+
+    A fifth, on the plane below: `source_failures.attempts` is a DDL column with no field on
+    the knowledge `SourceFailure`, so nothing here can hash it and nothing here emits it.
+    02.7 either adds the field — `_model_atoms` then picks it up with no change, but
+    `SourceFailure` also travels in `EvidenceBundle.failures`, and `contracts.py` holds that
+    an optional field with a default is NOT exempt, so that door costs an
+    `EvidenceBundle.schema_version` bump — or drops the column, which costs a
+    `SCHEMA_VERSION` bump instead. It may not do neither, and neither door is free.
+
+    `options` IS NOT READ HERE. It is accepted so the signature 02.7 consumes is already the
+    ported one, and discarded — see `IndexOptions`.
+    """
+    options = options or IndexOptions()
+    decorative, no_speech = declined_media(item)
+    kinds = sorted(
+        source.kind
+        for _index, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
+    )
+    return _sha256(
+        _canonical(
+            "item",
+            [
+                SURFACE_VERSION,
+                item.id,
+                item.source,
+                item.url,
+                item.author.handle,
+                item.author.name,
+                item.created_at.isoformat(),
+                item.captured_at.isoformat(),
+                item.bookmark_folder,
+                item.enriched.primary_topic if item.enriched else None,
+                list(item_topics(item)),
+                kinds,
+                [surface_row(surface) for surface in item_surfaces(item)],
+                [_model_atoms(failure) for failure in failed_sources(item)],
+                [_model_atoms(link) for link in unfetched_links(item)],
+                [decorative, no_speech],
+            ],
+        )
+    )
+
+
+def store_fingerprint(store: Mapping[str, Item], *, options: IndexOptions | None = None) -> str:
+    """The DEEP store signal: one sha256 over every item's fingerprint, in id order.
+
+    Order-independent by construction — the ids are sorted — because a dict's iteration order
+    is a property of how the store was loaded, not of what it contains. Each `(id, hash)` is
+    its own array, so an id cannot run into the hash beside it: that nesting is what stops an
+    id ending in a hex run from re-cutting the boundary and presenting a different store as
+    this one.
+
+    NOT PAID BY A QUERY. This walks every item and emits every surface; the cheap
+    `StoreSignal` above is what a query affords on every call, and keeping the two apart is
+    the whole point of 02.6a1's contract. Nothing in this module makes a status path read
+    deeply, and nothing may. The tempting shape is a fingerprint computed beside
+    `IndexInputs.signal`, *since we have already parsed the store*: measured 2026-09-03 on
+    the live store (2,404 items, sha256 `f76341a3...`), the parse is ~130 ms and this walk
+    adds ~134 ms — a 2x on a door `status` calls.
+    """
+    return _sha256(
+        _canonical(
+            "store", [[k, item_fingerprint(store[k], options=options)] for k in sorted(store)]
+        )
+    )
+
+
+def _canonical(domain: str, value: object) -> str:
+    """The ONE serialisation every fingerprint here hashes, and the only one (rule 5).
+
+    INJECTIVE ON THE PAYLOAD DOMAIN THESE FINGERPRINTS ACTUALLY BUILD, and the scope of that
+    claim is the claim. JSON is NOT injective over Python values in general — `(1, 2)` and
+    `[1, 2]` encode identically, and so do `{1: "a"}` and `{"1": "a"}` — so an unqualified
+    *injective by round trip* would be false the moment someone believed it. What holds, and
+    what the payloads here are built out of, is: `str`, `int`, `None`, and SEQUENCES of those
+    nested to any depth. Over that domain `json.loads` recovers the exact structure, so two
+    different structures cannot encode alike and no argument about which strings may appear
+    is left. Three consequences a future payload must respect:
+
+    - **`list` and `tuple` are the same value here.** `surface_row` returns a tuple and the
+      regions around it are lists; that is fine because they are POSITIONAL, never because
+      the encoder tells them apart. Nothing may distinguish two item states by sequence type.
+    - **No `dict` may enter.** Its keys are coerced to strings, which collides. `_model_atoms`
+      exists partly for this: it turns a pydantic projection into `[[name, value], ...]`
+      instead of a mapping.
+    - **No `float` may enter.** `allow_nan=False` is here so a stray `NaN`/`Infinity` RAISES
+      instead of emitting the non-JSON literals `NaN`/`Infinity`, which no reader could parse
+      back — fail closed, at the first build, rather than a blob that only looks canonical.
+
+    This replaced a NUL-JOIN, which framed nothing below the region: both store writers
+    persist a NUL, so a stored value could re-split the stream and move every later boundary,
+    including the count tags meant to fix them. Measured before the change: two topic lists,
+    two vocabularies and two topic planes, each pair distinct after `save`/`load` and each
+    pair hashing alike.
+
+    `ensure_ascii=False` IS THE INJECTIVE SETTING, a correctness choice: with `True` a lone
+    surrogate PAIR and the astral character it spells serialise to the same escape, which is
+    a collision; with `False` they differ and a lone surrogate raises at `.encode("utf-8")`.
+    That raise is REACHABLE from a real `items.json` and not only from a constructed model:
+    the escape is pure ASCII on disk, so `_read_bound`'s decode succeeds and `json.loads`
+    hands back the lone surrogate intact. It surfaces as a raw `UnicodeEncodeError` — a
+    `ValueError`, so no `OSError` handler at any door will catch it — and turning it into a
+    named message is the first consumer's obligation, exactly as `_read_bound`'s is.
+    `domain` is hashed IN so two planes cannot serialise alike — `store_fingerprint({"a": i})`
+    and a one-entry vocabulary with slug `a` and description `i`'s fingerprint were both
+    `[["a", <64 hex>]]`, measured EQUAL. Closed because it costs one argument. (NUL is spelled
+    in words here: as an escape in a non-raw docstring it puts a real one in `__doc__` —
+    three, in the first version of this text.)
+    """
+    return json.dumps([domain, value], ensure_ascii=False, allow_nan=False)
+
+
+def _sha256(blob: str) -> str:
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()

--- a/src/xbrain/knowledge/index_schema.py
+++ b/src/xbrain/knowledge/index_schema.py
@@ -73,7 +73,18 @@ from xbrain.models import _reject_local_path_traversal
 # and a v2 base's fingerprints were computed over the text alone, so every one of its rows
 # would fail verification. The door refuses it by name, with the rebuild, rather than
 # answering «22,286 chunks excluded».
-SCHEMA_VERSION = "3"
+# "4" since the 02.6a2a review: `source_failures.attempts` is GONE. It was the one column
+# across both failure planes with no field on the knowledge `SourceFailure`, so the versioned
+# public projection and the DDL disagreed and `item_fingerprint`, which hashes the projection,
+# could not see it — the shape review #161 exists to close. Of the two doors, ADDING the field
+# would put fetch bookkeeping inside the hash, and `fetch._source_signature` excludes
+# `attempts` for exactly that reason: a persistently-failing link re-fetched every run would
+# re-index an item whose evidence did not move. It would also bump `EvidenceBundle`'s public
+# version for a number no consumer asked for. So the column goes instead: the only writer that
+# ever existed bound it to a literal `None` (`b61e04b:index_build.py:838`) and nothing has ever
+# read it back. `tests/test_knowledge_index_build.py` binds the two DDLs to their projections
+# by NAME, so neither side can move again without the other.
+SCHEMA_VERSION = "4"
 
 DB_FILENAME = "knowledge.db"
 MANIFEST_FILENAME = "manifest.json"
@@ -218,8 +229,7 @@ CREATE TABLE IF NOT EXISTS source_failures (
     url            TEXT NOT NULL,
     failure_reason TEXT NOT NULL,
     error          TEXT,
-    http_status    INTEGER,
-    attempts       INTEGER
+    http_status    INTEGER
 );
 CREATE INDEX IF NOT EXISTS source_failures_item ON source_failures (item_id);
 

--- a/src/xbrain/knowledge/index_schema.py
+++ b/src/xbrain/knowledge/index_schema.py
@@ -83,7 +83,16 @@ from xbrain.models import _reject_local_path_traversal
 # version for a number no consumer asked for. So the column goes instead: the only writer that
 # ever existed bound it to a literal `None` (`b61e04b:index_build.py:838`) and nothing has ever
 # read it back. `tests/test_knowledge_index_build.py` binds the two DDLs to their projections
-# by NAME, so neither side can move again without the other.
+# by NAME and pins their declarations by VALUE, so neither side can move again without the other.
+# WHAT THE BUMP DOES AND DOES NOT DO IN THIS TREE, because the paragraph opening this block
+# reads like an enforcement and here it is an intention: NOTHING consumes this constant. The
+# manifest that would compare it is 02.6b's — `load_compatible_manifest` has one hit repo-wide,
+# a comment at `ids.py:42` — and `_verify_schema` tolerates EXTRA columns by design, so an
+# existing v3 base, which differs from v4 only by carrying `attempts`, is ACCEPTED today
+# (verified by opening one). The bump's only live effect is the other direction: v3 code reading
+# a v4 base finds `source_failures.attempts` missing and refuses it. The table also diverges
+# from Plan 02's frozen DDL in TWO cells now — that DDL still declares `attempts` and still
+# omits the `http_status` an earlier child added — so 02.7's writer is built against THIS file.
 SCHEMA_VERSION = "4"
 
 DB_FILENAME = "knowledge.db"

--- a/src/xbrain/knowledge/surfaces.py
+++ b/src/xbrain/knowledge/surfaces.py
@@ -537,6 +537,28 @@ def _note_path(item: Item, vault_dir: Path | None) -> str | None:
     return relative.as_posix()
 
 
+def item_content_kinds(item: Item) -> tuple[ContentKind, ...]:
+    """The kinds with a READABLE body, deduplicated, in the order `content.sources` carries them.
+
+    ONE DERIVATION, BECAUSE THERE WERE TWO. `knowledge_item` served this walk to the consumer
+    and `index_build.item_fingerprint` re-derived it to hash the `item_content_kinds` plane —
+    two hands on the filter `--content-kind` reads, which is rule 5's shape. They also
+    DISAGREED: the second was a sorted MULTISET while the table is keyed `(item_id, kind)`, so
+    an item with two sources of one kind hashed two entries against one row and every added
+    duplicate re-hashed an item whose rows do not move (10 of 2,404 on the live store,
+    measured 2026-09-03). Deduplicating here makes the hash the plane it is hashing.
+
+    A failed fetch appears in `failed_sources` instead (spec §3.2): listing its kind as
+    available would tell a consumer to ask `get` for a body that does not exist.
+    """
+    return tuple(
+        dict.fromkeys(
+            source.kind
+            for _i, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
+        )
+    )
+
+
 def knowledge_item(item: Item, *, vault_dir: Path | None = None) -> KnowledgeItem:
     """The read projection of one item (spec §3.2).
 
@@ -545,12 +567,7 @@ def knowledge_item(item: Item, *, vault_dir: Path | None = None) -> KnowledgeIte
     to ask `get` for a body that does not exist.
     """
     surfaces = item_surfaces(item)
-    kinds = tuple(
-        dict.fromkeys(
-            source.kind
-            for _i, source in iter_content_sources(item, set(CONTENT_KIND_TO_SURFACE_TYPES))
-        )
-    )
+    kinds = item_content_kinds(item)
     return KnowledgeItem(
         item_id=item.id,
         source=item.source,

--- a/src/xbrain/knowledge/surfaces.py
+++ b/src/xbrain/knowledge/surfaces.py
@@ -438,7 +438,7 @@ def item_topics(item: Item) -> tuple[str, ...]:
     return tuple(dict.fromkeys(topic for topic in ordered if topic))
 
 
-def _failed_sources(item: Item) -> tuple[SourceFailure, ...]:
+def failed_sources(item: Item) -> tuple[SourceFailure, ...]:
     return tuple(
         SourceFailure(
             kind=source.kind,
@@ -452,7 +452,7 @@ def _failed_sources(item: Item) -> tuple[SourceFailure, ...]:
     )
 
 
-def _unfetched_links(item: Item) -> tuple[UnfetchedLink, ...]:
+def unfetched_links(item: Item) -> tuple[UnfetchedLink, ...]:
     """The URLs in `item.links` with no recovered body, each with its recorded reason (m7).
 
     Spec §4: these are metadata the consumer must SEE, together with why there is no body —
@@ -562,8 +562,8 @@ def knowledge_item(item: Item, *, vault_dir: Path | None = None) -> KnowledgeIte
         topics=item_topics(item),
         available_surfaces=tuple(dict.fromkeys(s.surface_type for s in surfaces)),
         content_kinds=kinds,
-        failed_sources=_failed_sources(item),
-        unfetched_links=_unfetched_links(item),
+        failed_sources=failed_sources(item),
+        unfetched_links=unfetched_links(item),
         note_path=_note_path(item, vault_dir),
         bookmark_folder=item.bookmark_folder,
     )

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -10,14 +10,32 @@ from __future__ import annotations
 
 import dataclasses
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
 
-from xbrain.knowledge import index_build
-from xbrain.models import Item, Topic, TopicPage
+from xbrain.knowledge import index_build, index_schema
+from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams
+from xbrain.knowledge.ids import SURFACE_VERSION
+from xbrain.knowledge.models import KnowledgeSurface, Locator, SourceFailure, UnfetchedLink
+from xbrain.executors.api import iter_content_sources, iter_described_photos
+from xbrain.knowledge.surfaces import failed_sources, item_surfaces, item_topics, unfetched_links
+from xbrain.models import (
+    Author,
+    Content,
+    ContentSourceFailure,
+    ContentSourceSuccess,
+    Enrichment,
+    Item,
+    Link,
+    MediaPhotoDescribed,
+    Topic,
+    TopicPage,
+)
 
 FIXTURES = Path(__file__).parent / "fixtures"
+UTC = timezone.utc
 
 ZERO = index_build.StoreSignal(0, 0, 0, 0, 0, 0)
 
@@ -612,3 +630,673 @@ def test_the_stat_guard_is_no_broader_than_os_error() -> None:
     """
     with pytest.raises(AttributeError):
         index_build.StoreSignal.of(None, Path("v"), Path("t"))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# The DEEP plane — `_canonical` / `_sha256` / `surface_row` / `item_fingerprint` /
+# `store_fingerprint` (Plan 02 §2, child 02.6a2a)
+#
+# Every encoder guard below is asserted ON THE ENCODER, not through a fingerprint that
+# happens to differ. Two hashes differing tells you nothing about WHY — and rule 1's fourth
+# row is exactly the assertion whose two sides both come out of the thing under test.
+# ---------------------------------------------------------------------------
+
+
+def _item(**overrides) -> Item:
+    """The smallest real item, so a guard can vary ONE field and nothing else."""
+    defaults = dict(
+        id="42",
+        source="bookmark",
+        url="https://x.com/a/status/42",
+        author=Author(handle="a", name="A"),
+        text="the post body",
+        created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        captured_at=datetime(2026, 1, 2, tzinfo=UTC),
+    )
+    return Item(**{**defaults, **overrides})
+
+
+def _photo(**overrides) -> MediaPhotoDescribed:
+    """A described photo, so a guard can vary only what makes it CONTENT-bearing."""
+    defaults = dict(
+        url="https://pbs.example/1.jpg",
+        local_path="42/0.jpg",
+        width=1,
+        height=1,
+        bytes_size=1,
+        downloaded_at=datetime(2026, 1, 3, tzinfo=UTC),
+        description="a described photo",
+        description_lang="Spanish",
+        is_decorative=False,
+        description_version="v1",
+        described_at=datetime(2026, 1, 3, tzinfo=UTC),
+    )
+    return MediaPhotoDescribed(**{**defaults, **overrides})
+
+
+def _video_content(text: str = "", has_speech: bool | None = False) -> Content:
+    """One `x_video` source, the only shape `no_speech` is derived from."""
+    return Content(
+        fetched_at=datetime(2026, 1, 3, tzinfo=UTC),
+        sources=[
+            ContentSourceSuccess(
+                kind="x_video", url="https://video.example/1", text=text, has_speech=has_speech
+            )
+        ],
+    )
+
+
+def _surface(**overrides) -> KnowledgeSurface:
+    """A surface whose fifteen persisted values are all DISTINCT and self-naming."""
+    defaults = dict(
+        surface_id="item:42:post:0",
+        owner_type="item",
+        owner_id="42",
+        surface_type="post",
+        text="0123456789",
+        title="THE-TITLE",
+        origin="source",
+        trust_class="primary_source",
+        derived=True,
+        attribution=Author(handle="THE-HANDLE", name="THE-NAME"),
+        locator=Locator(kind="item_text", url="THE-LOCATOR-URL"),
+        fingerprint="a" * 64,
+        language="THE-LANGUAGE",
+    )
+    return KnowledgeSurface(**{**defaults, **overrides})
+
+
+# ---------------------------------------------------------------------------
+# `_canonical` — what the injectivity claim covers, and where it stops
+# ---------------------------------------------------------------------------
+
+
+def test_the_canonical_encoding_is_injective_where_ensure_ascii_would_not_be() -> None:
+    """`ensure_ascii=True` collides a lone surrogate PAIR with the astral character it spells
+    — `json.dumps` emits the same escape for both — so the setting is a correctness choice
+    and prose alone never held it: measured on the snapshot, the whole file stayed GREEN
+    under the mutant `ensure_ascii=False` -> `True`. Asserted on the ENCODER because the
+    surrogate side raises at `_sha256`'s `.encode("utf-8")`, which is fail-closed and not a
+    hash to compare.
+    """
+    assert index_build._canonical("t", ["\ud83d\ude00"]) != index_build._canonical(
+        "t", ["\U0001f600"]
+    )
+
+
+def test_the_domain_travels_at_the_head_so_two_planes_cannot_serialise_alike() -> None:
+    """The collision the `domain` argument closed, reproduced on the ENCODER.
+
+    Before it, a one-item store and a one-entry vocabulary both encoded as
+    `[["a", <64 hex>]]` — measured EQUAL. Asserting two *fingerprints* differ would not pin
+    this: they differ for many reasons and would keep differing if the domain moved
+    somewhere it does not separate. So the payload is fixed, the two domains vary, and the
+    position of the domain is read back out of the blob.
+    """
+    collided = [["a", "0" * 64]]
+    assert index_build._canonical("store", collided) != index_build._canonical("vocab", collided)
+    assert json.loads(index_build._canonical("store", collided))[0] == "store"
+
+
+def test_the_variadic_regions_are_nested_so_a_splice_cannot_reproduce_them() -> None:
+    """Two item states that a FLATTENED payload encodes identically.
+
+    `topics=("thread",)` with no sources, against no topics with one blank `thread` source:
+    spliced into one list both read `[..., "thread", ...]`. Nested, the boundary is
+    structural.
+
+    This is an ENCODER property: it shows why nesting is sufficient, not that
+    `item_fingerprint` nests. What pins THAT is the atom-by-atom guard below, which is the
+    test the splice mutation actually reddens.
+    """
+    spliced_alike = (["thread"], []), ([], ["thread"])
+    first, second = spliced_alike
+    assert sum(first, []) == sum(second, [])
+    assert index_build._canonical("item", list(first)) != index_build._canonical(
+        "item", list(second)
+    )
+
+
+def test_a_nul_inside_a_hashed_value_cannot_forge_the_boundary_between_two_atoms() -> None:
+    """The delimiter family, which is why the join this encoder replaced had to go.
+
+    The old encoder joined atoms with a NUL byte and framed nothing below the region, and
+    both store writers persist a NUL — so a stored value could re-split the stream and move
+    every later boundary. Here the two payloads collide under that join and separate under
+    `_canonical`. The quote, the backslash and the bracket are the same attack in the
+    characters JSON itself uses.
+    """
+    forged = ["a\0b", "c"]
+    honest = ["a", "b\0c"]
+    assert "\0".join(forged) == "\0".join(honest)
+    assert index_build._canonical("t", forged) != index_build._canonical("t", honest)
+    assert index_build._canonical("t", ['a"],["b']) != index_build._canonical("t", ["a", "b"])
+
+
+def test_the_injectivity_claim_is_scoped_to_the_domain_the_payloads_build() -> None:
+    """The three limits the docstring names, pinned so nobody builds a payload assuming
+    otherwise.
+
+    JSON is NOT injective over Python values in general. A sequence's TYPE is not a
+    distinguishing feature (`tuple` and `list` encode alike), a mapping's KEY TYPE is not
+    either, and a float has values no reader could parse back. The first two are why the
+    claim is scoped rather than stated flat; the third is why `allow_nan=False` is there.
+    """
+    assert index_build._canonical("t", (1, 2)) == index_build._canonical("t", [1, 2])
+    assert index_build._canonical("t", {1: "a"}) == index_build._canonical("t", {"1": "a"})
+    with pytest.raises(ValueError):
+        index_build._canonical("t", [float("nan")])
+
+
+def test_a_lone_surrogate_is_refused_by_the_hash_and_never_replaced() -> None:
+    """Fail closed. `errors="replace"` would hash U+FFFD and call two different strings the
+    same content — the fail-open family the whole module exists to close.
+    """
+    with pytest.raises(UnicodeEncodeError):
+        index_build._sha256(index_build._canonical("t", ["\ud800"]))
+
+
+def test_absent_and_empty_are_not_the_same_atom() -> None:
+    """`None` is a column that holds NULL; `""` is a column that holds a string. The index
+    persists both, `search` serves both, and an encoder that folded them would make a
+    repaired-to-blank value read as never-set.
+    """
+    assert index_build._canonical("t", [None]) != index_build._canonical("t", [""])
+    assert index_build._canonical("t", [None]) != index_build._canonical("t", [[]])
+
+
+# ---------------------------------------------------------------------------
+# `surface_row` — the fifteen columns, by value and by arity
+# ---------------------------------------------------------------------------
+
+
+def _schema_columns(table: str) -> list[str]:
+    """The column NAMES the DDL declares for one table, read out of `_SCHEMA` itself.
+
+    Read from the schema string rather than from a hand-copied list: a column added to
+    `surfaces` has to reach this test without anyone remembering to edit it.
+    """
+    body = index_schema._SCHEMA.split(f"CREATE TABLE IF NOT EXISTS {table} (", 1)[1]
+    body = body.split(");", 1)[0]
+    return [
+        line.strip().split()[0]
+        for line in body.splitlines()
+        if line.strip() and not line.strip().startswith("--")
+    ]
+
+
+def test_the_surface_row_is_the_fifteen_values_the_schema_persists_in_order() -> None:
+    """Every column pinned BY VALUE, against a literal written by hand.
+
+    Review #161 measured seven of the fifteen unpinned on the snapshot: a swap between two
+    same-typed neighbours (title/url, handle/name, language/fingerprint) moved what the index
+    STORES and reddened nothing. The expected side here is a literal, not `surface_row`
+    recomputed, so the two sides do not come out of the same function (rule 1, fourth row).
+
+    EVERY VALUE HAS TO BE THE ONE A MUTANT WOULD NOT INSTALL, which is why `derived` is True
+    here and not the False a surface most often carries: pinned at False the column reads 0,
+    a constant-0 mutant installs 0, and the guard passes on the mutant — measured, the one
+    cell of fifteen that survived before this fixture changed. And the count itself is a
+    property of the mutant, not of the test: under column DELETION an arity assertion catches
+    all fifteen and says nothing about any value, so "N unpinned" without the mutant beside it
+    is the error rule 2 exists to stop.
+    """
+    surface = _surface()
+    assert index_build.surface_row(surface) == (
+        "item:42:post:0",
+        "item",
+        "42",
+        "post",
+        "source",
+        "primary_source",
+        1,
+        "THE-HANDLE",
+        "THE-NAME",
+        "THE-TITLE",
+        "THE-LOCATOR-URL",
+        surface.locator.model_dump_json(),
+        "THE-LANGUAGE",
+        "a" * 64,
+        10,
+    )
+
+
+def test_the_row_has_one_value_per_column_the_schema_declares() -> None:
+    """A totality guard, and the only mechanical one this child can offer.
+
+    It catches a column ADDED to `surfaces` without a value beside it. It does NOT catch a
+    column REORDERED into a same-typed neighbour — that needs the readback test 02.7 owes,
+    written against a writer that does not exist in this tree yet.
+    """
+    assert len(_schema_columns("surfaces")) == 15
+    assert len(index_build.surface_row(_surface())) == len(_schema_columns("surfaces"))
+
+
+def test_the_last_column_is_a_length_and_never_the_body() -> None:
+    """Spec §10.8: the index stores what it needs to filter, not a second copy of the text.
+    The body is covered by `fingerprint`, which hashes it — so two bodies of the same length
+    still separate.
+    """
+    row = index_build.surface_row(_surface(text="x" * 10))
+    assert row[-1] == 10
+    assert "x" * 10 not in row
+    assert index_build.surface_row(
+        _surface(text="abcdefghij", fingerprint="b" * 64)
+    ) != index_build.surface_row(_surface(text="0123456789", fingerprint="a" * 64))
+
+
+def test_the_rows_region_is_a_set_because_one_item_cannot_emit_a_surface_id_twice(
+    corpus,
+) -> None:
+    """What the rows region actually rests on — and it is NOT its order.
+
+    The region is emitted in emitter order, and a `sorted()` around it changes every stored
+    fingerprint without changing what any of them SAYS: `surface_id` is
+    `<owner>:<id>:<type>:<source_key>` and is unique per item, so the rows are a set and
+    their sequence carries nothing the set does not. Measured: the mutant
+    `[surface_row(s) for s in ...]` -> `sorted(...)` leaves this file GREEN, and that is
+    correct rather than a gap — claiming otherwise would be a guard on a property nobody
+    holds.
+
+    What WOULD make the order load-bearing is a duplicate id, and that is what this pins,
+    across every item in the corpus. If an emitter ever produced one, two distinct surfaces
+    would occupy the same row on disk and the argument above would quietly stop being true.
+    """
+    store, _vocab, _pages = corpus
+    for item in store.values():
+        ids = [surface.surface_id for surface in item_surfaces(item)]
+        assert len(ids) == len(set(ids)), item.id
+
+
+# ---------------------------------------------------------------------------
+# `item_fingerprint` — the four persisted planes it must reach (rule 6)
+#
+# Each guard varies ONE field and asserts what the projection does with it, so a green run
+# says which plane is covered rather than that two hex strings differ.
+# ---------------------------------------------------------------------------
+
+
+def test_the_item_fingerprint_changes_when_indexable_text_changes(corpus) -> None:
+    """The floor: the body the index serves is inside the hash."""
+    store, _vocab, _pages = corpus
+    item = next(iter(store.values()))
+    assert index_build.item_fingerprint(item) != index_build.item_fingerprint(
+        item.model_copy(update={"text": item.text + " edited"})
+    )
+
+
+def test_the_item_fingerprint_covers_the_source_failures_plane() -> None:
+    """HIGH-1 of review #161, half one — and the reason this child exists.
+
+    `source_failures` is written per item and read back by `get`, and before this nothing
+    about it moved a fingerprint: a fetch whose recorded error changed rewrote the row on
+    disk while `update` reported the item unchanged (rule 6). The two items here differ in
+    NOTHING else — a failure emits no surface and appears in no content kind, so the moved
+    plane is the only thing that can move the hash.
+    """
+    failing = _item(
+        content=Content(
+            fetched_at=datetime(2026, 1, 3, tzinfo=UTC),
+            sources=[
+                ContentSourceFailure(
+                    kind="external_article",
+                    url="https://e.example",
+                    failure_reason="not_found",
+                    error="one",
+                )
+            ],
+        )
+    )
+    repaired = failing.model_copy(
+        update={
+            "content": Content(
+                fetched_at=failing.content.fetched_at,
+                sources=[
+                    ContentSourceFailure(
+                        kind="external_article",
+                        url="https://e.example",
+                        failure_reason="not_found",
+                        error="two",
+                    )
+                ],
+            )
+        }
+    )
+    assert item_surfaces(failing) == item_surfaces(repaired)
+    assert failed_sources(failing) != failed_sources(repaired)
+    assert index_build.item_fingerprint(failing) != index_build.item_fingerprint(repaired)
+
+
+def test_the_item_fingerprint_covers_the_unfetched_links_plane() -> None:
+    """HIGH-1 of review #161, half two.
+
+    `item.links` reaches the index through `unfetched_links` and through NOTHING else — no
+    surface, no content kind, no other hashed atom — so a link that changed and a
+    fingerprint that did not was the whole defect, and this pair isolates it exactly.
+    """
+    before = _item(links=[Link(url="https://a.example", domain="a.example")])
+    after = _item(links=[Link(url="https://b.example", domain="b.example")])
+    assert item_surfaces(before) == item_surfaces(after)
+    assert unfetched_links(before) != unfetched_links(after)
+    assert index_build.item_fingerprint(before) != index_build.item_fingerprint(after)
+
+
+def test_a_field_added_to_either_failure_projection_is_hashed_without_being_remembered() -> None:
+    """The structural half of the HIGH-1 fix, asserted as a totality.
+
+    A hand-written field list is what let those two planes drift, so `_model_atoms` walks
+    `model_fields` instead. This pins that it walks ALL of them, in order, with the name
+    beside the value — a rename is a schema change and has to move the hash too.
+    """
+    failure = SourceFailure(
+        kind="external_article", url="u", failure_reason="not_found", http_status=404
+    )
+    assert [name for name, _value in index_build._model_atoms(failure)] == list(
+        SourceFailure.model_fields
+    )
+    assert index_build._model_atoms(failure)[-1] == ["http_status", 404]
+    link = UnfetchedLink(url="u", reason="not_attempted")
+    assert [name for name, _value in index_build._model_atoms(link)] == list(
+        UnfetchedLink.model_fields
+    )
+
+
+def test_the_item_fingerprint_covers_the_primary_topic_the_topics_tuple_hides() -> None:
+    """Two enrichments the persisted `items.primary_topic` column separates and
+    `item_topics()` does not.
+
+    `item_topics` puts the primary first and then DEDUPLICATES, so `(None, ["a", "b"])` and
+    `("a", ["b"])` both collapse to `("a", "b")`. The equal side is asserted here on
+    purpose: without it a green run would not say that the tuple hides anything, and the
+    guard would look like a restatement of "different enrichment, different hash".
+    """
+    hidden = _item(
+        enriched=Enrichment(
+            enriched_at=datetime(2026, 1, 3, tzinfo=UTC),
+            executor="manual",
+            primary_topic=None,
+            topics=["a", "b"],
+        )
+    )
+    declared = _item(
+        enriched=Enrichment(
+            enriched_at=datetime(2026, 1, 3, tzinfo=UTC),
+            executor="manual",
+            primary_topic="a",
+            topics=["b"],
+        )
+    )
+    assert item_topics(hidden) == item_topics(declared) == ("a", "b")
+    assert index_build.item_fingerprint(hidden) != index_build.item_fingerprint(declared)
+
+
+def test_the_item_fingerprint_covers_the_media_the_emitter_declined_to_surface() -> None:
+    """`items.skipped_decorative` moves with no surface behind it.
+
+    `xbrain describe` classifying a photo as decorative flips the counter 0 -> 1 and emits
+    NOTHING — no surface, no content kind — so before the counters were hashed the row on
+    disk changed and the item read as unchanged. The equal `item_surfaces` is the half that
+    makes this a measurement rather than a restatement.
+    """
+    bare = _item()
+    decorated = _item(media=[_photo(description="", is_decorative=True)])
+    assert item_surfaces(bare) == item_surfaces(decorated)
+    assert index_build.declined_media(bare) == (0, 0)
+    assert index_build.declined_media(decorated) == (1, 0)
+    assert index_build.item_fingerprint(bare) != index_build.item_fingerprint(decorated)
+
+
+def test_a_silent_video_is_counted_by_the_predicate_the_store_records() -> None:
+    """`items.skipped_no_speech`, pinned against the two mutants that leave it silent.
+
+    Asserting only that a silent video moves the hash passes under a swapped predicate —
+    `has_speech is False` traded for "the transcript is blank" — because on an ordinary
+    fixture the two agree. The `[music]` case is where they part: a transcriber that heard
+    no speech and wrote a marker anyway is `has_speech=False` with non-blank text, and only
+    the recorded flag gets it right. And the counter is asserted NON-ZERO, because a slot
+    only ever asserted at 0 is asserted against the constant a mutant installs.
+    """
+    silent = _item(content=_video_content(text="", has_speech=False))
+    speaking = _item(content=_video_content(text="hello", has_speech=True))
+    assert index_build.declined_media(silent) == (0, 1)
+    assert index_build.declined_media(speaking) == (0, 0)
+    assert index_build.declined_media(_item(content=_video_content("[music]", False))) == (0, 1)
+    assert index_build.item_fingerprint(silent) != index_build.item_fingerprint(_item())
+
+
+def test_a_photo_described_as_nothing_is_declined_like_a_decorative_one() -> None:
+    """The second clause of the decorative sum, which is what makes it the COMPLEMENT of
+    `iter_described_photos`'s seam rather than a reading of one flag.
+
+    A photo the vision pass had nothing to say about emits no surface either, so dropping
+    `or not entry.description` would leave it counted nowhere — declined by the emitter and
+    recorded by neither.
+    """
+    empty = _item(media=[_photo(description="", is_decorative=False)])
+    assert list(iter_described_photos(empty)) == []
+    assert index_build.declined_media(empty) == (1, 0)
+    assert index_build.item_fingerprint(empty) != index_build.item_fingerprint(_item())
+
+
+def test_the_declined_counters_are_the_emitters_complement_over_the_corpus(corpus) -> None:
+    """The rule-5 guard: two hand-written readings of one fact, held to each other.
+
+    `declined_media` decides a photo is declined by `is_decorative or not description` and a
+    video by `has_speech is False`; the EMITTER decides by `iter_described_photos`'s filter
+    and by a blank transcript. Nothing in code binds the two, so this asserts the property
+    that makes them one — declined plus emitted equals present — over every item.
+
+    They agree on the live store too: measured 2026-09-03 over 2,404 items (sha256
+    `f76341a3...`), 14 declined photos, 108 silent videos, and 0 items where either sum
+    fails. The agreement is CONTINGENT, and the shape that would break it is an `x_video`
+    attached with `has_speech=None` and no text — the HLS path, or a transcriber exiting
+    clean with nothing — which the emitter declines and this counter does not see. Zero of
+    those exist today; that is a fact about the corpus, not an invariant.
+    """
+    store, _vocab, _pages = corpus
+    for item in store.values():
+        decorative, no_speech = index_build.declined_media(item)
+        described = sum(1 for entry in item.media if isinstance(entry, MediaPhotoDescribed))
+        assert decorative + sum(1 for _i, _p in iter_described_photos(item)) == described, item.id
+        videos = [source for _i, source in iter_content_sources(item, {"x_video"})]
+        emitted = sum(1 for source in videos if source.text and source.text.strip())
+        assert no_speech + emitted == len(videos), item.id
+
+
+def test_a_bookmark_folder_that_is_absent_is_not_one_that_is_empty() -> None:
+    """The mutation two reviewers measured reddening NOT ONE test on the snapshot:
+    `item.bookmark_folder` -> `item.bookmark_folder or ""`.
+
+    `items.bookmark_folder` is a nullable column and the two states are different rows.
+    Folding them means a bookmark moved OUT of every folder reads as one that was never in
+    a folder, and `update` reports the item unchanged.
+    """
+    assert index_build.item_fingerprint(
+        _item(bookmark_folder=None)
+    ) != index_build.item_fingerprint(_item(bookmark_folder=""))
+
+
+def test_the_item_fingerprint_covers_the_filterable_metadata_no_surface_carries() -> None:
+    """A changed author changes what `--author` returns with no text moved (A-1). Handle and
+    name are hashed APART: they are two columns, and one person renaming themselves is not
+    the same row as a different account.
+    """
+    base = _item()
+    for update in (
+        {"author": Author(handle="b", name="A")},
+        {"author": Author(handle="a", name="B")},
+        {"source": "own_tweet"},
+        {"url": "https://x.com/a/status/43"},
+        {"created_at": datetime(2026, 1, 9, tzinfo=UTC)},
+        {"captured_at": datetime(2026, 1, 9, tzinfo=UTC)},
+    ):
+        assert index_build.item_fingerprint(base) != index_build.item_fingerprint(
+            base.model_copy(update=update)
+        ), update
+
+
+def test_the_item_fingerprint_moves_when_the_content_sources_are_permuted(corpus) -> None:
+    """M4. Order is not decoration: `locator.source_index` points at a position in
+    `content.sources`, so permuting them repoints every locator the index serves.
+
+    The mechanism is asserted beside the hash, because the hash alone would also move if the
+    rows had merely been reordered — and this property is about the locators, which is the
+    half a reader has to be able to check by hand.
+    """
+    store, _vocab, _pages = corpus
+    item = next(i for i in store.values() if i.content is not None and len(i.content.sources) > 1)
+    flipped = item.model_copy(
+        update={
+            "content": item.content.model_copy(
+                update={"sources": list(reversed(item.content.sources))}
+            )
+        }
+    )
+    assert [(s.surface_id, s.locator.source_index) for s in item_surfaces(item)] != [
+        (s.surface_id, s.locator.source_index) for s in item_surfaces(flipped)
+    ]
+    assert index_build.item_fingerprint(item) != index_build.item_fingerprint(flipped)
+
+
+def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this() -> None:
+    """A CHARACTERIZATION of a deliberate hole, not a property anyone wants to keep.
+
+    `IndexOptions` travels so the signature 02.7 consumes is already the ported one, and it
+    is read NOWHERE. This asserts that: two options that differ in both fields hash alike.
+    When 02.7 gives them their first consumer this goes RED, and the change has to be made
+    on purpose — which is the whole reason it is written down rather than left implicit.
+    """
+    item = _item()
+    assert index_build.item_fingerprint(
+        item, options=index_build.IndexOptions(params=ChunkerParams(target=1), vault_dir=Path("/x"))
+    ) == index_build.item_fingerprint(item)
+    assert index_build.store_fingerprint(
+        {item.id: item}, options=index_build.IndexOptions(params=ChunkerParams(target=1))
+    ) == index_build.store_fingerprint({item.id: item})
+    assert [f.name for f in dataclasses.fields(index_build.IndexOptions)] == [
+        "params",
+        "vault_dir",
+    ]
+    assert index_build.IndexOptions().params == DEFAULT_CHUNKER_PARAMS
+    assert index_build.IndexOptions().vault_dir is None
+
+
+def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all() -> None:
+    """`SURFACE_VERSION` leads the payload so a bump invalidates even an item whose surface
+    rows are empty — there is nothing else on such an item for a bump to move.
+
+    The expected side is the payload written out ATOM BY ATOM, so this is also the arity
+    guard: an atom added, removed or reordered reddens here, and a reader can see in one
+    place what an item fingerprint is made of.
+    """
+    bare = _item(text="")
+    assert item_surfaces(bare) == ()
+    assert index_build.item_fingerprint(bare) == index_build._sha256(
+        index_build._canonical(
+            "item",
+            [
+                SURFACE_VERSION,
+                "42",
+                "bookmark",
+                "https://x.com/a/status/42",
+                "a",
+                "A",
+                "2026-01-01T00:00:00+00:00",
+                "2026-01-02T00:00:00+00:00",
+                None,
+                None,
+                [],
+                [],
+                [],
+                [],
+                [],
+                [0, 0],
+            ],
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# `store_fingerprint` — the outer atom, and what an id may not forge
+# ---------------------------------------------------------------------------
+
+
+def test_the_store_fingerprint_is_independent_of_how_the_store_was_loaded(corpus) -> None:
+    """A dict's iteration order is a property of the load, not of the contents. The ids are
+    sorted, so two loads of the same corpus certify the same store.
+    """
+    store, _vocab, _pages = corpus
+    assert index_build.store_fingerprint(store) == index_build.store_fingerprint(
+        dict(reversed(list(store.items())))
+    )
+
+
+def test_the_outer_store_atom_is_a_pair_and_not_a_concatenation() -> None:
+    """The boundary between an id and the hash beside it is STRUCTURAL, not arithmetic.
+
+    Said exactly, because the overclaim is tempting: a flat `id + hex` join is injective
+    TODAY, and only because the second half is always 64 characters, so a reader can cut it
+    off the end. Measured — the mutant `[[k, hex]]` -> `[k + hex]` leaves the door's own
+    guards GREEN. What the pair buys is that the separation stops depending on that width:
+    the day an atom of variable length joins it, `["a", "b" + h]` and `["ab", h]` are the
+    same stream and two different stores certify as one. Asserted on the ENCODER, which is
+    where that forgery lives and the only place it can be shown.
+    """
+    forged, honest = ["a", "b" + "0" * 64], ["ab", "0" * 64]
+    assert "".join(forged) == "".join(honest)
+    assert index_build._canonical("store", [forged]) != index_build._canonical("store", [honest])
+
+
+def test_the_store_plane_survives_a_nul_inside_an_id() -> None:
+    """The pre-fix NUL join, on the plane where a real `items.json` can reach it.
+
+    `Item.id` is a bare `str` with no pattern and no validator, and a NUL travels through
+    `save_store` / `parse_store` as a plain ASCII escape — so the key `a=<hex>` + NUL + `b`
+    round-trips, and under the join it produced exactly the stream that a two-item store
+    produces. Two different stores, one certificate. The encoder guard above cannot reach
+    this: it shows why the pair is safe, and this shows the reversion that removes the pair.
+    """
+    item = _item(id="X")
+    two = {"a": item, "b": item}
+    forged = {f"a={index_build.item_fingerprint(item)}\0b": item}
+    assert index_build.store_fingerprint(two) != index_build.store_fingerprint(forged)
+
+
+def test_the_store_fingerprint_covers_the_key_an_item_is_filed_under() -> None:
+    """The store is a MAPPING, and the key is half of each entry.
+
+    `item_fingerprint` hashes `item.id`, which is normally the same string — so this is the
+    guard that keeps the key in the atom for its own sake rather than by luck, and it
+    reddens under dropping `k` from the pair.
+    """
+    item = _item(id="42")
+    assert index_build.store_fingerprint({"42": item}) != index_build.store_fingerprint(
+        {"filed-elsewhere": item}
+    )
+
+
+def test_the_store_fingerprint_moves_when_any_one_item_moves(corpus) -> None:
+    """The deep signal's whole promise, and the one the cheap `StoreSignal` cannot make."""
+    store, _vocab, _pages = corpus
+    key = sorted(store)[0]
+    edited = dict(store)
+    edited[key] = store[key].model_copy(update={"text": store[key].text + " edited"})
+    assert index_build.store_fingerprint(store) != index_build.store_fingerprint(edited)
+
+
+def test_the_deep_fingerprints_stay_out_of_the_cheap_signal(three_inputs: Path) -> None:
+    """02.6a1's contract, inherited unchanged: a query pays three `os.stat` and nothing else.
+
+    A deep read leaking into `StoreSignal.of` or `load_index_inputs` would put a full corpus
+    walk behind every `search`. Asserted by counting calls into the deep plane while the two
+    cheap doors run.
+    """
+    calls: list[str] = []
+    original = index_build.item_fingerprint
+    index_build.item_fingerprint = lambda *a, **k: calls.append("deep") or original(*a, **k)
+    try:
+        index_build.StoreSignal.of(*_paths(three_inputs))
+        index_build.load_index_inputs(*_paths(three_inputs))
+    finally:
+        index_build.item_fingerprint = original
+    assert calls == []

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -9,7 +9,9 @@ fails in — is stated once, in `index_build.py`'s module docstring; it is not r
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -20,8 +22,16 @@ from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams
 from xbrain.knowledge.ids import SURFACE_VERSION
 from xbrain.knowledge.models import KnowledgeSurface, Locator, SourceFailure, UnfetchedLink
 from xbrain.executors.api import iter_content_sources, iter_described_photos
-from xbrain.knowledge.surfaces import failed_sources, item_surfaces, item_topics, unfetched_links
+from xbrain.knowledge.surfaces import (
+    article_block_texts,
+    failed_sources,
+    item_content_kinds,
+    item_surfaces,
+    item_topics,
+    unfetched_links,
+)
 from xbrain.models import (
+    ArticleTextBlock,
     Author,
     Content,
     ContentSourceFailure,
@@ -633,12 +643,10 @@ def test_the_stat_guard_is_no_broader_than_os_error() -> None:
 
 
 # ---------------------------------------------------------------------------
-# The DEEP plane — `_canonical` / `_sha256` / `surface_row` / `item_fingerprint` /
-# `store_fingerprint` (Plan 02 §2, child 02.6a2a)
-#
-# Every encoder guard below is asserted ON THE ENCODER, not through a fingerprint that
-# happens to differ. Two hashes differing tells you nothing about WHY — and rule 1's fourth
-# row is exactly the assertion whose two sides both come out of the thing under test.
+# The DEEP plane (Plan 02 §2, child 02.6a2a). Every encoder guard below is asserted ON THE
+# ENCODER, not through a fingerprint that happens to differ: two hashes differing tells you
+# nothing about WHY, and rule 1's fourth row is the assertion whose two sides both come out
+# of the thing under test.
 # ---------------------------------------------------------------------------
 
 
@@ -712,12 +720,11 @@ def _surface(**overrides) -> KnowledgeSurface:
 
 
 def test_the_canonical_encoding_is_injective_where_ensure_ascii_would_not_be() -> None:
-    """`ensure_ascii=True` collides a lone surrogate PAIR with the astral character it spells
-    — `json.dumps` emits the same escape for both — so the setting is a correctness choice
-    and prose alone never held it: measured on the snapshot, the whole file stayed GREEN
-    under the mutant `ensure_ascii=False` -> `True`. Asserted on the ENCODER because the
-    surrogate side raises at `_sha256`'s `.encode("utf-8")`, which is fail-closed and not a
-    hash to compare.
+    """`ensure_ascii=True` collides a lone surrogate PAIR with the astral character it spells —
+    `json.dumps` emits the same escape for both — so the setting is a correctness choice, and
+    prose alone never held it: the mutant `False` -> `True` left the whole file GREEN. Asserted
+    on the ENCODER because the surrogate side raises at `_sha256`'s `.encode("utf-8")`, which
+    is fail-closed and not a hash to compare.
     """
     assert index_build._canonical("t", ["\ud83d\ude00"]) != index_build._canonical(
         "t", ["\U0001f600"]
@@ -725,13 +732,12 @@ def test_the_canonical_encoding_is_injective_where_ensure_ascii_would_not_be() -
 
 
 def test_the_domain_travels_at_the_head_so_two_planes_cannot_serialise_alike() -> None:
-    """The collision the `domain` argument closed, reproduced on the ENCODER.
-
-    Before it, a one-item store and a one-entry vocabulary both encoded as
-    `[["a", <64 hex>]]` — measured EQUAL. Asserting two *fingerprints* differ would not pin
-    this: they differ for many reasons and would keep differing if the domain moved
-    somewhere it does not separate. So the payload is fixed, the two domains vary, and the
-    position of the domain is read back out of the blob.
+    """The collision the `domain` argument closed, reproduced on the ENCODER: a one-item store
+    and a one-entry vocabulary both encoded as `[["a", <64 hex>]]`, measured EQUAL. Asserting
+    two *fingerprints* differ would not pin it — they differ for many reasons and would keep
+    differing if the domain moved somewhere it does not separate — so the payload is fixed, the
+    domains vary, and the position of the domain is read back out of the blob. Which domain
+    each FUNCTION passes is pinned separately, by reading it off a real call.
     """
     collided = [["a", "0" * 64]]
     assert index_build._canonical("store", collided) != index_build._canonical("vocab", collided)
@@ -739,15 +745,11 @@ def test_the_domain_travels_at_the_head_so_two_planes_cannot_serialise_alike() -
 
 
 def test_the_variadic_regions_are_nested_so_a_splice_cannot_reproduce_them() -> None:
-    """Two item states that a FLATTENED payload encodes identically.
-
-    `topics=("thread",)` with no sources, against no topics with one blank `thread` source:
-    spliced into one list both read `[..., "thread", ...]`. Nested, the boundary is
-    structural.
-
-    This is an ENCODER property: it shows why nesting is sufficient, not that
-    `item_fingerprint` nests. What pins THAT is the atom-by-atom guard below, which is the
-    test the splice mutation actually reddens.
+    """Two item states that a FLATTENED payload encodes identically: `topics=("thread",)` with
+    no sources, against no topics with one blank `thread` source — spliced into one list both
+    read `[..., "thread", ...]`, nested the boundary is structural. An ENCODER property: it
+    shows why nesting is sufficient, not that `item_fingerprint` nests, which the atom-by-atom
+    guard below is what reddens under the splice.
     """
     spliced_alike = (["thread"], []), ([], ["thread"])
     first, second = spliced_alike
@@ -758,13 +760,11 @@ def test_the_variadic_regions_are_nested_so_a_splice_cannot_reproduce_them() -> 
 
 
 def test_a_nul_inside_a_hashed_value_cannot_forge_the_boundary_between_two_atoms() -> None:
-    """The delimiter family, which is why the join this encoder replaced had to go.
-
-    The old encoder joined atoms with a NUL byte and framed nothing below the region, and
-    both store writers persist a NUL — so a stored value could re-split the stream and move
-    every later boundary. Here the two payloads collide under that join and separate under
-    `_canonical`. The quote, the backslash and the bracket are the same attack in the
-    characters JSON itself uses.
+    """The delimiter family, and why the join this encoder replaced had to go: it joined atoms
+    with a NUL and framed nothing below the region, and both store writers persist a NUL, so a
+    stored value could re-split the stream and move every later boundary. These two payloads
+    collide under that join and separate under `_canonical`; the quote and the bracket are the
+    same attack in the characters JSON itself uses.
     """
     forged = ["a\0b", "c"]
     honest = ["a", "b\0c"]
@@ -775,12 +775,10 @@ def test_a_nul_inside_a_hashed_value_cannot_forge_the_boundary_between_two_atoms
 
 def test_the_injectivity_claim_is_scoped_to_the_domain_the_payloads_build() -> None:
     """The three limits the docstring names, pinned so nobody builds a payload assuming
-    otherwise.
-
-    JSON is NOT injective over Python values in general. A sequence's TYPE is not a
-    distinguishing feature (`tuple` and `list` encode alike), a mapping's KEY TYPE is not
-    either, and a float has values no reader could parse back. The first two are why the
-    claim is scoped rather than stated flat; the third is why `allow_nan=False` is there.
+    otherwise. JSON is NOT injective over Python values in general: a sequence's TYPE is not a
+    distinguishing feature, a mapping's KEY TYPE is not either, and a float has values no
+    reader could parse back. The first two are why the claim is SCOPED rather than stated flat;
+    the third is why `allow_nan=False` is there.
     """
     assert index_build._canonical("t", (1, 2)) == index_build._canonical("t", [1, 2])
     assert index_build._canonical("t", {1: "a"}) == index_build._canonical("t", {"1": "a"})
@@ -828,18 +826,17 @@ def _schema_columns(table: str) -> list[str]:
 def test_the_surface_row_is_the_fifteen_values_the_schema_persists_in_order() -> None:
     """Every column pinned BY VALUE, against a literal written by hand.
 
-    Review #161 measured seven of the fifteen unpinned on the snapshot: a swap between two
-    same-typed neighbours (title/url, handle/name, language/fingerprint) moved what the index
-    STORES and reddened nothing. The expected side here is a literal, not `surface_row`
-    recomputed, so the two sides do not come out of the same function (rule 1, fourth row).
-
-    EVERY VALUE HAS TO BE THE ONE A MUTANT WOULD NOT INSTALL, which is why `derived` is True
-    here and not the False a surface most often carries: pinned at False the column reads 0,
-    a constant-0 mutant installs 0, and the guard passes on the mutant — measured, the one
-    cell of fifteen that survived before this fixture changed. And the count itself is a
-    property of the mutant, not of the test: under column DELETION an arity assertion catches
-    all fifteen and says nothing about any value, so "N unpinned" without the mutant beside it
-    is the error rule 2 exists to stop.
+    Review #161 measured seven of the fifteen unpinned: a swap between two same-typed
+    neighbours (title/url, handle/name, language/fingerprint) moved what the index STORES and
+    reddened nothing. The expected side is a literal, not `surface_row` recomputed, so the two
+    sides do not come out of one function (rule 1, fourth row). EVERY VALUE IS THE ONE A MUTANT
+    WOULD NOT INSTALL — which is why `derived` is True and not the False a surface usually
+    carries: pinned at False the column reads 0, a constant-0 mutant installs 0, and the guard
+    passes. The count is a property of the mutant and not of the test: under column DELETION an
+    arity assertion catches all fifteen and says nothing about any value, so "N unpinned"
+    without the mutant beside it is the error rule 2 exists to stop. Nullability and cell TYPE
+    are pinned separately below — `None` folded to `""`, and `True`/`1.0` for `1`, are what
+    this literal cannot see.
     """
     surface = _surface()
     assert index_build.surface_row(surface) == (
@@ -890,17 +887,11 @@ def test_the_rows_region_is_a_set_because_one_item_cannot_emit_a_surface_id_twic
 ) -> None:
     """What the rows region actually rests on — and it is NOT its order.
 
-    The region is emitted in emitter order, and a `sorted()` around it changes every stored
-    fingerprint without changing what any of them SAYS: `surface_id` is
-    `<owner>:<id>:<type>:<source_key>` and is unique per item, so the rows are a set and
-    their sequence carries nothing the set does not. Measured: the mutant
-    `[surface_row(s) for s in ...]` -> `sorted(...)` leaves this file GREEN, and that is
-    correct rather than a gap — claiming otherwise would be a guard on a property nobody
-    holds.
-
-    What WOULD make the order load-bearing is a duplicate id, and that is what this pins,
-    across every item in the corpus. If an emitter ever produced one, two distinct surfaces
-    would occupy the same row on disk and the argument above would quietly stop being true.
+    `surface_id` is `<owner>:<id>:<type>:<source_key>` and unique per item, so the rows are a
+    SET and their sequence carries nothing the set does not: the mutant `sorted(...)` around
+    the region leaves this file GREEN, which is correct rather than a gap. What WOULD make the
+    order load-bearing is a duplicate id, and that is what this pins across the whole corpus —
+    two distinct surfaces on one row would quietly end the argument above.
     """
     store, _vocab, _pages = corpus
     for item in store.values():
@@ -928,40 +919,29 @@ def test_the_item_fingerprint_changes_when_indexable_text_changes(corpus) -> Non
 def test_the_item_fingerprint_covers_the_source_failures_plane() -> None:
     """HIGH-1 of review #161, half one — and the reason this child exists.
 
-    `source_failures` is written per item and read back by `get`, and before this nothing
-    about it moved a fingerprint: a fetch whose recorded error changed rewrote the row on
-    disk while `update` reported the item unchanged (rule 6). The two items here differ in
-    NOTHING else — a failure emits no surface and appears in no content kind, so the moved
-    plane is the only thing that can move the hash.
+    `source_failures` is written per item and read back by `get`, and before this nothing about
+    it moved a fingerprint: a fetch whose recorded error changed rewrote the row on disk while
+    `update` reported the item unchanged (rule 6). The two items differ in NOTHING else — a
+    failure emits no surface and appears in no content kind — so the moved plane is the only
+    thing that can move the hash.
     """
-    failing = _item(
-        content=Content(
-            fetched_at=datetime(2026, 1, 3, tzinfo=UTC),
-            sources=[
-                ContentSourceFailure(
-                    kind="external_article",
-                    url="https://e.example",
-                    failure_reason="not_found",
-                    error="one",
-                )
-            ],
-        )
-    )
-    repaired = failing.model_copy(
-        update={
-            "content": Content(
-                fetched_at=failing.content.fetched_at,
+
+    def failed(error: str) -> Item:
+        return _item(
+            content=Content(
+                fetched_at=datetime(2026, 1, 3, tzinfo=UTC),
                 sources=[
                     ContentSourceFailure(
                         kind="external_article",
                         url="https://e.example",
                         failure_reason="not_found",
-                        error="two",
+                        error=error,
                     )
                 ],
             )
-        }
-    )
+        )
+
+    failing, repaired = failed("one"), failed("two")
     assert item_surfaces(failing) == item_surfaces(repaired)
     assert failed_sources(failing) != failed_sources(repaired)
     assert index_build.item_fingerprint(failing) != index_build.item_fingerprint(repaired)
@@ -982,11 +962,10 @@ def test_the_item_fingerprint_covers_the_unfetched_links_plane() -> None:
 
 
 def test_a_field_added_to_either_failure_projection_is_hashed_without_being_remembered() -> None:
-    """The structural half of the HIGH-1 fix, asserted as a totality.
-
-    A hand-written field list is what let those two planes drift, so `_model_atoms` walks
-    `model_fields` instead. This pins that it walks ALL of them, in order, with the name
-    beside the value — a rename is a schema change and has to move the hash too.
+    """The structural half of the HIGH-1 fix, asserted as a totality: a hand-written field list
+    is what let those two planes drift, so `_model_atoms` walks `model_fields`. This pins that
+    it walks ALL of them, in order, with the name beside the value — a rename is a schema
+    change and has to move the hash too.
     """
     failure = SourceFailure(
         kind="external_article", url="u", failure_reason="not_found", http_status=404
@@ -1001,31 +980,42 @@ def test_a_field_added_to_either_failure_projection_is_hashed_without_being_reme
     )
 
 
+def test_each_failure_plane_persists_exactly_what_its_public_projection_carries() -> None:
+    """The binding that makes the two failure DDLs and the ONE versioned projection agree.
+
+    `item_fingerprint` hashes the projection, so a column the DDL declares and the projection
+    does not carry is one no fingerprint can ever see: `source_failures` declared `attempts`,
+    `SourceFailure` had no field for it, and an item whose attempt count moved certified as
+    unchanged. The column is gone (`SCHEMA_VERSION` "4") and this stops the gap reopening from
+    EITHER side. The DDL side is read out of `_SCHEMA` and the model side off `model_fields`,
+    so neither is hand-copied and the two come from different modules; `item_id` is the join
+    key, carried by `store_fingerprint`'s `(key, hash)` pair rather than by the projection.
+    """
+    for table, model in (("source_failures", SourceFailure), ("unfetched_links", UnfetchedLink)):
+        assert set(_schema_columns(table)) == {"item_id", *model.model_fields}, table
+
+
 def test_the_item_fingerprint_covers_the_primary_topic_the_topics_tuple_hides() -> None:
     """Two enrichments the persisted `items.primary_topic` column separates and
     `item_topics()` does not.
 
     `item_topics` puts the primary first and then DEDUPLICATES, so `(None, ["a", "b"])` and
-    `("a", ["b"])` both collapse to `("a", "b")`. The equal side is asserted here on
-    purpose: without it a green run would not say that the tuple hides anything, and the
-    guard would look like a restatement of "different enrichment, different hash".
+    `("a", ["b"])` both collapse to `("a", "b")`. The equal side is asserted on purpose:
+    without it a green run would not say the tuple hides anything, and the guard would read as
+    a restatement of "different enrichment, different hash".
     """
-    hidden = _item(
-        enriched=Enrichment(
-            enriched_at=datetime(2026, 1, 3, tzinfo=UTC),
-            executor="manual",
-            primary_topic=None,
-            topics=["a", "b"],
+
+    def enriched(primary: str | None, topics: list[str]) -> Item:
+        return _item(
+            enriched=Enrichment(
+                enriched_at=datetime(2026, 1, 3, tzinfo=UTC),
+                executor="manual",
+                primary_topic=primary,
+                topics=topics,
+            )
         )
-    )
-    declared = _item(
-        enriched=Enrichment(
-            enriched_at=datetime(2026, 1, 3, tzinfo=UTC),
-            executor="manual",
-            primary_topic="a",
-            topics=["b"],
-        )
-    )
+
+    hidden, declared = enriched(None, ["a", "b"]), enriched("a", ["b"])
     assert item_topics(hidden) == item_topics(declared) == ("a", "b")
     assert index_build.item_fingerprint(hidden) != index_build.item_fingerprint(declared)
 
@@ -1034,9 +1024,13 @@ def test_the_item_fingerprint_covers_the_media_the_emitter_declined_to_surface()
     """`items.skipped_decorative` moves with no surface behind it.
 
     `xbrain describe` classifying a photo as decorative flips the counter 0 -> 1 and emits
-    NOTHING — no surface, no content kind — so before the counters were hashed the row on
-    disk changed and the item read as unchanged. The equal `item_surfaces` is the half that
-    makes this a measurement rather than a restatement.
+    NOTHING — no surface, no content kind — so before the counters were hashed the row on disk
+    changed and the item read as unchanged. The equal `item_surfaces` is what makes this a
+    measurement rather than a restatement. The mutant that DROPS `entry.is_decorative or` and
+    keeps `not entry.description` survives, and no test can kill it: `MediaPhotoDescribed`
+    validates `is_decorative => not description` at the TYPE boundary (`models.py:318`), so the
+    input that would separate the two clauses cannot be constructed. An equivalent mutant, not
+    a gap — the clause is kept because the emitter's own filter reads the flag.
     """
     bare = _item()
     decorated = _item(media=[_photo(description="", is_decorative=True)])
@@ -1050,27 +1044,29 @@ def test_a_silent_video_is_counted_by_the_predicate_the_store_records() -> None:
     """`items.skipped_no_speech`, pinned against the two mutants that leave it silent.
 
     Asserting only that a silent video moves the hash passes under a swapped predicate —
-    `has_speech is False` traded for "the transcript is blank" — because on an ordinary
-    fixture the two agree. The `[music]` case is where they part: a transcriber that heard
-    no speech and wrote a marker anyway is `has_speech=False` with non-blank text, and only
-    the recorded flag gets it right. And the counter is asserted NON-ZERO, because a slot
-    only ever asserted at 0 is asserted against the constant a mutant installs.
+    `has_speech is False` traded for "the transcript is blank" — because on an ordinary fixture
+    the two agree. The `[music]` case is where they part: a transcriber that heard no speech
+    and wrote a marker anyway is `has_speech=False` with non-blank text, and only the recorded
+    flag gets it right. `has_speech=None` is where `is False` parts from truthiness: UNKNOWN is
+    not KNOWN-SILENT, the emitter declines it and this counter must not claim it — the shape
+    the corpus-complement guard below names, and 0 of 2,404 today. The counter is asserted
+    NON-ZERO, because a slot only ever asserted at 0 is asserted against the constant a mutant
+    installs.
     """
     silent = _item(content=_video_content(text="", has_speech=False))
     speaking = _item(content=_video_content(text="hello", has_speech=True))
     assert index_build.declined_media(silent) == (0, 1)
     assert index_build.declined_media(speaking) == (0, 0)
     assert index_build.declined_media(_item(content=_video_content("[music]", False))) == (0, 1)
+    assert index_build.declined_media(_item(content=_video_content("", None))) == (0, 0)
     assert index_build.item_fingerprint(silent) != index_build.item_fingerprint(_item())
 
 
 def test_a_photo_described_as_nothing_is_declined_like_a_decorative_one() -> None:
-    """The second clause of the decorative sum, which is what makes it the COMPLEMENT of
-    `iter_described_photos`'s seam rather than a reading of one flag.
-
-    A photo the vision pass had nothing to say about emits no surface either, so dropping
-    `or not entry.description` would leave it counted nowhere — declined by the emitter and
-    recorded by neither.
+    """The second clause of the decorative sum, which makes it the COMPLEMENT of
+    `iter_described_photos`'s seam rather than a reading of one flag: a photo the vision pass
+    had nothing to say about emits no surface either, so dropping `or not entry.description`
+    would leave it declined by the emitter and recorded by neither.
     """
     empty = _item(media=[_photo(description="", is_decorative=False)])
     assert list(iter_described_photos(empty)) == []
@@ -1081,17 +1077,15 @@ def test_a_photo_described_as_nothing_is_declined_like_a_decorative_one() -> Non
 def test_the_declined_counters_are_the_emitters_complement_over_the_corpus(corpus) -> None:
     """The rule-5 guard: two hand-written readings of one fact, held to each other.
 
-    `declined_media` decides a photo is declined by `is_decorative or not description` and a
-    video by `has_speech is False`; the EMITTER decides by `iter_described_photos`'s filter
-    and by a blank transcript. Nothing in code binds the two, so this asserts the property
-    that makes them one — declined plus emitted equals present — over every item.
-
-    They agree on the live store too: measured 2026-09-03 over 2,404 items (sha256
-    `f76341a3...`), 14 declined photos, 108 silent videos, and 0 items where either sum
-    fails. The agreement is CONTINGENT, and the shape that would break it is an `x_video`
-    attached with `has_speech=None` and no text — the HLS path, or a transcriber exiting
-    clean with nothing — which the emitter declines and this counter does not see. Zero of
-    those exist today; that is a fact about the corpus, not an invariant.
+    `declined_media` decides a photo by `is_decorative or not description` and a video by
+    `has_speech is False`; the EMITTER decides by `iter_described_photos`'s filter and by a
+    blank transcript. Nothing in code binds the two, so this asserts the property that makes
+    them one — declined plus emitted equals present — over every item. They agree on the live
+    store too: measured 2026-09-03 over 2,404 items (sha256 `f76341a3...`), 14 declined photos,
+    108 silent videos, 0 items where either sum fails. The agreement is CONTINGENT: an
+    `x_video` with `has_speech=None` and no text (the HLS path, or a transcriber exiting clean
+    with nothing) is declined by the emitter and not seen by this counter. Zero today — a fact
+    about the corpus, not an invariant.
     """
     store, _vocab, _pages = corpus
     for item in store.values():
@@ -1105,11 +1099,9 @@ def test_the_declined_counters_are_the_emitters_complement_over_the_corpus(corpu
 
 def test_a_bookmark_folder_that_is_absent_is_not_one_that_is_empty() -> None:
     """The mutation two reviewers measured reddening NOT ONE test on the snapshot:
-    `item.bookmark_folder` -> `item.bookmark_folder or ""`.
-
-    `items.bookmark_folder` is a nullable column and the two states are different rows.
-    Folding them means a bookmark moved OUT of every folder reads as one that was never in
-    a folder, and `update` reports the item unchanged.
+    `item.bookmark_folder` -> `item.bookmark_folder or ""`. It is a nullable column and the two
+    states are different rows — folding them means a bookmark moved OUT of every folder reads
+    as one that was never in a folder, and `update` reports the item unchanged.
     """
     assert index_build.item_fingerprint(
         _item(bookmark_folder=None)
@@ -1160,11 +1152,9 @@ def test_the_item_fingerprint_moves_when_the_content_sources_are_permuted(corpus
 
 def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this() -> None:
     """A CHARACTERIZATION of a deliberate hole, not a property anyone wants to keep.
-
-    `IndexOptions` travels so the signature 02.7 consumes is already the ported one, and it
-    is read NOWHERE. This asserts that: two options that differ in both fields hash alike.
-    When 02.7 gives them their first consumer this goes RED, and the change has to be made
-    on purpose — which is the whole reason it is written down rather than left implicit.
+    `IndexOptions` travels so the signature 02.7 consumes is already the ported one and is read
+    NOWHERE — two options differing in both fields hash alike. When 02.7 gives them their first
+    consumer this goes RED and the change is made on purpose, which is why it is written down.
     """
     item = _item()
     assert index_build.item_fingerprint(
@@ -1182,12 +1172,14 @@ def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this()
 
 
 def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all() -> None:
-    """`SURFACE_VERSION` leads the payload so a bump invalidates even an item whose surface
-    rows are empty — there is nothing else on such an item for a bump to move.
+    """`SURFACE_VERSION` leads the payload so a bump invalidates even an item whose surface rows
+    are empty — there is nothing else on such an item for a bump to move.
 
-    The expected side is the payload written out ATOM BY ATOM, so this is also the arity
-    guard: an atom added, removed or reordered reddens here, and a reader can see in one
-    place what an item fingerprint is made of.
+    The expected side is the payload ATOM BY ATOM, so this is the ARITY guard and the readable
+    account of what a fingerprint is made of. It is NOT a positional guard, and the earlier
+    claim that it was is WITHDRAWN: on a bare item the last seven atoms degenerate to
+    `None, None, [], [], [], [], []`, and four same-shaped region swaps were measured leaving
+    this file and the full suite green. Position is pinned by the populated literal below.
     """
     bare = _item(text="")
     assert item_surfaces(bare) == ()
@@ -1210,10 +1202,182 @@ def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all() -
                 [],
                 [],
                 [],
+                [],
                 [0, 0],
             ],
         )
     )
+
+
+def _rich(*, parts: tuple[str, ...] = ("abc", "defg"), **overrides) -> Item:
+    """An item that populates EVERY variadic region, each with a DIFFERENT value — which is
+    what the bare item above cannot do. The sources are inserted in the order `sorted()` does
+    NOT produce and the topics in the order `item_topics` does NOT return, so both deliberate
+    normalisations are pinned; and every variadic region carries TWO entries, so truncating one
+    to its first is visible.
+    """
+    defaults = dict(
+        bookmark_folder="THE-FOLDER",
+        links=[
+            Link(url="https://one.example/", domain="one.example"),
+            Link(url="https://two.example/", domain="two.example"),
+        ],
+        enriched=Enrichment(
+            summary="",
+            topics=["t-one", "t-two"],
+            primary_topic="t-two",
+            enriched_at=datetime(2026, 1, 4, tzinfo=UTC),
+            executor="manual",
+        ),
+        content=Content(
+            fetched_at=datetime(2026, 1, 3, tzinfo=UTC),
+            sources=[
+                ContentSourceSuccess(
+                    kind="x_video", url="https://v.example/1", text="", has_speech=False
+                ),
+                ContentSourceSuccess(
+                    kind="x_article",
+                    url="https://x.com/i/article/1",
+                    text="".join(parts),
+                    blocks=[ArticleTextBlock(text=p) for p in parts],
+                ),
+                ContentSourceFailure(
+                    kind="external_article",
+                    url="https://one.example/",
+                    failure_reason="not_found",
+                    http_status=404,
+                    attempts=1,
+                ),
+                ContentSourceFailure(
+                    kind="quoted_tweet",
+                    url="https://x.com/b/status/9",
+                    failure_reason="forbidden",
+                    attempts=2,
+                ),
+            ],
+        ),
+    )
+    return _item(**{**defaults, **overrides})
+
+
+def test_the_whole_payload_is_pinned_by_value_on_an_item_that_populates_every_region() -> None:
+    """The POSITIONAL and CHARACTERIZATION guard the belt above is not, in one literal.
+
+    Two holes close here. The belt's expected side runs the same `_canonical` and `_sha256` as
+    its actual side, so an ENCODER change moves both together — rule 1's fourth row — and
+    `separators=(",", ":")`, `hexdigest()[:16]` and `sha256 -> sha1` were each measured leaving
+    the file green. And on a BARE item the last seven atoms are indistinguishable by position,
+    so `kinds`<->`rows`, `failures`<->`links`, `topics`<->`kinds` and
+    `bookmark_folder`<->`primary_topic` all survived. A digest written down as a LITERAL is on
+    neither side of the encoder and sees both. Same instrument, and same reason, as
+    `tests/test_evidence_characterization.py`'s pin on `contract_fingerprint`: one byte of
+    drift retires every stored fingerprint, so a DELIBERATE change re-derives this literal in
+    the commit that makes it. The belt above stays the readable account of the payload.
+    """
+    fingerprint = index_build.item_fingerprint(_rich())
+    assert re.fullmatch(r"[0-9a-f]{64}", fingerprint), fingerprint
+    assert (
+        fingerprint
+        == "83d6407b9c518db6fb72d12db66a755a16e8b9d5c3fab1662d99a56f9798a20e"  # pragma: allowlist secret
+    )
+
+
+def test_the_serialisation_itself_is_pinned_and_the_digest_is_a_real_sha256() -> None:
+    """Both pinned against a value computed OUTSIDE this module — the only way an assertion on
+    an encoder is not the encoder asserting itself. `_sha256("abc")` is the published SHA-256
+    of `abc`, so `sha1` and a truncation both redden without this file owning the oracle.
+    """
+    assert index_build._canonical("t", ["a", 1, None]) == '["t", ["a", 1, null]]'
+    assert index_build._sha256("abc") == hashlib.sha256(b"abc").hexdigest()
+
+
+def test_an_article_block_repartition_moves_a_hash_no_surface_value_can_see() -> None:
+    """The `chunks` plane. `ContentSourceSuccess` validates `text == "".join(blocks)`, so the
+    flattened body is a function of the partition and NOT the reverse: these two items are one
+    article cut in different places. Every persisted SURFACE value is identical — asserted
+    beside the hash, because two hashes differing would not say the CUTS are what moved — while
+    `chunk_surfaces(..., blocks_by_surface_id=...)` emits different `chunk_id`s, offsets and
+    bodies. 41 of 2,404 items carry usable blocks, 41 of 41 more than one (2026-09-03), and the
+    parser that sets them is the one CLAUDE.md records as unconfirmed against a real capture.
+    """
+    one, two = _rich(parts=("abcdefg",)), _rich(parts=("abc", "defg"))
+    assert [index_build.surface_row(s) for s in item_surfaces(one)] == [
+        index_build.surface_row(s) for s in item_surfaces(two)
+    ]
+    assert [len(t) for v in article_block_texts(one).values() for t in v] == [7]
+    assert index_build.item_fingerprint(one) != index_build.item_fingerprint(two)
+
+
+def test_the_item_fingerprint_covers_the_topics_plane_the_primary_atom_does_not() -> None:
+    """`item_topics` is a persisted table, `chunks.topics` is copied from it, `--topic` filters
+    on it, and 2,404 of 2,404 items populate it — yet the region could be a constant `[]` with
+    the file green, because the only test that varied topics separated its items by the
+    `primary_topic` atom. Here the primary is HELD EQUAL, so the tuple is all that can move.
+    """
+    assert index_build.item_fingerprint(
+        _rich(
+            enriched=Enrichment(
+                summary="",
+                topics=["t-one", "t-two"],
+                primary_topic="t-two",
+                enriched_at=datetime(2026, 1, 4, tzinfo=UTC),
+                executor="manual",
+            )
+        )
+    ) != index_build.item_fingerprint(
+        _rich(
+            enriched=Enrichment(
+                summary="",
+                topics=["t-one", "t-three"],
+                primary_topic="t-two",
+                enriched_at=datetime(2026, 1, 4, tzinfo=UTC),
+                executor="manual",
+            )
+        )
+    )
+
+
+def test_the_item_fingerprint_covers_the_content_kinds_no_surface_and_no_counter_moves() -> None:
+    """`item_content_kinds` is a persisted table with 1,387 of 2,404 items in it, and its atom
+    could be a constant `[]` with nothing red. Isolated: the added source is an `x_video` with
+    `has_speech=None` and no text, so it emits NO surface, counts in NEITHER declined counter
+    (unknown is not known-silent), and moves nothing but the kinds region.
+
+    The region is a SET, and that is a behaviour and not a comment: `item_content_kinds` is the
+    ONE derivation `knowledge_item` also reads, and the plane on disk is keyed
+    `(item_id, kind)`, so two sources of one kind are ONE row. A derivation that stopped
+    deduplicating would re-hash every item that gains a second source of a kind it already had
+    — 10 of 2,404 on the live store, measured 2026-09-03 — with no row moved.
+    """
+    without = _item()
+    with_video = _item(content=_video_content("", None))
+    doubled = _item(
+        content=_video_content("", None).model_copy(
+            update={
+                "sources": [*_video_content("", None).sources, *_video_content("", None).sources]
+            }
+        )
+    )
+    assert item_content_kinds(doubled) == ("x_video",)
+    assert item_surfaces(without) == item_surfaces(with_video)
+    assert index_build.declined_media(without) == index_build.declined_media(with_video) == (0, 0)
+    assert index_build.item_fingerprint(without) != index_build.item_fingerprint(with_video)
+
+
+def test_a_nullable_surface_column_that_is_absent_is_not_one_that_is_empty() -> None:
+    """The `bookmark_folder` argument, carried across to the five columns it was never applied
+    to. `surfaces.title`, `.url`, `.language` and the two attribution cells are nullable exactly
+    as `items.bookmark_folder` is, and NULL is a different row from `''`; the by-value literal
+    pins every cell NON-null, so a `... or ""` mutant never meets a `None` and all five
+    survived. The INTEGER cells are pinned by TYPE beside them: `True == 1` and `1.0 == 1`, so
+    tuple equality cannot see `int(derived)` become a bool or a float — and `_canonical`, which
+    states that no float may enter, hashes all three differently.
+    """
+    bare = _surface(title=None, language=None, attribution=None, locator=Locator(kind="item_text"))
+    row = index_build.surface_row(bare)
+    assert row[7:11] == (None, None, None, None)
+    assert row[12] is None
+    assert type(row[6]) is int and type(row[14]) is int
 
 
 # ---------------------------------------------------------------------------
@@ -1248,13 +1412,12 @@ def test_the_outer_store_atom_is_a_pair_and_not_a_concatenation() -> None:
 
 
 def test_the_store_plane_survives_a_nul_inside_an_id() -> None:
-    """The pre-fix NUL join, on the plane where a real `items.json` can reach it.
-
-    `Item.id` is a bare `str` with no pattern and no validator, and a NUL travels through
-    `save_store` / `parse_store` as a plain ASCII escape — so the key `a=<hex>` + NUL + `b`
-    round-trips, and under the join it produced exactly the stream that a two-item store
-    produces. Two different stores, one certificate. The encoder guard above cannot reach
-    this: it shows why the pair is safe, and this shows the reversion that removes the pair.
+    """The pre-fix NUL join, on the plane where a real `items.json` can reach it. `Item.id` is a
+    bare `str` with no pattern and no validator, and a NUL travels through `save_store` /
+    `parse_store` as a plain ASCII escape, so the key `a=<hex>` + NUL + `b` round-trips and
+    under the join produced exactly the stream a two-item store produces — two different
+    stores, one certificate. The encoder guard above shows why the pair is safe; this shows the
+    reversion that removes it.
     """
     item = _item(id="X")
     two = {"a": item, "b": item}
@@ -1263,33 +1426,41 @@ def test_the_store_plane_survives_a_nul_inside_an_id() -> None:
 
 
 def test_the_store_fingerprint_covers_the_key_an_item_is_filed_under() -> None:
-    """The store is a MAPPING, and the key is half of each entry.
-
-    `item_fingerprint` hashes `item.id`, which is normally the same string — so this is the
-    guard that keeps the key in the atom for its own sake rather than by luck, and it
-    reddens under dropping `k` from the pair.
+    """The store is a MAPPING and the key is half of each entry. `item_fingerprint` hashes
+    `item.id`, normally the same string, so this is what keeps the key in the atom for its own
+    sake rather than by luck and reddens under dropping `k` from the pair. The DOMAIN is pinned
+    beside it: `"store"` is a hand-written literal here, so the mutant that hashes this plane
+    under `"item"` — which no other test could see — reddens.
     """
     item = _item(id="42")
     assert index_build.store_fingerprint({"42": item}) != index_build.store_fingerprint(
         {"filed-elsewhere": item}
     )
+    assert index_build.store_fingerprint({}) == index_build._sha256(
+        index_build._canonical("store", [])
+    )
 
 
 def test_the_store_fingerprint_moves_when_any_one_item_moves(corpus) -> None:
-    """The deep signal's whole promise, and the one the cheap `StoreSignal` cannot make."""
+    """The deep signal's whole promise, and the one the cheap `StoreSignal` cannot make.
+
+    BOTH ENDS OF THE ORDER, because "any" is the word this name makes load-bearing. Every
+    store-plane guard varied `sorted(store)[0]`, and the mutant `[...][:1]` — hash the FIRST
+    item and no other — left the whole file green: under it every item but one certifies as
+    unchanged forever, the open-failing direction rule 6 exists for. The complement `[1:]` was
+    already killed, and that asymmetry is the tell that the test measured position 0, not any.
+    """
     store, _vocab, _pages = corpus
-    key = sorted(store)[0]
-    edited = dict(store)
-    edited[key] = store[key].model_copy(update={"text": store[key].text + " edited"})
-    assert index_build.store_fingerprint(store) != index_build.store_fingerprint(edited)
+    for key in (sorted(store)[0], sorted(store)[-1]):
+        edited = dict(store)
+        edited[key] = store[key].model_copy(update={"text": store[key].text + " edited"})
+        assert index_build.store_fingerprint(store) != index_build.store_fingerprint(edited), key
 
 
 def test_the_deep_fingerprints_stay_out_of_the_cheap_signal(three_inputs: Path) -> None:
-    """02.6a1's contract, inherited unchanged: a query pays three `os.stat` and nothing else.
-
-    A deep read leaking into `StoreSignal.of` or `load_index_inputs` would put a full corpus
-    walk behind every `search`. Asserted by counting calls into the deep plane while the two
-    cheap doors run.
+    """02.6a1's contract, inherited unchanged: a query pays three `os.stat` and nothing else. A
+    deep read leaking into `StoreSignal.of` or `load_index_inputs` would put a full corpus walk
+    behind every `search`; asserted by counting calls into the deep plane while both doors run.
     """
     calls: list[str] = []
     original = index_build.item_fingerprint

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -1111,9 +1111,12 @@ def test_a_bookmark_folder_that_is_absent_is_not_one_that_is_empty() -> None:
 def test_the_item_fingerprint_covers_the_filterable_metadata_no_surface_carries() -> None:
     """A changed author changes what `--author` returns with no text moved (A-1). Handle and
     name are hashed APART: they are two columns, and one person renaming themselves is not
-    the same row as a different account.
+    the same row as a different account. On an item with NO surface, because the default one
+    emits a `post` carrying `attribution=item.author` and `locator.url=item.url`: three of the
+    six cells moved through the SURFACE region, and a mutant replacing an atom with the
+    FIXTURE'S OWN VALUE reddened nothing anywhere.
     """
-    base = _item()
+    base = _item(text="")
     for update in (
         {"author": Author(handle="b", name="A")},
         {"author": Author(handle="a", name="B")},
@@ -1171,7 +1174,7 @@ def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this()
     assert index_build.IndexOptions().vault_dir is None
 
 
-def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all() -> None:
+def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all(monkeypatch) -> None:
     """`SURFACE_VERSION` leads the payload so a bump invalidates even an item whose surface rows
     are empty — there is nothing else on such an item for a bump to move.
 
@@ -1180,9 +1183,19 @@ def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all() -
     claim that it was is WITHDRAWN: on a bare item the last seven atoms degenerate to
     `None, None, [], [], [], [], []`, and four same-shaped region swaps were measured leaving
     this file and the full suite green. Position is pinned by the populated literal below.
+
+    The version is also VARIED, not merely read back: every guard read it by VALUE — the
+    expected side imports the symbol, the populated literal bakes the string in — so replacing
+    `SURFACE_VERSION` with its own current literal survived both, and the bump this docstring
+    promises would have moved no fingerprint while every `surface.fingerprint` moved. Rule 6,
+    failing OPEN, on the atom whose whole job is to invalidate.
     """
     bare = _item(text="")
     assert item_surfaces(bare) == ()
+    before = index_build.item_fingerprint(bare)
+    monkeypatch.setattr(index_build, "SURFACE_VERSION", "xbrain-knowledge-surface/v99")
+    assert index_build.item_fingerprint(bare) != before
+    monkeypatch.undo()
     assert index_build.item_fingerprint(bare) == index_build._sha256(
         index_build._canonical(
             "item",
@@ -1209,12 +1222,14 @@ def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all() -
     )
 
 
-def _rich(*, parts: tuple[str, ...] = ("abc", "defg"), **overrides) -> Item:
+def _rich(*, parts: tuple[str, ...] = ("abcd", "efg"), **overrides) -> Item:
     """An item that populates EVERY variadic region, each with a DIFFERENT value — which is
     what the bare item above cannot do. The sources are inserted in the order `sorted()` does
     NOT produce and the topics in the order `item_topics` does NOT return, so both deliberate
     normalisations are pinned; and every variadic region carries TWO entries, so truncating one
-    to its first is visible.
+    to its first is visible. The block lengths DESCEND (`4, 3`) for the same reason: ascending,
+    `sorted()` over them is a no-op, and the mutant sorting them — which hashes two different
+    cuts of one article alike, the defect the region exists to catch — passed.
     """
     defaults = dict(
         bookmark_folder="THE-FOLDER",
@@ -1278,7 +1293,7 @@ def test_the_whole_payload_is_pinned_by_value_on_an_item_that_populates_every_re
     assert re.fullmatch(r"[0-9a-f]{64}", fingerprint), fingerprint
     assert (
         fingerprint
-        == "83d6407b9c518db6fb72d12db66a755a16e8b9d5c3fab1662d99a56f9798a20e"  # pragma: allowlist secret
+        == "a5352e1fb8977a9d5a72f32b84ed3f9d58ed9e259bcf50f4610771db997dc510"  # pragma: allowlist secret
     )
 
 

--- a/tests/test_knowledge_index_build.py
+++ b/tests/test_knowledge_index_build.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pytest
 
 from xbrain.knowledge import index_build, index_schema
-from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams
+from xbrain.knowledge.chunking import DEFAULT_CHUNKER_PARAMS, ChunkerParams, chunk_surfaces
 from xbrain.knowledge.ids import SURFACE_VERSION
 from xbrain.knowledge.models import KnowledgeSurface, Locator, SourceFailure, UnfetchedLink
 from xbrain.executors.api import iter_content_sources, iter_described_photos
@@ -808,19 +808,24 @@ def test_absent_and_empty_are_not_the_same_atom() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _schema_columns(table: str) -> list[str]:
-    """The column NAMES the DDL declares for one table, read out of `_SCHEMA` itself.
+def _schema_columns(table: str) -> dict[str, str]:
+    """`{column: declaration}` for one table, read out of `_SCHEMA` itself.
 
     Read from the schema string rather than from a hand-copied list: a column added to
-    `surfaces` has to reach this test without anyone remembering to edit it.
+    `surfaces` has to reach this test without anyone remembering to edit it. A MAPPING and not
+    a list of names, so a caller can pin a TYPE or a `NOT NULL` without a second parser, while
+    `set(...)` and `len(...)` over it still read the NAMES — which is all the totality and
+    arity guards below ask of it.
     """
     body = index_schema._SCHEMA.split(f"CREATE TABLE IF NOT EXISTS {table} (", 1)[1]
     body = body.split(");", 1)[0]
-    return [
-        line.strip().split()[0]
-        for line in body.splitlines()
-        if line.strip() and not line.strip().startswith("--")
-    ]
+    declarations: dict[str, str] = {}
+    for line in body.splitlines():
+        stripped = line.strip().rstrip(",")
+        if stripped and not stripped.startswith("--"):
+            name, _sep, rest = stripped.partition(" ")
+            declarations[name] = " ".join(rest.split())
+    return declarations
 
 
 def test_the_surface_row_is_the_fifteen_values_the_schema_persists_in_order() -> None:
@@ -836,7 +841,10 @@ def test_the_surface_row_is_the_fifteen_values_the_schema_persists_in_order() ->
     arity assertion catches all fifteen and says nothing about any value, so "N unpinned"
     without the mutant beside it is the error rule 2 exists to stop. Nullability and cell TYPE
     are pinned separately below — `None` folded to `""`, and `True`/`1.0` for `1`, are what
-    this literal cannot see.
+    this literal cannot see. One cell is ALSO varied: `_surface()`'s `owner_id` is `"42"`,
+    which is `_item()`'s id too, so the constant mutant `surface.owner_id -> "42"` installed
+    exactly the value this literal expects and survived. A literal cannot catch a constant
+    equal to its own fixture — only varying the input can, which is the whole of rule 1.
     """
     surface = _surface()
     assert index_build.surface_row(surface) == (
@@ -856,6 +864,7 @@ def test_the_surface_row_is_the_fifteen_values_the_schema_persists_in_order() ->
         "a" * 64,
         10,
     )
+    assert index_build.surface_row(_surface(owner_id="99"))[2] == "99"
 
 
 def test_the_row_has_one_value_per_column_the_schema_declares() -> None:
@@ -889,9 +898,13 @@ def test_the_rows_region_is_a_set_because_one_item_cannot_emit_a_surface_id_twic
 
     `surface_id` is `<owner>:<id>:<type>:<source_key>` and unique per item, so the rows are a
     SET and their sequence carries nothing the set does not: the mutant `sorted(...)` around
-    the region leaves this file GREEN, which is correct rather than a gap. What WOULD make the
-    order load-bearing is a duplicate id, and that is what this pins across the whole corpus —
-    two distinct surfaces on one row would quietly end the argument above.
+    the region leaves this file GREEN, which is correct rather than a gap.
+
+    WHAT MAKES THAT UNIQUENESS TRUE IS STRUCTURAL, NOT THE CORPUS. `content_source_key` appends
+    an occurrence ORDINAL, so two sources with an identical `(kind, url)` produce `…699b` and
+    `…699b#1` — a duplicate is unrepresentable and this sweep could not come out any other way
+    (rule 2, in the repo that wrote it). It is kept as a corpus-wide CHARACTERIZATION of the
+    ordinal's effect, not as evidence for the argument above, which the ordinal carries.
     """
     store, _vocab, _pages = corpus
     for item in store.values():
@@ -924,6 +937,12 @@ def test_the_item_fingerprint_covers_the_source_failures_plane() -> None:
     `update` reported the item unchanged (rule 6). The two items differ in NOTHING else — a
     failure emits no surface and appears in no content kind — so the moved plane is the only
     thing that can move the hash.
+
+    TWO failures, and only the SECOND one varies. The region is variadic and the mutant
+    truncating it to `[:1]` used to be killed by the 64-hex characterization literal and by
+    NOTHING ELSE — a guard that disappears the moment 02.7 re-derives that literal for
+    `items.note_path`. A plane whose second row is a fabrication is the same defect as one
+    whose first row is.
     """
 
     def failed(error: str) -> Item:
@@ -935,8 +954,14 @@ def test_the_item_fingerprint_covers_the_source_failures_plane() -> None:
                         kind="external_article",
                         url="https://e.example",
                         failure_reason="not_found",
+                        error="the first failure, held equal",
+                    ),
+                    ContentSourceFailure(
+                        kind="quoted_tweet",
+                        url="https://x.com/b/status/9",
+                        failure_reason="forbidden",
                         error=error,
-                    )
+                    ),
                 ],
             )
         )
@@ -953,9 +978,13 @@ def test_the_item_fingerprint_covers_the_unfetched_links_plane() -> None:
     `item.links` reaches the index through `unfetched_links` and through NOTHING else — no
     surface, no content kind, no other hashed atom — so a link that changed and a
     fingerprint that did not was the whole defect, and this pair isolates it exactly.
+
+    TWO links, the first held equal, for the reason the failures guard above states: `[:1]`
+    over this region was killed by the characterization literal alone.
     """
-    before = _item(links=[Link(url="https://a.example", domain="a.example")])
-    after = _item(links=[Link(url="https://b.example", domain="b.example")])
+    kept = Link(url="https://a.example", domain="a.example")
+    before = _item(links=[kept, Link(url="https://b.example", domain="b.example")])
+    after = _item(links=[kept, Link(url="https://c.example", domain="c.example")])
     assert item_surfaces(before) == item_surfaces(after)
     assert unfetched_links(before) != unfetched_links(after)
     assert index_build.item_fingerprint(before) != index_build.item_fingerprint(after)
@@ -990,9 +1019,32 @@ def test_each_failure_plane_persists_exactly_what_its_public_projection_carries(
     EITHER side. The DDL side is read out of `_SCHEMA` and the model side off `model_fields`,
     so neither is hand-copied and the two come from different modules; `item_id` is the join
     key, carried by `store_fingerprint`'s `(key, hash)` pair rather than by the projection.
+
+    THE NAME BINDING'S POPULATION IS NAMES, and saying so is the point: a column added,
+    removed or renamed on either side goes red — measured four ways — while a column RETYPED,
+    or stripped of its `NOT NULL`, is invisible to it. That difference is not academic. Under a
+    `TEXT` `http_status`, SQLite's affinity stores `"404"` and `get` reads a string back into a
+    field typed `int | None`. So both failure DDLs are ALSO pinned BY DECLARATION below: the
+    mapping is what the name binding walks, and the literal is what a retype has to meet.
+    `surfaces` keeps only its arity guard — its fifteen values are pinned by the by-value row
+    test, and binding either table to a WRITER is the readback test 02.7 owes.
     """
     for table, model in (("source_failures", SourceFailure), ("unfetched_links", UnfetchedLink)):
         assert set(_schema_columns(table)) == {"item_id", *model.model_fields}, table
+    assert _schema_columns("source_failures") == {
+        "item_id": "TEXT NOT NULL",
+        "kind": "TEXT NOT NULL",
+        "url": "TEXT NOT NULL",
+        "failure_reason": "TEXT NOT NULL",
+        "error": "TEXT",
+        "http_status": "INTEGER",
+    }
+    assert _schema_columns("unfetched_links") == {
+        "item_id": "TEXT NOT NULL",
+        "url": "TEXT NOT NULL",
+        "reason": "TEXT NOT NULL",
+        "detail": "TEXT",
+    }
 
 
 def test_the_item_fingerprint_covers_the_primary_topic_the_topics_tuple_hides() -> None:
@@ -1108,6 +1160,36 @@ def test_a_bookmark_folder_that_is_absent_is_not_one_that_is_empty() -> None:
     ) != index_build.item_fingerprint(_item(bookmark_folder=""))
 
 
+def test_a_primary_topic_that_is_absent_is_not_one_that_is_empty() -> None:
+    """The same argument, carried to the THIRD nullable `items` column, which the round that
+    carried it to the five `surfaces` ones did not reach.
+
+    `item_topics()` filters falsy topics, so `primary_topic=None` and `primary_topic=""` build
+    the IDENTICAL tuple — asserted beside the hash, because that is what makes the topics atom
+    unable to separate them and the `primary_topic` atom the only thing that can. Both mutants
+    (`... or ""` and `... or None`) left the whole file green. The persisted cell reads `NULL`
+    against `''`: two different rows, and `item_topics.is_primary` follows the same value.
+    0 of 2,404 on the live store — today's corpus, kept so by `guardrails.yaml` and not by the
+    model, which is the same standing as every other class this payload separates.
+    """
+
+    def with_primary(primary: str | None) -> Item:
+        return _item(
+            enriched=Enrichment(
+                summary="",
+                topics=["t"],
+                primary_topic=primary,
+                enriched_at=datetime(2026, 1, 4, tzinfo=UTC),
+                executor="manual",
+            )
+        )
+
+    assert item_topics(with_primary(None)) == item_topics(with_primary("")) == ("t",)
+    assert index_build.item_fingerprint(with_primary(None)) != index_build.item_fingerprint(
+        with_primary("")
+    )
+
+
 def test_the_item_fingerprint_covers_the_filterable_metadata_no_surface_carries() -> None:
     """A changed author changes what `--author` returns with no text moved (A-1). Handle and
     name are hashed APART: they are two columns, and one person renaming themselves is not
@@ -1115,9 +1197,16 @@ def test_the_item_fingerprint_covers_the_filterable_metadata_no_surface_carries(
     emits a `post` carrying `attribution=item.author` and `locator.url=item.url`: three of the
     six cells moved through the SURFACE region, and a mutant replacing an atom with the
     FIXTURE'S OWN VALUE reddened nothing anywhere.
+
+    `item.id` is the SEVENTH cell of that kind and was not in the loop: on a surfaceless item
+    nothing else carries it, so `item.id -> "42"` — the constant a careless refactor actually
+    writes, the fixture's own value — survived the whole file. It never changes for a given
+    item and `store_fingerprint` carries the key separately, so the impact was bounded; the
+    atom is claimed by the docstring above, which is why it is pinned rather than argued away.
     """
     base = _item(text="")
     for update in (
+        {"id": "99"},
         {"author": Author(handle="b", name="A")},
         {"author": Author(handle="a", name="B")},
         {"source": "own_tweet"},
@@ -1158,6 +1247,12 @@ def test_the_index_options_are_carried_inert_and_02_7_is_what_must_redden_this()
     `IndexOptions` travels so the signature 02.7 consumes is already the ported one and is read
     NOWHERE — two options differing in both fields hash alike. When 02.7 gives them their first
     consumer this goes RED and the change is made on purpose, which is why it is written down.
+
+    THE STORE HALF OF THAT TRIPWIRE IS BLIND, so this name is true of the item half only. Both
+    cells assert EQUALITY, so dropping `options=options` from `store_fingerprint`'s
+    pass-through is invisible today (measured: SURVIVED) and stays invisible AFTER 02.7 makes
+    options live: the item cell reddens, the store cell reports the equality it always did.
+    Binding it needs the pass-through asserted by EFFECT, beside the consumer 02.7 gives it.
     """
     item = _item()
     assert index_build.item_fingerprint(
@@ -1222,14 +1317,17 @@ def test_the_emitter_version_is_the_belt_for_an_item_with_no_surfaces_at_all(mon
     )
 
 
-def _rich(*, parts: tuple[str, ...] = ("abcd", "efg"), **overrides) -> Item:
+def _rich(*, parts: tuple[str, ...] = ("abc ", "efg"), **overrides) -> Item:
     """An item that populates EVERY variadic region, each with a DIFFERENT value — which is
     what the bare item above cannot do. The sources are inserted in the order `sorted()` does
     NOT produce and the topics in the order `item_topics` does NOT return, so both deliberate
     normalisations are pinned; and every variadic region carries TWO entries, so truncating one
-    to its first is visible. The block lengths DESCEND (`4, 3`) for the same reason: ascending,
-    `sorted()` over them is a no-op, and the mutant sorting them — which hashes two different
-    cuts of one article alike, the defect the region exists to catch — passed.
+    to its first is visible. The default parts are chosen against TWO mutants at once: the
+    lengths DESCEND (`4, 3`), so `sorted()` over them is not a no-op, and the first part ENDS
+    IN A SPACE, so `len(t.strip())` collapses both to `3`. Each hashes two different cuts of
+    one article alike — the defect the region exists to catch — and each used to pass. Boundary
+    whitespace is not an exotic fixture: 2,672 of 2,710 real blocks (98.6 %) carry it, so a
+    `strip` normalisation would erase a real cut on every article in the corpus.
     """
     defaults = dict(
         bookmark_folder="THE-FOLDER",
@@ -1293,7 +1391,7 @@ def test_the_whole_payload_is_pinned_by_value_on_an_item_that_populates_every_re
     assert re.fullmatch(r"[0-9a-f]{64}", fingerprint), fingerprint
     assert (
         fingerprint
-        == "a5352e1fb8977a9d5a72f32b84ed3f9d58ed9e259bcf50f4610771db997dc510"  # pragma: allowlist secret
+        == "837d4e3a39610526fa0d9de1dce4d164ef583e7ac9be536d9ff7dbfa28967276"  # pragma: allowlist secret
     )
 
 
@@ -1306,21 +1404,59 @@ def test_the_serialisation_itself_is_pinned_and_the_digest_is_a_real_sha256() ->
     assert index_build._sha256("abc") == hashlib.sha256(b"abc").hexdigest()
 
 
+def _cuts(item: Item) -> list[tuple[str, int, int]]:
+    """The `chunks` rows a repartition moves — id and span — through the ONE batch entry point
+    `cli.py` and `evaluation.py` call, so the claim is about what the index would STORE.
+    """
+    return [
+        (c.chunk_id, c.char_start, c.char_end)
+        for c in chunk_surfaces(item_surfaces(item), blocks_by_surface_id=article_block_texts(item))
+    ]
+
+
 def test_an_article_block_repartition_moves_a_hash_no_surface_value_can_see() -> None:
     """The `chunks` plane. `ContentSourceSuccess` validates `text == "".join(blocks)`, so the
-    flattened body is a function of the partition and NOT the reverse: these two items are one
+    flattened body is a function of the partition and NOT the reverse: these items are one
     article cut in different places. Every persisted SURFACE value is identical — asserted
-    beside the hash, because two hashes differing would not say the CUTS are what moved — while
-    `chunk_surfaces(..., blocks_by_surface_id=...)` emits different `chunk_id`s, offsets and
-    bodies. 41 of 2,404 items carry usable blocks, 41 of 41 more than one (2026-09-03), and the
-    parser that sets them is the one CLAUDE.md records as unconfirmed against a real capture.
+    beside the hash, because two hashes differing would not say the CUTS are what moved.
+
+    THE FIXTURE IS 1,800 CHARACTERS BECAUSE SEVEN COULD NOT COME OUT ANY OTHER WAY. The old
+    pair — `("abcdefg",)` against `("abc", "defg")` — is packed by the chunker into ONE
+    seven-character chunk either way (measured: identical ids, spans and bodies), so the test
+    named a repartition `chunk_surfaces` cannot see and its stated property never went red
+    (rule 2). At 1,800 the cuts reach the chunker and the emitted rows differ.
+
+    THE SAME-MULTISET PAIR IS WHY THE REGION HASHES AN ORDERED LIST. `[1200, 600]` against
+    `[600, 1200]` emits chunks whose `chunk_id`s are IDENTICAL — the id is
+    `<surface_id>:<index>:<chunker_version>` and carries no content — over different
+    `char_start`/`char_end` and different bodies. `sorted()` over the lengths hashes the two
+    alike, so `update` would leave rows whose ids still RESOLVE serving the wrong text: the
+    worst shape available, because nothing downstream errors. The small pairs are that defect
+    at fixture scale, and the second carries the whitespace costume too — `("ab ", "cd")` and
+    `("ab", " cd")` are different cuts of one body that `len(t.strip())` folds to `[2, 2]`.
+    41 of 2,404 items carry usable blocks, 41 of 41 more than one (2026-09-03).
     """
-    one, two = _rich(parts=("abcdefg",)), _rich(parts=("abc", "defg"))
+    body = ("parrafo de relleno para el troceador. " * 60)[:1800]
+    one, two = _rich(parts=(body[:1200], body[1200:])), _rich(parts=(body[:600], body[600:]))
+    thrice = _rich(parts=(body[:600], body[600:1200], body[1200:]))
     assert [index_build.surface_row(s) for s in item_surfaces(one)] == [
-        index_build.surface_row(s) for s in item_surfaces(two)
+        index_build.surface_row(s) for s in item_surfaces(thrice)
     ]
-    assert [len(t) for v in article_block_texts(one).values() for t in v] == [7]
+    assert [[len(t) for t in v] for v in article_block_texts(one).values()] == [[1200, 600]]
+    assert [[len(t) for t in v] for v in article_block_texts(two).values()] == [[600, 1200]]
+    assert [[len(t) for t in v] for v in article_block_texts(thrice).values()] == [[600, 600, 600]]
+    assert _cuts(one) != _cuts(thrice)
+    assert index_build.item_fingerprint(one) != index_build.item_fingerprint(thrice)
+    assert [chunk_id for chunk_id, _s, _e in _cuts(one)] == [c for c, _s, _e in _cuts(two)]
+    assert _cuts(one) != _cuts(two)
     assert index_build.item_fingerprint(one) != index_build.item_fingerprint(two)
+    for left, right in ((("abcd", "efg"), ("abc", "defg")), (("ab ", "cd"), ("ab", " cd"))):
+        assert [index_build.surface_row(s) for s in item_surfaces(_rich(parts=left))] == [
+            index_build.surface_row(s) for s in item_surfaces(_rich(parts=right))
+        ], left
+        assert index_build.item_fingerprint(_rich(parts=left)) != index_build.item_fingerprint(
+            _rich(parts=right)
+        ), left
 
 
 def test_the_item_fingerprint_covers_the_topics_plane_the_primary_atom_does_not() -> None:

--- a/tests/test_knowledge_index_schema.py
+++ b/tests/test_knowledge_index_schema.py
@@ -97,10 +97,12 @@ def test_the_schema_version_is_declared() -> None:
     `chunks.fingerprint` hashes the whole evidence projection — provenance, ownership,
     position, attribution, narrowed locator — and a v2 base's fingerprints were computed
     over the text alone, so every row of it would fail verification: the door must refuse
-    it by name rather than answer «22,286 chunks excluded». The pin exists so a layout
-    change cannot ship without the bump that makes an existing index refuse the query.
+    it by name rather than answer «22,286 chunks excluded». "4" since the 02.6a2a review
+    dropped the dead `source_failures.attempts` column so the DDL and the versioned public
+    `SourceFailure` hold the same fields. The pin exists so a layout change cannot ship
+    without the bump that makes an existing index refuse the query.
     """
-    assert SCHEMA_VERSION == "3"
+    assert SCHEMA_VERSION == "4"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Child 02.6a2a of Plan 02** — the deep fingerprints of the **item/store plane**, and nothing else.
Draft: opened before any formal review, per §11.4.

## Base / head / size — measured at this head, not carried over

| | |
|---|---|
| Base (umbrella tip, unmoved) | `36dbc2369f94771687f5f2a1e85697103f96937c` — `VGonPa/umbrella-knowledge-index-lexical` |
| Head | **`836b209d7466a27dba3a3186bbcf0823c5222645`** (`1d247e3` delivery · `379736c` review round 01 · `e8ff8e3` round 02 · `836b209` round 03) |
| Files changed | **5** (`git diff --name-only <base> HEAD`) |
| Touched (`git diff --numstat <base> HEAD`, additions+deletions) | **1,447** = **+1,420 / −27** |
| `check.sh` | **raw exit 0**, reported conclusion **ALL CRITICAL CHECKS PASSED** |
| `origin/develop` drift | `0bd95273`, an ancestor of the umbrella — **no sync child needed** (rule 15) |

```
354	  9  src/xbrain/knowledge/index_build.py
 22	  3  src/xbrain/knowledge/index_schema.py
 27	 10  src/xbrain/knowledge/surfaces.py
1012	  2  tests/test_knowledge_index_build.py
  5	  3  tests/test_knowledge_index_schema.py
```

### The size, justified here because §6.6 of the umbrella plan puts the justification HERE

This body previously said *«1,080 of a 1,200 hard ceiling»* against head `1d247e3`. **Both halves
of that sentence are now wrong and are withdrawn**: the head moved three times, and the ceiling
was lifted. The record, in order:

1. `umbrellas:1522` set a **per-child budget** of `> 1200 ⇒ PARAR` for 02.6a2a, and `:1526` adds
   that exceeding it *«no se resuelve escribiendo una justificación mejor»*.
2. At round 01 the work stood at **1,292**. It was escalated **before** exceeding, **twice**, and
   the coordinator **lifted the budget to the authoritative 800–1,500 band** of §6.6 on the second
   ask — on the ground `umbrellas:1044-1069` states directly: *«si una banda y la coherencia
   chocan, gana la coherencia»*, *«partir para bajar el número está prohibido»*, *«los tests
   cuentan y no se descuentan»*, *«la banda no es un gate»*. `:1500` also calls those per-child
   numbers **PRESUPUESTOS, no cifras re-derivadas** — rule 2 applied to the plan itself.
3. Room was found by **compressing ~95 lines of this child's own prose**, never by weakening a
   test: no assertion was removed, no measured figure dropped, no named debt deleted.
4. **Splitting was declined and that is the coordinator's decision, not a drift.** The
   block-partition region and the only guard that proves it moves the hash are ONE reviewable
   unit; separating them puts a production change in one PR and its red-first evidence in
   another — the shape `umbrellas:1044` calls *«es el número lo que ha mejorado, no la revisión»*.
5. Round 03 (**+155**, to 1,447) is the review's own closure list: six named guards and the
   documentation the reviewers asked for **by name**. It is inside the same 800–1,500 band, 121
   under the ceiling, against a Plan-02 per-PR average of `17,558 ÷ 15 = 1,171`.

**A reader who disagrees with that decision now has everything needed to say so.**

## Scope — exactly this, and only this

Added to `src/xbrain/knowledge/index_build.py`:

| Symbol | What it is |
|---|---|
| `_canonical` / `_sha256` | the ONE serialisation every fingerprint here hashes (rule 5) |
| `IndexOptions` | declared **deliberately inert** — no consumer in this tree |
| `SurfaceRow` + `surface_row` | the projection of one `surfaces` row, fifteen columns |
| `declined_media` | `(decorative, no_speech)` — two persisted `items` counters, defined ONCE for 02.7 |
| `_model_atoms` | a pydantic projection as `[[name, value], …]`, walked from `model_fields` |
| `item_fingerprint` / `store_fingerprint` | the deep signal, paid only by `build`/`update`/`status` |

`src/xbrain/knowledge/surfaces.py`: `_failed_sources` / `_unfetched_links` become **public**
(`failed_sources` / `unfetched_links`), and a new **`item_content_kinds(item)`** is the ONE
deduplicating, ordered derivation that `knowledge_item` **and** `item_fingerprint` both read — so
the hashed region and the `(item_id, kind)` rows are the same object rather than two lists that
"should" agree (rule 5). 10 of 2,404 live items carry a repeated content kind.

`src/xbrain/knowledge/index_schema.py`: `source_failures.attempts` **dropped**, `SCHEMA_VERSION`
**"3" → "4"** — see below.

## Exclusions — deliberately NOT here

`vocab_fingerprint`, `topics_fingerprint` (**02.6a2b**) · manifest construction and invalidation
(**02.6b**) · `build`/`update`/`status` orchestration, SQLite writes, the `surfaces` writer
(**02.7**) · CLI/MCP · lexical retrieval · graph work. **No manifest is sealed by this PR**, which
is why the coverage gaps are being closed here: free before a manifest exists, expensive after.

The obsolete snapshot `VGonPa/knowledge-index-02-6a-reviewed-snapshot-161` (`e4413be`) was read
with `git show` for derivation ideas and **not cherry-picked**.

## What this closes

**HIGH-1 of review #161.** `source_failures` and `unfetched_links` are written per item and read
back by `get`, and moved on disk while every fingerprint stood still — a link that started
returning 404, or a fetch whose recorded error changed, rewrote the row while `update` reported the
item unchanged (rule 6). Both planes are hashed **structurally**: `_model_atoms` walks
`model_fields`, so a field added to either projection enters the hash with nobody remembering.

**`source_failures.attempts` — DOOR B, taken out loud.** An earlier version of this body listed the
column under *«what is NAMED as unreachable»* and said *«neither of 02.7's doors is free»*. **That
is withdrawn: this PR takes Door B.** `attempts` was the one column across both failure planes with
no field on the versioned public projection `item_fingerprint` hashes, so an item whose attempt
count moved certified as unchanged. Of the two doors:

- **Door A** (add the field) puts **fetch bookkeeping** inside the hash — and
  `fetch._source_signature` excludes `attempts` for exactly that reason, so a persistently-failing
  link re-fetched every run would re-index an item whose evidence never moved. It also bumps
  `EvidenceBundle.schema_version` for a value no consumer reads.
- **Door B** (drop the column) costs nothing real: the only writer that ever existed bound it to a
  literal `None` (`b61e04b:index_build.py:838`) and nothing has ever read it back.

`SCHEMA_VERSION` is **"3" → "4"**, and the comment beside it now states what the bump does **and
does not** do in this tree: nothing consumes the constant (`load_compatible_manifest` is 02.6b's
and does not exist here), `_verify_schema` tolerates extra columns by design so **a v3 base is
ACCEPTED today**, and the only live effect is that **v3 code refuses a v4 base**. The table also
now diverges from Plan 02's frozen DDL in **two** cells (`attempts` removed here, `http_status`
added by an earlier child), so 02.7's writer is built against the file, not against the plan.
Rule-2 note: `attempts` **does** vary in the live corpus (63 failures, `{1: 62, 2: 1}`), so the
justification is *"the value is not persisted"*, never *"the value never changes"*.

**The `chunks` plane — the article BLOCK PARTITION.** `ContentSourceSuccess` validates
`text == "".join(blocks)`, so the flattened body is a function of the partition and **not** the
reverse: two block lists that concatenate alike leave `surface_row` and `surface.fingerprint`
identical while `chunk_surfaces(..., blocks_by_surface_id=article_block_texts(item))` — the batch
entry point `cli.py` and `evaluation.py` actually call — cuts different `chunk_id`s, offsets and
bodies. The payload therefore carries the ordered block **LENGTHS** keyed by `surface_id` (never by
position: `fetch` rewrites `content.sources`). **Lengths and never bodies**: the concatenation is
already inside `surface.fingerprint`, and a second copy of the text is what spec §10.8 forbids.
41 of 2,404 items carry usable blocks, 41 of 41 more than one.

**Three columns the snapshot also missed**, each found by executing: `items.primary_topic` as its
own atom (`item_topics()` deduplicates, so `(None, ["a","b"])` and `("a", ["b"])` give the
identical tuple against stored `NULL` vs `"a"`), and `items.skipped_decorative` /
`items.skipped_no_speech`, pure functions of the item the emitter never surfaces.

**The injectivity claim is scoped**, because unqualified it is false: JSON maps `(1,2)` and `[1,2]`
to one text, `{1:"a"}` and `{"1":"a"}` to another. What holds is `str` / `int` / `None` / sequences,
with the three consequences named. `allow_nan=False` so a stray NaN raises rather than emitting a
literal no reader could parse back.

## What is NAMED as unreachable, not silently omitted

`items.note_path` (a projection of the **vault**, 02.6b/02.7) · `items.skipped_empty_text` (chunker
arithmetic under the inert options, 02.7) · `CHUNKER_VERSION` and `ChunkerParams` (02.6b's manifest
refusal, strictly stronger than per-item invalidation) · `profiles.profile_text` (a `vocab.yaml`
edit rewrites it for every assigned item; 02.6a2b/02.7) · `items.store_fingerprint`, which **is**
this value and cannot be inside itself — its name is historical and is a trap for 02.7's writer,
which must not read a **per-item** digest as a store-level one.

**THREE known false positives, not one.** The topics region keeps `Enrichment.topics`' order while
`item_topics` on disk is a SET (2,073 of 2,404 items carry more than one topic) — and the failures
and links regions are order-sensitive the same way, with neither table carrying a primary key or an
order column. All three cost one wasted rewrite and never a stale row, which is the direction this
module fails in on purpose. The body used to say "ONE"; it was measured.

## Tests — direct, and each proved against its own mutation

`uv run pytest tests/test_knowledge_index_build.py -q` → **65 passed** (was 26 at the base).
`bash scripts/check.sh` → **raw exit 0**, reported conclusion **ALL CRITICAL CHECKS PASSED**,
**2,297 passed / 1 xfailed**, coverage **94.32 %** total and **95 %** `knowledge/` (floor 90).
Ruff, format, mypy, bandit, vulture, interrogate, detect-secrets and deptry all PASS; radon's
warning-only grade-C functions are pre-existing. *(Both surfaces named — rule 9.)*

**Mutation testing, hardened.** The harness mutates the worktree source **in place** — the mutant
IS the imported module — and before every run asserts (a) the import path resolves inside the
worktree and (b) the **sha256 of the imported module's source matches the file on disk**. Round 03
added `PYTHONDONTWRITEBYTECODE=1` and a `__pycache__` sweep after measuring a **false SURVIVED**:
`links[:1]` reported SURVIVED directly after `failures[:1]` and KILLED when run alone, because
CPython validates a cached `.pyc` on *(mtime, size)* and two mutants adding the same number of
bytes within one second are indistinguishable to it. `-p no:cacheprovider` disables **pytest's**
cache, never CPython's. **All 32 mutants of rounds 01–02 were re-verified KILLED under the hardened
harness**, and round 03's nine were measured SURVIVING at `e8ff8e3` first (red-first) and KILLED
here — each by the **named** guard, not only by the characterization literal:

| Mutant | Killed by |
|---|---|
| `[len(t) …]` → `[len(t.strip()) …]` | the repartition guard **and** the 64-hex literal |
| block lengths → `sorted(…)` | the repartition guard |
| `primary_topic` → `… or ""` / `… or None` | `…a_primary_topic_that_is_absent_is_not_one_that_is_empty` |
| `item.id` → `"42"` (its own fixture value) | `…covers_the_filterable_metadata…` |
| `surface.owner_id` → `"42"` | `…the_fifteen_values_the_schema_persists_in_order` |
| failures region `[:1]` · links region `[:1]` | their two **named** plane guards |

**One declared survivor, and it is equivalent:** `item.id` → `item.id.lower()`. X ids are decimal,
so the two functions are identical on every value the domain admits; recorded rather than faked.

## Not for merge yet

Draft. Do not merge, and **no self-approval** (approvals stay at 0 — rule 12). Formal review per
§11.2/§11.3; 02.6a2b does not start until this is DONE in the §9 sense.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZk1rgy6EfUf8fe97SaLsy
